### PR TITLE
Revisions of OpenConfig BGP and routing policy models

### DIFF
--- a/experimental/openconfig/bgp/bgp-multiprotocol.yang
+++ b/experimental/openconfig/bgp/bgp-multiprotocol.yang
@@ -32,7 +32,7 @@ module bgp-multiprotocol {
     intended to capture the most";
 
 
-  revision "2014-11-30" {
+  revision "2015-05-15" {
     description
       "Refactored multiprotocol module";
     reference "TBD";
@@ -48,10 +48,6 @@ module bgp-multiprotocol {
           "Include this container for IPv4 Unicast specific
           configuration";
       }
-
-      presence
-        "Presence of this container indicates that the IPv4 Unicast
-        AFI,SAFI is enabled for a neighbour or group";
 
       description "IPv4 unicast configuration options";
 
@@ -72,10 +68,6 @@ module bgp-multiprotocol {
           "Include this container for IPv6 Unicast specific
           configuration";
       }
-
-      presence
-        "Presence of this container indicates that the IPv6 Unicast
-        AFI,SAFI is enabled for a neighbour or group";
 
       description "IPv6 unicast configuration options";
 
@@ -98,10 +90,6 @@ module bgp-multiprotocol {
           configuration";
       }
 
-      presence
-        "Presence of this container indicates that the IPv4 Labelled
-        Unicast AFI,SAFI is enabled for a neighbour or group";
-
       description "IPv4 Labelled Unicast configuration options";
 
       uses all-afi-safi-common;
@@ -121,10 +109,6 @@ module bgp-multiprotocol {
           "Include this container for IPv6 Labelled Unicast specific
           configuration";
       }
-
-      presence
-        "Presence of this container indicates that the IPv6 Labelled
-        Unicast AFI,SAFI is enabled for a neighbour or group";
 
       description "IPv6 Labelled Unicast configuration options";
 
@@ -146,10 +130,6 @@ module bgp-multiprotocol {
           configuration";
       }
 
-      presence
-        "Presence of this container indicates that IPv4 Unicast L3VPN
-        AFI,SAFI is enabled for a neighbour or group";
-
       description "Unicast IPv4 L3VPN configuration options";
 
       // include common L3VPN configuration options
@@ -169,9 +149,6 @@ module bgp-multiprotocol {
           "Include this container for unicast IPv6 L3VPN specific
           configuration";
       }
-
-      presence "Presence of this container indicates that the IPv6
-                Unicast L3VPN AFI,SAFI is enabled";
 
       description "Unicast IPv6 L3VPN configuration options";
 
@@ -194,9 +171,6 @@ module bgp-multiprotocol {
           configuration";
       }
 
-      presence "Presence of this container indicates the
-                IPv4 L3VPN Unicast AFI-SAFI is enabled";
-
       description "Multicast IPv4 L3VPN configuration options";
 
       // include common L3VPN multicast options
@@ -217,10 +191,6 @@ module bgp-multiprotocol {
           "Include this container for multicast IPv6 L3VPN specific
           configuration";
       }
-
-      presence
-        "Presence of this container indicates that the IPv6 Multicast
-        L3VPN AFI,SAFI is enabled";
 
       description "Multicast IPv6 L3VPN configuration options";
 
@@ -243,10 +213,6 @@ module bgp-multiprotocol {
           configuration";
       }
 
-      presence
-        "Presence of this container indicates that the BGP-signalled
-        VPLS AFI,SAFI is enabled";
-
       description "BGP-signalled VPLS configuration options";
 
       // include common L2VPN options
@@ -267,10 +233,6 @@ module bgp-multiprotocol {
           "Include this container for BGP EVPN specific
           configuration";
       }
-
-      presence
-        "Presence of this container indicates that the BGP EVPN
-        AFI,SAFI is enabled";
 
       description "BGP EVPN configuration options";
 
@@ -370,7 +332,7 @@ module bgp-multiprotocol {
       "Maximum number of parallel paths to consider when using
       BGP multipath. The default is use a single path.";
     }
-  } 
+  }
 
   grouping bgp-use-multiple-paths-ibgp_config {
     description
@@ -383,22 +345,28 @@ module bgp-multiprotocol {
         "Maximum number of parallel paths to consider when using
         iBGP multipath. The default is to use a single path";
     }
-  } 
+  }
 
-  grouping bgp-use-multiple-paths_config {
+  grouping bgp-use-multiple-paths {
     description
       "Configuration parameters relating to multipath for BGP - both
       iBGP and eBGP";
 
     container use-multiple-paths {
-      presence 
-        "Presence of this container indicates that multipath is 
-        enabled for eBGP and iBGP. Absence of the container 
-        indicates that multipath is disabled";
-
       description
         "Parameters related to the use of multiple paths for the
         same NLRI";
+
+      container config {
+        description
+          "Configuration parameters relating to multipath";
+        uses bgp-use-multiple-paths_config;
+      }
+      container state {
+        description
+          "State parameters relating to multipath";
+        uses bgp-use-multiple-paths_config;
+      }
 
       container ebgp {
         description
@@ -434,20 +402,25 @@ module bgp-multiprotocol {
     }
   }
 
-  grouping bgp-use-multiple-paths-neighbor_config {
+  grouping bgp-use-multiple-paths-neighbor {
     description
       "Per-neighbor configuration for multipath for BGP";
 
     container use-multiple-paths {
-      presence
-        "Presence of this container indicates that multiple paths
-        from this neighbor should be installed into the RIB. Absence
-        of this container results in the multipath configuration
-        being inherited from the peer-group if it exists.";
-
       description
         "Parameters related to the use of multiple-paths for the same
         NLRI when they are received only from this neighbor";
+
+      container config {
+        description
+          "Configuration parameters relating to multipath";
+        uses bgp-use-multiple-paths_config;
+      }
+      container state {
+        description
+          "State parameters relating to multipath";
+        uses bgp-use-multiple-paths_config;
+      }
 
       container ebgp {
         description
@@ -467,9 +440,45 @@ module bgp-multiprotocol {
     }
   }
 
+  grouping bgp-use-multiple-paths_config {
+    description
+      "Generic configuration options relating to use of multiple
+      paths for a referenced AFI-SAFI, group or neighbor";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "Whether the use of multiple paths for the same NLRI is
+        enabled for the neighbor. This value is overridden by
+        any more specific configuration value.";
+    }
+  }
+
+  grouping bgp-afi-safi-graceful-restart_config {
+    description
+      "BGP graceful restart parameters that apply on a per-AFI-SAFI
+      basis";
+
+    leaf enabled {
+      type boolean;
+      default false;
+      description
+        "This leaf indicates whether graceful-restart is enabled for
+        this AFI-SAFI";
+    }
+  }
+
   grouping bgp-afi-safi_config {
     description
       "Configuration parameters used for all BGP AFI-SAFIs";
+
+    leaf afi-safi-name {
+      type identityref {
+        base bgp-types:afi-safi-type;
+      }
+      description "AFI,SAFI";
+    }
 
     leaf enabled {
       type boolean;
@@ -523,7 +532,7 @@ module bgp-multiprotocol {
       default "false";
       description
         "If set to true, send the default-route to the neighbour(s)";
-    }    
+    }
   }
 
   grouping all-afi-safi-common {
@@ -536,7 +545,7 @@ module bgp-multiprotocol {
         accepted from a peer";
 
       container config {
-        description 
+        description
           "Configuration parameters relating to the prefix
           limit for the AFI-SAFI";
         uses all-afi-safi-common-prefix-limit_config;
@@ -605,9 +614,45 @@ module bgp-multiprotocol {
     uses all-afi-safi-common;
   }
 
+  grouping bgp-route-selection-options {
+    description
+      "Parameters relating to the BGP route selection process";
+
+    container route-selection-options {
+      description
+        "Parameters relating to options for route selection";
+      container config {
+        description
+          "Configuration parameters relating to route selection
+          options";
+        uses bgp-route-selection-options_config;
+      }
+      container state {
+        config false;
+        description
+          "State information for the route selection options";
+        uses bgp-route-selection-options_config;
+      }
+    }
+  }
+
   // *********** STRUCTURE GROUPINGS **********************
 
-  grouping bgp-global-afi-safi-list {
+  grouping bgp-global-afi-safi {
+    description
+      "Parameters and route selection options for MP-BGP
+      specific to the Global AFI-SAFI";
+    uses bgp-route-selection-options;
+  }
+
+  grouping bgp-group-afi-safi {
+    description
+      "Parameters and route selection options for MP-BGP
+      specific to peer groups";
+    uses bgp-route-selection-options;
+  }
+
+  grouping bgp-common-afi-safi-list {
     description
       "List of address-families associated with the BGP instance,
       a peer-group or neighbor";
@@ -619,31 +664,31 @@ module bgp-multiprotocol {
         "AFI,SAFI configuration available for the
         neighbour or group";
 
+
       leaf afi-safi-name {
-        type identityref {
-          base bgp-types:afi-safi-type;
+        type leafref {
+          path "../config/afi-safi-name";
         }
-        description "AFI,SAFI";
+        description
+          "Reference to the AFI-SAFI name used as a key
+          for the AFI-SAFI list";
       }
 
-      container route-selection-options {
+      container graceful-restart {
         description
-          "Parameters relating to options for route selection";
+          "Parameters relating to BGP graceful-restart";
         container config {
           description
-            "Configuration parameters relating to route selection
-            options";
-          uses bgp-route-selection-options_config;
+            "Configuration options for BGP graceful-restart";
+          uses bgp-afi-safi-graceful-restart_config;
         }
         container state {
           config false;
           description
-            "State information for the route selection options";
-          uses bgp-route-selection-options_config;
+            "State information for BGP graceful-restart";
+          uses bgp-afi-safi-graceful-restart_config;
         }
       }
-
-      uses bgp-use-multiple-paths_config;
 
       container config {
         description
@@ -670,7 +715,7 @@ module bgp-multiprotocol {
       uses l3vpn-ipv4-multicast-group;
       uses l3vpn-ipv6-multicast-group;
       uses l2vpn-vpls-group;
-      uses l2vpn-evpn-group;      
+      uses l2vpn-evpn-group;
     }
   }
 }

--- a/experimental/openconfig/bgp/bgp-operational.yang
+++ b/experimental/openconfig/bgp/bgp-operational.yang
@@ -28,7 +28,7 @@ module bgp-operational {
     variables) related to BGP operations";
 
 
-  revision "2014-12-02" {
+  revision "2015-05-15" {
     description
       "Initial revision";
     reference "TBD";
@@ -161,7 +161,17 @@ module bgp-operational {
       "Operational state on a per-AFI-SAFI basis for a BGP
       neighbor";
 
-      uses bgp-neighbor-prefix-counters_state;
+    leaf active {
+      type boolean;
+      description
+        "This value indicates whether a particular AFI-SAFI has
+        been succesfully negotiated with the peer. An AFI-SAFI
+        may be enabled in the current running configuration, but a
+        session restart may be required in order to negotiate the new
+        capability.";
+    }
+
+    uses bgp-neighbor-prefix-counters_state;
   }
 
   grouping bgp-neighbor-prefix-counters_state {
@@ -301,13 +311,6 @@ module bgp-operational {
       "Operational state information relevant to graceful restart
       for BGP";
 
-    leaf active {
-      type boolean;
-      description
-        "Whether graceful-restart has been enabled for the AFI,
-        SAFI for the peer";
-    }
-
     leaf peer-restart-time {
       type uint16 {
         range 0..4096;
@@ -317,7 +320,73 @@ module bgp-operational {
         the peer expects a restart of a BGP session to
         take";
     }
+
+    leaf peer-restarting {
+      type boolean;
+      description
+        "This flag indicates whether the remote neighbor is currently
+        in the process of restarting, and hence received routes are
+        currently stale";
+    }
+
+    leaf local-restarting {
+      type boolean;
+      description
+        "This flag indicates whether the local neighbor is currently
+        restarting. The flag is unset after all NLRI have been
+        advertised to the peer, and the End-of-RIB (EOR) marker has
+        been unset";
+    }
+
+    leaf mode {
+      type enumeration {
+        enum HELPER-ONLY {
+          description
+            "The local router is operating in helper-only mode, and
+            hence will not retain forwarding state during a local
+            session restart, but will do so during a restart of the
+            remote peer";
+        }
+        enum BILATERAL {
+          description
+            "The local router is operating in both helper mode, and
+            hence retains forwarding state during a remote restart,
+            and also maintains forwarding state during local session
+            restart";
+        }
+        enum REMOTE-HELPER {
+          description
+            "The local system is able to retain routes during restart
+            but the remote system is only able to act as a helper";
+        }
+      }
+      description
+        "Ths leaf indicates the mode of operation of BGP graceful
+        restart with the peer";
+    }
   }
+
+  grouping bgp-neighbor-afi-safi-graceful-restart_state {
+    description
+      "Operational state variables relating to the graceful-restart
+      mechanism on a per-AFI-SAFI basis";
+
+    leaf received {
+      type boolean;
+      description
+        "This leaf indicates whether the neighbor advertised the
+        ability to support graceful-restart for this AFI-SAFI";
+    }
+
+    leaf advertised {
+      type boolean;
+      description
+        "This leaf indicates whether the ability to support
+        graceful-restart has been advertised to the peer";
+    }
+  }
+
+
 }
 
 

--- a/experimental/openconfig/bgp/bgp-policy.yang
+++ b/experimental/openconfig/bgp/bgp-policy.yang
@@ -10,7 +10,8 @@ module bgp-policy {
   // import some basic types
   import ietf-inet-types { prefix inet; }
   import routing-policy {prefix rpol; }
-  import policy-types {prefix pt; }
+  import policy-types { prefix pt; }
+  import bgp-types { prefix bgp-types; }
 
 
 
@@ -27,7 +28,7 @@ module bgp-policy {
     It augments the base routing-policy module with BGP-specific
     options for conditions and actions.";
 
-  revision "2014-11-30" {
+  revision "2015-05-15" {
     description
       "Updated model to augment base routing-policy module";
     reference "TBD";
@@ -46,94 +47,6 @@ module bgp-policy {
     description
       "Option for the BGP as-prepend policy action.  Prepends the
       local AS number repeated n times";
-  }
-
-  typedef bgp-well-known-community-type {
-    type enumeration {
-      enum INTERNET {
-        description "entire Internet community (0x00000000)";
-      }
-      enum NO_EXPORT {
-        // value 0xFFFFFF01;
-        description "no export";
-      }
-      enum NO_ADVERTISE {
-        description "no advertise (0xFFFFFF02)";
-      }
-      enum NO_EXPORT_SUBCONFED {
-        description "no export subconfed, equivalent to
-        local AS (0xFFFFFF03)";
-      }
-    }
-    description
-      "Type definition for well-known IETF community attribute
-      values";
-    reference "RFC 1997 - BGP Communities Attribute";
-  }
-
-
-  typedef bgp-std-community-type {
-    // TODO: further refine restrictions and allowed patterns
-    // 4-octet value:
-    //  <as number> 2 octets
-    //  <community value> 2 octets
-    type union {
-      type uint32 {
-      // per RFC 1997, 0x00000000 - 0x0000FFFF and 0xFFFF0000 -
-      // 0xFFFFFFFF are reserved
-        range "65536..4294901759"; // 0x00010000..0xFFFEFFFF
-      }
-      type string {
-        pattern '([0-9]+:[0-9]+)';
-      }
-    }
-    description
-      "Type definition for standard commmunity attributes";
-    reference "RFC 1997 - BGP Communities Attribute";
-  }
-
-  typedef bgp-ext-community-type {
-    // TODO: needs more work to make this more precise given the
-    // variability of extended community attribute specifications
-    // 8-octet value:
-    //  <type> 2 octects
-    //  <value> 6 octets
-    type string {
-      pattern '([0-9\.]+(:[0-9]+)?:[0-9]+)';
-    }
-    description
-      "Type definition for extended community attributes";
-    reference "RFC 4360 - BGP Extended Communities Attribute";
-  }
-
-  typedef bgp-community-regexp-type {
-    // TODO: needs more work to decide what format these regexps can
-    // take.
-    type string;
-    description
-      "Type definition for communities specified as regular
-      expression patterns";
-  }
-
-  typedef bgp-origin-attr-type {
-    type enumeration {
-      enum IGP {
-        value 0;
-        description "Origin of the NLRI is internal";
-      }
-      enum EGP {
-        value 1;
-        description "Origin of the NLRI is EGP";
-      }
-      enum INCOMPLETE {
-        value 2;
-        description "Origin of the NLRI is neither IGP or EGP";
-      }
-    }
-    description
-      "Type definition for standard BGP origin attribute";
-    reference "RFC 4271 - A Border Gateway Protocol 4 (BGP-4),
-      Sec 4.3";
   }
 
   typedef bgp-set-community-option-type {
@@ -178,6 +91,9 @@ module bgp-policy {
   typedef bgp-set-med-type {
     type union {
       type uint32;
+      type string {
+        pattern "^[+-][0-9]+";
+      }
       type enumeration {
         enum IGP {
           description "set the MED value to the IGP cost toward the
@@ -185,8 +101,11 @@ module bgp-policy {
         }
       }
     }
-    description "type definition for specifying how the BGP MED can
-    be set in BGP policy actions";
+    description
+      "Type definition for specifying how the BGP MED can
+      be set in BGP policy actions. The three choices are to set
+      the MED directly, increment/decrement using +/- notation,
+      and setting it to the IGP cost (predefined value).";
   }
 
   // grouping statements
@@ -208,8 +127,8 @@ module bgp-policy {
       leaf community-set {
         type leafref {
           path "/rpol:routing-policy/rpol:defined-sets/" +
-            "bgp-pol:bgp-defined-sets/bgp-pol:community-set/" +
-            "bgp-pol:community-set-name";
+            "bgp-pol:bgp-defined-sets/bgp-pol:community-sets/" +
+            "bgp-pol:community-set/bgp-pol:community-set-name";
           require-instance true;
         }
         description
@@ -230,7 +149,8 @@ module bgp-policy {
       leaf ext-community-set {
         type leafref {
           path "/rpol:routing-policy/rpol:defined-sets/" +
-            "bgp-pol:bgp-defined-sets/bgp-pol:ext-community-set/" +
+            "bgp-pol:bgp-defined-sets/bgp-pol:ext-community-sets/" +
+            "bgp-pol:ext-community-set/" +
             "bgp-pol:ext-community-set-name";
           require-instance true;
         }
@@ -251,8 +171,8 @@ module bgp-policy {
       leaf as-path-set {
         type leafref {
           path "/rpol:routing-policy/rpol:defined-sets/" +
-            "bgp-pol:bgp-defined-sets/bgp-pol:as-path-set/" +
-            "bgp-pol:as-path-set-name";
+            "bgp-pol:bgp-defined-sets/bgp-pol:as-path-sets/" +
+            "bgp-pol:as-path-set/bgp-pol:as-path-set-name";
           require-instance true;
         }
         description "References a defined AS path set";
@@ -274,7 +194,7 @@ module bgp-policy {
     }
 
     leaf origin-eq {
-      type bgp-origin-attr-type;
+      type bgp-types:bgp-origin-attr-type;
       description
         "Condition to check if the route origin is equal to the
         specified value";
@@ -346,80 +266,94 @@ module bgp-policy {
       description
         "BGP-related set definitions for policy match conditions";
 
-      list community-set {
-        key community-set-name;
+      container community-sets {
         description
-            "Definitions for community sets";
+          "Enclosing container for community sets";
 
-        leaf community-set-name {
-          type string;
-          mandatory true;
+        list community-set {
+          key community-set-name;
           description
-            "name / label of the community set -- this is used to
-            reference the set in match conditions";
-        }
+              "Definitions for community sets";
 
-        leaf-list community-members {
-          type union {
-            type bgp-std-community-type;
-            type bgp-community-regexp-type;
-            type bgp-well-known-community-type;
+          leaf community-set-name {
+            type string;
+            mandatory true;
+            description
+              "name / label of the community set -- this is used to
+              reference the set in match conditions";
           }
-          description
-            "members of the community set";
-        }
 
-      }
-
-      list ext-community-set {
-        key ext-community-set-name;
-        description
-            "Definitions for extended community sets";
-
-        leaf ext-community-set-name {
-          type string;
-          description
-            "name / label of the extended community set -- this is
-            used to reference the set in match conditions";
-        }
-
-        leaf-list ext-community-members {
-          type union {
-            type bgp-ext-community-type;
-            // TODO: is regexp support needed for extended
-            // communities?
-            type bgp-community-regexp-type;
+          leaf-list community-member {
+            type union {
+              type bgp-types:bgp-std-community-type;
+              type bgp-types:bgp-community-regexp-type;
+              type bgp-types:bgp-well-known-community-type;
+            }
+            description
+              "members of the community set";
           }
-          description
-              "members of the extended community set";
         }
       }
 
-      list as-path-set {
-        key as-path-set-name;
+      container ext-community-sets {
         description
-            "Definitions for AS path sets";
+          "Enclosing container for extended community sets";
 
-        leaf as-path-set-name {
-          type string;
+        list ext-community-set {
+          key ext-community-set-name;
           description
-            "name of the AS path set -- this is used to reference the
-            the set in match conditions";
-        }
+              "Definitions for extended community sets";
 
-        leaf-list as-path-set-members {
-          // TODO: need to refine typedef for AS path expressions
-          type string;
+          leaf ext-community-set-name {
+            type string;
+            description
+              "name / label of the extended community set -- this is
+              used to reference the set in match conditions";
+          }
+
+          leaf-list ext-community-member {
+            type union {
+              type bgp-types:bgp-ext-community-type;
+              // TODO: is regexp support needed for extended
+              // communities?
+              type bgp-types:bgp-community-regexp-type;
+            }
+            description
+                "members of the extended community set";
+          }
+        }
+      }
+
+      container as-path-sets {
+        description
+          "Enclosing container for AS path sets";
+
+        list as-path-set {
+          key as-path-set-name;
           description
-              "AS path expression -- list of ASes in the set";
-        }
+              "Definitions for AS path sets";
 
+          leaf as-path-set-name {
+            type string;
+            description
+              "name of the AS path set -- this is used to reference
+              the set in match conditions";
+          }
+
+          leaf-list as-path-set-member {
+            // TODO: need to refine typedef for AS path expressions
+            type string;
+            description
+                "AS path expression -- list of ASes in the set";
+          }
+        }
       }
     }
   }
 
-  augment "/rpol:routing-policy/rpol:policy-definition/" +
-    "rpol:statement/rpol:conditions" {
+  augment "/rpol:routing-policy/rpol:policy-definitions/" +
+    "rpol:policy-definition/rpol:statements/rpol:statement/" +
+    "rpol:conditions" {
     description "BGP policy conditions added to routing policy
     module";
 
@@ -433,8 +367,9 @@ module bgp-policy {
     }
   }
 
-  augment "/rpol:routing-policy/rpol:policy-definition/" +
-    "rpol:statement/rpol:actions" {
+  augment "/rpol:routing-policy/rpol:policy-definitions/" +
+    "rpol:policy-definition/rpol:statements/rpol:statement/" +
+    "rpol:actions" {
     description "BGP policy actions added to routing policy
     module";
 
@@ -445,7 +380,7 @@ module bgp-policy {
 
       container set-as-path-prepend {
 
-        presence "node is pesent in the config data to use the AS
+        presence "node is present in the config data to use the AS
       prepend action";
         description
             "action to prepend local AS number to the AS-path a
@@ -473,8 +408,8 @@ module bgp-policy {
           case inline {
             leaf-list communities {
               type union {
-                type bgp-std-community-type;
-                type bgp-well-known-community-type;
+                type bgp-types:bgp-std-community-type;
+                type bgp-types:bgp-well-known-community-type;
               }
               description
                 "Set the community values for the update inline with
@@ -485,7 +420,8 @@ module bgp-policy {
             leaf community-set-ref {
               type leafref {
                 path "/rpol:routing-policy/rpol:defined-sets/" +
-                  "bgp-pol:bgp-defined-sets/bgp-pol:community-set/" +
+                  "bgp-pol:bgp-defined-sets/" +
+                  "bgp-pol:community-sets/bgp-pol:community-set/" +
                   "bgp-pol:community-set-name";
                 require-instance true;
               }
@@ -520,8 +456,8 @@ module bgp-policy {
           case inline {
             leaf-list communities {
               type union {
-                type bgp-ext-community-type;
-                type bgp-well-known-community-type;
+                type bgp-types:bgp-ext-community-type;
+                type bgp-types:bgp-well-known-community-type;
               }
               description
                 "Set the community values for the update inline with
@@ -533,6 +469,7 @@ module bgp-policy {
               type leafref {
                 path "/rpol:routing-policy/rpol:defined-sets/" +
                   "bgp-pol:bgp-defined-sets/" +
+                  "bgp-pol:ext-community-sets/" +
                   "bgp-pol:ext-community-set/" +
                   "bgp-pol:ext-community-set-name";
                 require-instance true;
@@ -554,7 +491,7 @@ module bgp-policy {
       }
 
       leaf set-route-origin {
-        type bgp-origin-attr-type;
+        type bgp-types:bgp-origin-attr-type;
         description "set the origin attribute to the specified
         value";
       }

--- a/experimental/openconfig/bgp/bgp-types.yang
+++ b/experimental/openconfig/bgp/bgp-types.yang
@@ -20,80 +20,11 @@ module bgp-types {
     policy. It can be imported by modules that make use of BGP
     attributes";
 
-  revision "2015-03-03" {
+  revision "2015-05-15" {
     description "Initial revision";
     reference "TBD";
   }
 
-  typedef peer-type {
-    type enumeration {
-      enum INTERNAL {
-        description "internal (iBGP) peer";
-      }
-      enum EXTERNAL {
-        description "external (eBGP) peer";
-      }
-    }
-    description
-      "labels a peer or peer group as explicitly internal or
-      external";
-  }
-
-
-  typedef remove-private-as-option {
-    type enumeration {
-      enum ALL {
-        description "remove all private ASes in the path";
-      }
-      enum REPLACE {
-        description "replace private ASes with local AS";
-      }
-    }
-    description
-      "set of options for configuring how private AS path numbers
-      are removed from advertisements";
-  }
-
-  typedef percentage {
-    type uint8 {
-      range "0..100";
-    }
-    description
-      "Integer indicating a percentage value";
-  }
-
-  typedef rr-cluster-id-type {
-    type union {
-      type uint32;
-      type inet:ipv4-address;
-    }
-    description
-      "union type for route reflector cluster ids:
-      option 1: 4-byte number
-      option 2: IP address";
-  }
-
-  typedef community-type {
-    type enumeration {
-      enum STANDARD {
-        description "send only standard communities";
-      }
-      enum EXTENDED {
-        description "send only extended communities";
-      }
-      enum BOTH {
-        description "send both standard and extended communities";
-      }
-      enum NONE {
-        description "do not send any community attribute";
-      }
-    }
-    description
-      "type describing variations of community attributes:
-      STANDARD: standard BGP community [rfc1997]
-      EXTENDED: extended BGP community [rfc4360]
-      BOTH: both standard and extended community";
-  }
 
   identity bgp-capability {
     description "Base identity for a BGP capability";
@@ -101,7 +32,7 @@ module bgp-types {
 
   identity MPBGP {
     base "bgp-capability";
-    description 
+    description
       "Multi-protocol extensions to BGP";
     reference "RFC2858";
   }
@@ -209,6 +140,60 @@ module bgp-types {
       "BGP MPLS Based Ethernet VPN (AFI,SAFI = 25,70)";
   }
 
+  identity bgp-well-known-std-community {
+    description
+      "Reserved communities within the standard community space
+      defined by RFC1997. These communities must fall within the
+      range 0x00000000 to 0xFFFFFFFF";
+    reference "RFC1997";
+  }
+
+  identity NO_EXPORT {
+    base bgp-well-known-std-community;
+    description
+      "Do not export NLRI received carrying this community outside
+      the bounds of this autonomous system, or this confederation if
+      the local autonomous system is a confederation member AS. This
+      community has a value of 0xFFFFFF01.";
+    reference "RFC1997";
+  }
+
+  identity NO_ADVERTISE {
+    base bgp-well-known-std-community;
+    description
+      "All NLRI received carrying this community must not be
+      advertised to other BGP peers. This community has a value of
+      0xFFFFFF02.";
+    reference "RFC1997";
+  }
+
+  identity NO_EXPORT_SUBCONFED {
+    base bgp-well-known-std-community;
+    description
+      "All NLRI received carrying this community must not be
+      advertised to external BGP peers - including over confederation
+      sub-AS boundaries. This community has a value of 0xFFFFFF03.";
+    reference "RFC1997";
+  }
+
+  identity NOPEER {
+    base bgp-well-known-std-community;
+    description
+      "An autonomous system receiving NLRI tagged with this community
+      is advised not to readvertise the NLRI to external bi-lateral
+      peer autonomous systems. An AS may also filter received NLRI
+      from bilateral peer sessions when they are tagged with this
+      community value";
+    reference "RFC3765";
+  }
+
+  identity INTERNET {
+    base bgp-well-known-std-community;
+    description
+      "A community used by some implementations with the value 0:0
+      which represents all possible community values.";
+  }
+
   typedef bgp-session-direction {
     type enumeration {
       enum INBOUND {
@@ -222,6 +207,149 @@ module bgp-types {
     }
     description
       "Type to describe the direction of NLRI transmission";
+  }
+
+  typedef bgp-well-known-community-type {
+    type identityref {
+      base bgp-well-known-std-community;
+    }
+    description
+      "Type definition for well-known IETF community attribute
+      values";
+    reference
+      "IANA Border Gateway Protocol (BGP) Well Known Communities";
+  }
+
+
+  typedef bgp-std-community-type {
+    // TODO: further refine restrictions and allowed patterns
+    // 4-octet value:
+    //  <as number> 2 octets
+    //  <community value> 2 octets
+    type union {
+      type uint32 {
+      // per RFC 1997, 0x00000000 - 0x0000FFFF and 0xFFFF0000 -
+      // 0xFFFFFFFF are reserved
+        range "65536..4294901759"; // 0x00010000..0xFFFEFFFF
+      }
+      type string {
+        pattern '([0-9]+:[0-9]+)';
+      }
+    }
+    description
+      "Type definition for standard commmunity attributes";
+    reference "RFC 1997 - BGP Communities Attribute";
+  }
+
+  typedef bgp-ext-community-type {
+    // TODO: needs more work to make this more precise given the
+    // variability of extended community attribute specifications
+    // 8-octet value:
+    //  <type> 2 octects
+    //  <value> 6 octets
+    type string {
+      pattern '([0-9\.]+(:[0-9]+)?:[0-9]+)';
+    }
+    description
+      "Type definition for extended community attributes";
+    reference "RFC 4360 - BGP Extended Communities Attribute";
+  }
+
+  typedef bgp-community-regexp-type {
+    // TODO: needs more work to decide what format these regexps can
+    // take.
+    type string;
+    description
+      "Type definition for communities specified as regular
+      expression patterns";
+  }
+
+  typedef bgp-origin-attr-type {
+    type enumeration {
+      enum IGP {
+        description "Origin of the NLRI is internal";
+      }
+      enum EGP {
+        description "Origin of the NLRI is EGP";
+      }
+      enum INCOMPLETE {
+        description "Origin of the NLRI is neither IGP or EGP";
+      }
+    }
+    description
+      "Type definition for standard BGP origin attribute";
+    reference "RFC 4271 - A Border Gateway Protocol 4 (BGP-4),
+      Sec 4.3";
+  }
+
+  typedef peer-type {
+    type enumeration {
+      enum INTERNAL {
+        description "internal (iBGP) peer";
+      }
+      enum EXTERNAL {
+        description "external (eBGP) peer";
+      }
+    }
+    description
+      "labels a peer or peer group as explicitly internal or
+      external";
+  }
+
+
+  typedef remove-private-as-option {
+    type enumeration {
+      enum ALL {
+        description "remove all private ASes in the path";
+      }
+      enum REPLACE {
+        description "replace private ASes with local AS";
+      }
+    }
+    description
+      "set of options for configuring how private AS path numbers
+      are removed from advertisements";
+  }
+
+  typedef percentage {
+    type uint8 {
+      range "0..100";
+    }
+    description
+      "Integer indicating a percentage value";
+  }
+
+  typedef rr-cluster-id-type {
+    type union {
+      type uint32;
+      type inet:ipv4-address;
+    }
+    description
+      "union type for route reflector cluster ids:
+      option 1: 4-byte number
+      option 2: IP address";
+  }
+
+  typedef community-type {
+    type enumeration {
+      enum STANDARD {
+        description "send only standard communities";
+      }
+      enum EXTENDED {
+        description "send only extended communities";
+      }
+      enum BOTH {
+        description "send both standard and extended communities";
+      }
+      enum NONE {
+        description "do not send any community attribute";
+      }
+    }
+    description
+      "type describing variations of community attributes:
+      STANDARD: standard BGP community [rfc1997]
+      EXTENDED: extended BGP community [rfc4360]
+      BOTH: both standard and extended community";
   }
 
 

--- a/experimental/openconfig/bgp/bgp.yang
+++ b/experimental/openconfig/bgp/bgp.yang
@@ -38,6 +38,7 @@ module bgp {
       BGP
         |
         +-> [ global BGP configuration ]
+          +-> AFI / SAFI global
         +-> peer group
           +-> [ peer group config ]
           +-> AFI / SAFI [ per-AFI overrides ]
@@ -46,7 +47,7 @@ module bgp {
           +-> [ optional pointer to peer-group ]
           +-> AFI / SAFI [ per-AFI overrides ]";
 
-  revision "2014-03-05" {
+  revision "2015-05-15" {
       description
         "";
       reference "TBD";
@@ -101,6 +102,13 @@ module bgp {
       router is within an autonomous system which is part of a BGP
       confederation.";
 
+    leaf enabled {
+      type boolean;
+      description
+        "When this leaf is set to true it indicates that
+        the local-AS is part of a BGP confederation";
+    }
+
     leaf identifier {
       type inet:as-number;
       description
@@ -123,6 +131,15 @@ module bgp {
       type inet:as-number;
       description
         "AS number of the peer.";
+    }
+
+    leaf local-as {
+      type inet:as-number;
+      description
+        "The local autonomous system number that is to be used
+        when establishing sessions with the remote peer or peer
+        group, if this differs from the global BGP router
+        autonomous system number.";
     }
 
     leaf peer-type {
@@ -218,20 +235,14 @@ module bgp {
       }
       default 30;
       description
-        "Mininum time interval in seconds between transmission
-        of BGP updates to neighbors";
+        "Minimum time which must elapse between subsequent UPDATE
+        messages relating to a common set of NLRI being transmitted
+        to a peer. This timer is referred to as
+        MinRouteAdvertisementIntervalTimer by RFC 4721 and serves to
+        reduce the number of UPDATE messages transmitted when a
+        particular set of NLRI exhibit instability.";
       reference
-        "RFC 4271 - A Border Gateway Protocol 4, Sec 10";
-    }
-
-    leaf send-update-delay {
-      type decimal64 {
-        fraction-digits 2;
-      }
-      description
-        "Time interval between routes changing in the routing
-        table and corresponding updates sent to neighbors --
-        serves to batch updates";
+        "RFC 4271 - A Border Gateway Protocol 4, Sec 9.2.1.1";
     }
   }
 
@@ -263,10 +274,18 @@ module bgp {
     }
 
     leaf local-address {
-      type inet:ip-address;
+      type union {
+        type inet:ip-address;
+        type string;
+      }
+      //TODO:  the string should be converted to a leafref type
+      //to point to an interface when YANG 1.1 is available with
+      //leafrefs in union types.
       description
         "Set the local IP (either IPv4 or IPv6) address to use
-        for the session when sending BGP update messages.";
+        for the session when sending BGP update messages.  This
+        may be expressed as either an IP address or reference
+        to the name of an interface.";
     }
   }
 
@@ -305,13 +324,20 @@ module bgp {
       "Configuration parameters specifying the multihop behaviour for
       BGP sessions to the peer";
 
+    leaf enabled {
+      type boolean;
+      default "false";
+      description
+        "When enabled the referenced group or neighbors are permitted
+        to be indirectly connected - including cases where the TTL
+        can be decremented between the BGP peers";
+    }
+
     leaf multihop-ttl {
       type uint8;
-      default 1;
       description
-        "Time-to-live for multihop BGP sessions.  The default
-        value of 1 is for directly connected peers (i.e.,
-        multihop disabled";
+        "Time-to-live value to use when packets are sent to the
+        referenced group or neighbors and ebgp-multihop is enabled";
     }
   }
 
@@ -400,7 +426,7 @@ module bgp {
     }
   }
 
-  grouping bgp-graceful-restart_config {
+  grouping bgp-graceful-restart {
     description
       "Configures BGP graceful restart, which is a negotiated
       option that indicates that a BGP speaker is able to retain
@@ -408,9 +434,6 @@ module bgp {
 
     reference "RFC 4724: Graceful Restart Mechanism for BGP";
     container graceful-restart {
-      presence
-        "Presence of this item indicates that BGP graceful restart
-        is enabled.";
       description
         "Parameters relating the graceful restart mechanism for BGP";
       container config {
@@ -431,15 +454,22 @@ module bgp {
     description
       "Configuration parameters relating to BGP graceful restart.";
 
+    leaf enabled {
+      type boolean;
+      description
+        "Enable or disable the graceful-restart capability.";
+    }
+
     leaf restart-time {
       type uint16 {
         range 0..4096;
       }
       description
-        "Estimated time in seconds for the BGP session to be
-        re-established after a restart.  This is a 12-bit value
-        advertised by the router to peers.  Per RFC 4724, the
-        suggested default value is <= the hold-time value";
+        "Estimated time (in seconds) for the local BGP speaker to
+        restart a session. This value is advertise in the graceful
+        restart BGP capability.  This is a 12-bit value, referred to
+        as Restart Time in RFC4724.  Per RFC4724, the suggested
+        default value is <= the hold-time value.";
     }
 
     leaf stale-routes-time {
@@ -447,9 +477,22 @@ module bgp {
         fraction-digits 2;
       }
       description
-        "Sets an upper bound on the time in seconds that stale
-        routes will be retained by the router after a session is
-        restarted";
+        "An upper-bound on the time thate stale routes will be
+        retained by a router after a session is restarted. If an
+        End-of-RIB (EOR) marker is received prior to this timer
+        expiring stale-routes will be flushed upon its receipt - if
+        no EOR is received, then when this timer expires stale paths
+        will be purged. This timer is referred to as the
+        Selection_Deferral_Timer in RFC4724";
+    }
+
+    leaf helper-only {
+      type boolean;
+      description
+        "Enable graceful-restart in helper mode only. When this
+        leaf is set, the local system does not retain forwarding
+        its own state during a restart, but supports procedures
+        for the receiving speaker, as defined in RFC4724.";
     }
   }
 
@@ -474,6 +517,8 @@ module bgp {
       uses bgp-op:bgp-global_state;
     }
 
+    uses bgp-mp:bgp-route-selection-options;
+
     container default-route-distance {
       description
         "Administrative distance (or preference) assigned to
@@ -495,10 +540,6 @@ module bgp {
     }
 
     container confederation {
-      presence
-        "Presence of this container indicates that the local AS is
-        part of a confederation";
-
       description
         "Parameters indicating whether the local system acts as part
         of a BGP confederation";
@@ -516,13 +557,14 @@ module bgp {
       }
     }
 
-    uses bgp-mp:bgp-use-multiple-paths_config;
-    uses bgp-graceful-restart_config;
+    uses bgp-mp:bgp-use-multiple-paths;
 
-    container afi-safi {
+    uses bgp-graceful-restart;
+
+    container afi-safis {
       description
         "Address family specific configuration";
-      uses bgp-mp:bgp-global-afi-safi-list;
+      uses bgp-mp:bgp-common-afi-safi-list;
     }
   }
 
@@ -536,10 +578,14 @@ module bgp {
         uniquely identified by peer IPv[46] address";
 
       leaf neighbor-address {
-        type inet:ip-address;
+        type leafref {
+          path "../config/neighbor-address";
+        }
         description
-          "Address of the BGP peer, either in IPv4 or IPv6";
+          "Reference to the address of the BGP neighbor used as
+          a key in the neighbor list";
       }
+
       uses bgp-neighbor-group;
     }
   }
@@ -553,11 +599,15 @@ module bgp {
         "List of BGP peer-groups configured on the local system -
         uniquely identified by peer-group name";
 
-      leaf peer-group-name {
-        type string;
-        description
-          "";
+    leaf peer-group-name {
+      type leafref {
+        path "../config/peer-group-name";
       }
+      description
+        "Reference to the name of the BGP peer-group used as a
+        key in the peer-group list";
+      }
+
       uses bgp-neighbor-group;
     }
   }
@@ -726,16 +776,38 @@ module bgp {
       }
     }
 
-    container afi-safi {
+    container afi-safis {
       description
         "Per-address-family configuration parameters associated with
         the neighbor or group";
-      uses bgp-mp:bgp-global-afi-safi-list;
+      uses bgp-mp:bgp-common-afi-safi-list;
     }
 
-    uses bgp-graceful-restart_config;
+    uses bgp-graceful-restart;
 
     uses rpol:apply-policy-group;
+  }
+
+  grouping bgp-neighbor-neighbor-address_config {
+    description
+      "Configuration options relating to the BGP neighbor address";
+
+    leaf neighbor-address {
+        type inet:ip-address;
+        description
+          "Address of the BGP peer, either in IPv4 or IPv6";
+    }
+  }
+
+  grouping bgp-peer-group-peer-group-name_config {
+    description
+      "Configuration options relating to the BGP peer-group name";
+
+    leaf peer-group-name {
+      type string;
+      description
+        "Name of the BGP peer-group";
+    }
   }
 
   // add peer-group pointer only for the neighbor list
@@ -756,14 +828,71 @@ module bgp {
   augment /bgp/peer-groups/peer-group {
     description
       "Augmentation to add multipath configuration to a peer-group";
-    uses bgp-mp:bgp-use-multiple-paths_config;
+    uses bgp-mp:bgp-use-multiple-paths;
   }
 
   augment /bgp/neighbors/neighbor {
     description
       "Augmentation to add the multipath configuration to a
       neighbor";
-    uses bgp-mp:bgp-use-multiple-paths-neighbor_config;
+    uses bgp-mp:bgp-use-multiple-paths-neighbor;
+  }
+
+  augment /bgp/peer-groups/peer-group/afi-safis/afi-safi {
+    description
+      "Augmentation to add multipath configuration to a peer-group
+      on a per-AFI-SAFI basis";
+    uses bgp-mp:bgp-use-multiple-paths;
+  }
+
+  augment /bgp/neighbors/neighbor/afi-safis/afi-safi {
+    description
+      "Augmentation to add multipath configuration to a neighbor
+      on a per-AFI-SAFI basis";
+    uses bgp-mp:bgp-use-multiple-paths-neighbor;
+  }
+
+  augment /bgp/global/afi-safis/afi-safi {
+    description
+      "Augmentation to add global instance specific AFI-SAFI
+      configuration information";
+    uses bgp-mp:bgp-global-afi-safi;
+    uses bgp-mp:bgp-use-multiple-paths;
+  }
+
+  augment /bgp/peer-groups/peer-group/afi-safis/afi-safi {
+    description
+      "Augmentation that adds peer-group instance specific
+      AFI-SAFI configuration information";
+    uses bgp-mp:bgp-group-afi-safi;
+  }
+
+  augment /bgp/neighbors/neighbor/config {
+    description
+      "Augmentation adding the neighbor address to the
+      neighbor configuration container";
+    uses bgp-neighbor-neighbor-address_config;
+  }
+
+  augment /bgp/neighbors/neighbor/state {
+    description
+      "Augmentation adding the neighbor address to the
+      neighbor state container";
+    uses bgp-neighbor-neighbor-address_config;
+  }
+
+  augment /bgp/peer-groups/peer-group/config {
+    description
+      "Augmentation adding the peer-group name to the
+      peer-group configuration container";
+    uses bgp-peer-group-peer-group-name_config;
+  }
+
+  augment /bgp/peer-groups/peer-group/state {
+    description
+      "Augmentation adding the peer-group name to the
+      peer-group state container";
+    uses bgp-peer-group-peer-group-name_config;
   }
 
   // ************************************************************
@@ -844,18 +973,26 @@ module bgp {
     uses bgp-op:bgp-peer-group_state;
   }
 
-  augment /bgp/global/afi-safi/afi-safi/state {
+  augment /bgp/global/afi-safis/afi-safi/state {
     description
       "Augmentation to add operational state and counters
       on a per-AFI-SAFI basis to the global BGP router";
     uses bgp-op:bgp-global-afi-safi_state;
   }
 
-  augment /bgp/neighbors/neighbor/afi-safi/afi-safi/state {
+  augment /bgp/neighbors/neighbor/afi-safis/afi-safi/state {
     description
       "Augmentation to add per-AFI-SAFI operational state
       and counters to the BGP neighbor";
     uses bgp-op:bgp-neighbor-afi-safi_state;
+  }
+
+  augment "/bgp/neighbors/neighbor/afi-safis/afi-safi/" +
+    "graceful-restart/state" {
+    description
+      "Augmentation to add per-AFI-SAFI operational state for BGP
+      graceful-restart";
+    uses bgp-op:bgp-neighbor-afi-safi-graceful-restart_state;
   }
 
   // ************************************************************

--- a/experimental/openconfig/policy/policy-types.yang
+++ b/experimental/openconfig/policy/policy-types.yang
@@ -8,7 +8,6 @@ module policy-types {
   prefix "ptypes";
 
   // import some basic types
-  import ietf-inet-types { prefix inet; }
   import ietf-yang-types { prefix yang; }
 
 
@@ -25,7 +24,7 @@ module policy-types {
     policy.  It can be imported by modules that contain protocol-
     specific policy conditions and actions.";
 
-  revision "2014-11-30" {
+  revision "2015-05-15" {
     description
       "Initial revision";
     reference "TBD";
@@ -76,6 +75,27 @@ module policy-types {
       of the members of the defined set";
   }
 
+  typedef match-set-options-restricted-type {
+    type enumeration {
+      enum ANY {
+        description "match is true if given value matches any member
+        of the defined set";
+      }
+      enum INVERT {
+        description "match is true if given value does not match any
+        member of the defined set";
+      }
+    }
+    default ANY;
+    description
+      "Options that govern the behavior of a match statement.  The
+      default behavior is ANY, i.e., the given value matches any
+      of the members of the defined set.  Note this type is a
+      restricted version of the match-set-options-type.";
+      //TODO: restriction on enumerated types is only allowed in
+      //YANG 1.1.  Until then, we will require this additional type
+  }
+
   grouping attribute-compare-operators {
     description "common definitions for comparison operations in
     condition statements";
@@ -107,6 +127,50 @@ module policy-types {
       "RFC 2178 OSPF Version 2
       RFC 5130 A Policy Control Mechanism in IS-IS Using
       Administrative Tags";
-      
+  }
+
+  identity install-protocol-type {
+    description
+      "Base type for protocols which can install prefixes into the
+      RIB";
+  }
+
+  identity BGP {
+    base install-protocol-type;
+    description "BGP";
+    reference "RFC 4271";
+  }
+
+  identity ISIS {
+    base install-protocol-type;
+    description "IS-IS";
+    reference "ISO/IEC 10589";
+  }
+
+  identity OSPF {
+    base install-protocol-type;
+    description "OSPFv2";
+    reference "RFC 2328";
+  }
+
+  identity OSPF3 {
+    base install-protocol-type;
+    description "OSPFv3";
+    reference "RFC 5340";
+  }
+
+  identity STATIC {
+    base install-protocol-type;
+    description "Locally-installed static route";
+  }
+
+  identity DIRECTLY-CONNECTED {
+    base install-protocol-type;
+    description "A directly connected route";
+  }
+
+  identity LOCAL-AGGREGATE {
+    base install-protocol-type;
+    description "Locally defined aggregate route";
   }
 }

--- a/experimental/openconfig/policy/routing-policy.yang
+++ b/experimental/openconfig/policy/routing-policy.yang
@@ -67,16 +67,16 @@ module routing-policy {
     Policy 'subroutines' (or nested policies) are supported by
     allowing policy statement conditions to reference another policy
     definition which applies conditions and actions from the
-    referenced policy before returning to the calling policy 
+    referenced policy before returning to the calling policy
     statement and resuming evaluation.  If the called policy
     results in an accept-route (either explicit or by default), then
     the subroutine returns an effective true value to the calling
     policy.  Similarly, a reject-route action returns false.  If the
     subroutine returns true, the calling policy continues to evaluate
-    the remaining conditions (using a modified route if the 
+    the remaining conditions (using a modified route if the
     subroutine performed any changes to the route).";
 
-  revision "2014-11-30" {
+  revision "2015-05-15" {
     description
       "Initial revision";
     reference "TBD";
@@ -98,46 +98,6 @@ module routing-policy {
     a policy chain";
   }
 
-  identity install-protocol-type {
-    description
-      "Base type for protocols which can install prefixes into the
-      RIB";
-  }
-
-  identity BGP {
-    base install-protocol-type;
-    description "BGP";
-    reference "RFC 4271";
-  }
-
-  identity ISIS {
-    base install-protocol-type;
-    description "IS-IS";
-    reference "ISO/IEC 10589";
-  }
-
-  identity OSPF {
-    base install-protocol-type;
-    description "OSPFv2";
-    reference "RFC 2328";
-  }
-
-  identity OSPF3 {
-    base install-protocol-type;
-    description "OSPFv3";
-    reference "RFC 5340";
-  }
-
-  identity STATIC {
-    base install-protocol-type;
-    description "Locally-installed static route";
-  }
-
-  identity DIRECTLY-CONNECTED {
-    base install-protocol-type;
-    description "A directly connected route";
-  }
-
 
   // grouping statements
 
@@ -148,107 +108,114 @@ module routing-policy {
       be used in matching conditions in different routing
       protocols.";
 
-    list prefix-set {
-      key prefix-set-name;
+    container prefix-sets {
       description
-        "Definitions for prefix sets";
+        "Enclosing container for defined prefix sets for matching";
 
-      leaf prefix-set-name {
-        type string;
+      list prefix-set {
+        key prefix-set-name;
         description
-          "name / label of the prefix set -- this is used to
-          reference the set in match conditions";
-      }
+          "List of the defined prefix sets";
 
-      list prefix {
-        key "address masklength masklength-range";
-        description
-          "list of prefix expressions that are part of the set";
-
-        leaf address {
-          type inet:ip-address;
-          mandatory true;
+        leaf prefix-set-name {
+          type string;
           description
-            "address portion of the prefix";
-        }
-
-        leaf masklength {
-          type uint8 {
-            // simple range covers both ipv4 and ipv6 --
-            // could separate this into different types
-            // for IPv4 and IPv6 prefixes
-            range 0..128;
-          }
-          mandatory true;
-          description
-            "masklength for the prefix specification";
-        }
-
-        leaf masklength-range {
-          type string {
-            // pattern modeled after ietf-inet-types
-            pattern '(([0-9])|([1-9][0-9])|(1[0-1][0-9])|'
-              + '(12[0-8]))\.\.'
-              + '(([0-9])|([1-9][0-9])|(1[0-1][0-9])|'
-              + '(12[0-8]))';
-          }
-          description
-            "Defines an optional range for the masklength.  Absence
-            of the masklength-length implies that the prefix has an
-            exact masklength given by the masklength parameter.
-            Example: 10.3.192.0/21 through 10.3.192.0/24 would be
-            expressed as address: 10.3.192.0, masklength: 21,
-            masklength-range: 21..24";
-        }
-      }
-    }
-
-    list neighbor-set {
-      key neighbor-set-name;
-      description
-          "Definitions for neighbor sets";
-
-      leaf neighbor-set-name {
-        type string;
-        description
-            "name / label of the neighbor set -- this is used to
+            "name / label of the prefix set -- this is used to
             reference the set in match conditions";
-      }
+        }
 
-      list neighbor {
-        key "address";
-        description
-            "list of addresses that are part of the neighbor set";
-
-        leaf address {
-          type inet:ip-address;
+        list prefix {
+          key "ip-prefix masklength-range";
           description
-              "IP address of the neighbor set member";
+            "List of prefix expressions that are part of the set";
+
+          leaf ip-prefix {
+            type inet:ip-prefix;
+            mandatory true;
+            description
+              "The prefix member in CIDR notation -- while the
+              prefix may be either IPv4 or IPv6, most
+              implementations require all members of the prefix set
+              to be the same address family.  Mixing address types in
+              the same prefix set is likely to cause an error.";
+          }
+
+          leaf masklength-range {
+            type string {
+              pattern '^([0-9]+\.\.[0-9]+)|exact$';
+            }
+            description
+              "Defines a range for the masklength, or 'exact' if
+              the prefix has an exact length.
+
+              Example: 10.3.192.0/21 through 10.3.192.0/24 would be
+              expressed as prefix: 10.3.192.0/21,
+              masklength-range: 21..24.
+
+              Example: 10.3.192.0/21 would be expressed as
+              prefix: 10.3.192.0/21,
+              masklength-range: exact";
+          }
         }
       }
     }
 
-    list tag-set {
-      key tag-set-name;
+    container neighbor-sets {
       description
-        "Definitions for tag sets";
+        "Enclosing container for defined neighbor sets for matching";
 
-      leaf tag-set-name {
-        type string;
+      list neighbor-set {
+        key neighbor-set-name;
         description
-          "name / label of the tag set -- this is used to reference
-          the set in match conditions";
-      }
+            "Definitions for neighbor sets";
 
-      list tag {
-        key "value";
-        description
-          "list of tags that are part of the tag set";
-
-        leaf value {
-          type pt:tag-type;
+        leaf neighbor-set-name {
+          type string;
           description
-            "Value of the tag set member";
+              "name / label of the neighbor set -- this is used to
+              reference the set in match conditions";
+        }
+
+        list neighbor {
+          key "address";
+          description
+              "list of addresses that are part of the neighbor set";
+
+          leaf address {
+            type inet:ip-address;
+            description
+                "IP address of the neighbor set member";
+          }
+        }
+      }
+    }
+
+    container tag-sets {
+      description
+        "Enclosing container for defined tag sets for matching";
+
+      list tag-set {
+        key tag-set-name;
+        description
+          "Definitions for tag sets";
+
+        leaf tag-set-name {
+          type string;
+          description
+            "name / label of the tag set -- this is used to reference
+            the set in match conditions";
+        }
+
+        list tag {
+          key "value";
+          description
+            "list of tags that are part of the tag set";
+
+          leaf value {
+            type pt:tag-type;
+            description
+              "Value of the tag set member";
+          }
         }
       }
     }
@@ -261,7 +228,7 @@ module routing-policy {
 
     leaf install-protocol-eq {
       type identityref {
-        base install-protocol-type;
+        base pt:install-protocol-type;
       }
       description
         "Condition to check the protocol / method used to install
@@ -282,6 +249,20 @@ module routing-policy {
     }
   }
 
+  grouping match-set-options-restricted-group {
+    description
+      "Grouping for a restricted set of match operation modifiers";
+
+    leaf match-set-options {
+      type pt:match-set-options-restricted-type;
+      description
+        "Optional parameter that governs the behaviour of the
+        match operation.  This leaf only supports matching on ANY
+        member of the set or inverting the match.  Matching on ALL is
+        not supported)";
+    }
+  }
+
   grouping generic-conditions {
     description "Condition statement definitions for checking
     membership in a generic defined set";
@@ -297,13 +278,15 @@ module routing-policy {
 
       leaf prefix-set {
         type leafref {
-          path "/routing-policy/defined-sets/prefix-set" +
-          "/prefix-set-name";
-          require-instance true;
+          path "/routing-policy/defined-sets/prefix-sets/" +
+          "prefix-set/prefix-set-name";
+          //TODO: require-instance should be added when it's
+          //supported in YANG 1.1
+          //require-instance true;
         }
         description "References a defined prefix set";
       }
-      uses match-set-options-group;
+      uses match-set-options-restricted-group;
     }
 
     container match-neighbor-set {
@@ -317,13 +300,15 @@ module routing-policy {
 
       leaf neighbor-set {
         type leafref {
-          path "/routing-policy/defined-sets/neighbor-set" +
-          "/neighbor-set-name";
-          require-instance true;
+          path "/routing-policy/defined-sets/neighbor-sets/" +
+          "neighbor-set/neighbor-set-name";
+          //TODO: require-instance should be added when it's
+          //supported in YANG 1.1
+          //require-instance true;
         }
         description "References a defined neighbor set";
       }
-      uses match-set-options-group;
+      uses match-set-options-restricted-group;
     }
 
     container match-tag-set {
@@ -337,13 +322,15 @@ module routing-policy {
 
       leaf tag-set {
         type leafref {
-          path "/routing-policy/defined-sets/tag-set" +
+          path "/routing-policy/defined-sets/tag-sets/tag-set" +
           "/tag-set-name";
-          require-instance true;
+          //TODO: require-instance should be added when it's
+          //supported in YANG 1.1
+          //require-instance true;
         }
         description "References a defined tag set";
       }
-      uses match-set-options-group;
+      uses match-set-options-restricted-group;
     }
 
     uses local-generic-conditions;
@@ -371,14 +358,19 @@ module routing-policy {
       "Definitions for common set of policy action statements that
       manage the disposition or control flow of the policy";
 
-    leaf accept-route {
-      type empty;
-      description "accepts the route into the routing table";
-    }
+    choice route-disposition {
+      description
+        "Select the final disposition for the route, either
+        accept or reject.";
+      leaf accept-route {
+        type empty;
+        description "accepts the route into the routing table";
+      }
 
-    leaf reject-route {
-      type empty;
-      description "rejects the route";
+      leaf reject-route {
+        type empty;
+        description "rejects the route";
+      }
     }
   }
 
@@ -392,7 +384,8 @@ module routing-policy {
 
       leaf set-tag {
         type pt:tag-type;
-        description "set the tag value for OSPF or IS-IS routes";
+        description
+          "Set the tag value for OSPF or IS-IS routes.";
       }
     }
   }
@@ -402,8 +395,6 @@ module routing-policy {
       "top-level container for all routing policy configuration";
 
     container defined-sets {
-      presence "Container for sets defined for matching in policy
-        statements";
       description
           "Predefined sets of attributes used in policy match
           statements";
@@ -414,134 +405,184 @@ module routing-policy {
       // e.g., for OSPF, IS-IS, etc.
     }
 
-    list policy-definition {
-
-      key name;
+    container policy-definitions {
       description
-        "List of top-level policy definitions, keyed by unique
-        name.  These policy definitions are expected to be
-        referenced (by name) in policy chains specified in import/
-        export configuration statements.";
+        "Enclosing container for the list of top-level policy
+        definitions";
 
+      list policy-definition {
 
-      leaf name {
-        type string;
-        description
-            "Name of the top-level policy definition -- this name
-              is used in references to the current policy";
-      }
-
-
-      list statement {
         key name;
-        // TODO: names of policy statements within a policy defn
-        // should be optional, however, YANG requires a unique id
-        // for lists; not sure that a compound key works either;
-        // need to investigate further.
-        ordered-by user;
         description
-          "Policy statements group conditions and actions within
-          a policy definition.  They are evaluated in the order
-          specified (see the description of policy evaluation
-          at the top of this module.";
+          "List of top-level policy definitions, keyed by unique
+          name.  These policy definitions are expected to be
+          referenced (by name) in policy chains specified in import/
+          export configuration statements.";
+
 
         leaf name {
           type string;
-          description "name of the policy statement";
+          description
+              "Name of the top-level policy definition -- this name
+                is used in references to the current policy";
         }
 
-        container conditions {
-          presence "conditions";
-          description "Condition statements for this
-            policy statement";
+        container statements {
+          description
+            "Enclosing container for policy statements";
 
-          leaf call-policy {
-            type leafref {
-              path "/rpol:routing-policy/rpol:policy-definition/" +
-                  "rpol:name";
-              require-instance true;
-            }
+          list statement {
+            key name;
+            // TODO: names of policy statements within a policy defn
+            // should be optional, however, YANG requires a unique id
+            // for lists; not sure that a compound key works either;
+            // need to investigate further.
+            ordered-by user;
             description
-             "Applies the statements from the specified policy
-             definition and then returns control the current policy
-             statement.  Note that the called policy may itself call
-             other policies (subject to implementation limitations).
-             This is intended to provide a policy 'subroutine'
-             capability.  The called policy should contain an
-             explicit or a default route disposition that returns an
-             effective true (accept-route) or false (reject-route),
-             otherwise the behavior may be ambiguous and
-             implementation dependent";
+              "Policy statements group conditions and actions within
+              a policy definition.  They are evaluated in the order
+              specified (see the description of policy evaluation
+              at the top of this module.";
+
+            leaf name {
+              type string;
+              description "name of the policy statement";
+            }
+
+            container conditions {
+
+              description "Condition statements for this
+                policy statement";
+
+              leaf call-policy {
+                type leafref {
+                  path "/rpol:routing-policy/" +
+                    "rpol:policy-definitions/" +
+                    "rpol:policy-definition/rpol:name";
+                  //TODO: require-instance should be added when it's
+                  //supported in YANG 1.1
+                  //require-instance true;
+                }
+                description
+                  "Applies the statements from the specified policy
+                  definition and then returns control the current
+                  policy statement. Note that the called policy may
+                  itself call other policies (subject to
+                  implementation limitations). This is intended to
+                  provide a policy 'subroutine' capability.  The
+                  called policy should contain an explicit or a
+                  default route disposition that returns an effective
+                  true (accept-route) or false (reject-route),
+                  otherwise the behavior may be ambiguous and
+                  implementation dependent";
+              }
+              uses generic-conditions;
+              uses igp-conditions;
+            }
+
+            container actions {
+
+              description "Action statements for this policy
+                    statement";
+
+              uses generic-actions;
+              uses igp-actions;
+            }
           }
-          uses generic-conditions;
-          uses igp-conditions;
-        }
-
-        container actions {
-          presence "actions";
-          description "Action statements for this policy
-                statement";
-
-          uses generic-actions;
-          uses igp-actions;
         }
       }
     }
   }
 
+  grouping apply-policy-config {
+    description
+      "Configuration data for routing policies";
+
+    leaf-list import-policy {
+      type leafref {
+        path "/rpol:routing-policy/rpol:policy-definitions/" +
+          "rpol:policy-definition/rpol:name";
+        //TODO: require-instance should be added when it's
+        //supported in YANG 1.1
+        //require-instance true;
+      }
+      ordered-by user;
+      description
+        "list of policy names in sequence to be applied on
+        receiving a routing update in the current context, e.g.,
+        for the current peer group, neighbor, address family,
+        etc.";
+    }
+
+    leaf default-import-policy {
+      type default-policy-type;
+      default REJECT-ROUTE;
+      description
+        "explicitly set a default policy if no policy definition
+        in the import policy chain is satisfied.";
+    }
+
+    leaf-list export-policy {
+      type leafref {
+        path "/rpol:routing-policy/rpol:policy-definitions/" +
+          "rpol:policy-definition/rpol:name";
+        //TODO: require-instance should be added when it's
+        //supported in YANG 1.1
+        //require-instance true;
+      }
+      ordered-by user;
+      description
+        "list of policy names in sequence to be applied on
+        sending a routing update in the current context, e.g.,
+        for the current peer group, neighbor, address family,
+        etc.";
+    }
+
+    leaf default-export-policy {
+      type default-policy-type;
+      default REJECT-ROUTE;
+      description
+        "explicitly set a default policy if no policy definition
+        in the export policy chain is satisfied.";
+    }
+  }
+
+  grouping apply-policy-state {
+    description
+      "Operational state associated with routing policy";
+
+    //TODO: identify additional state data beyond the intended
+    //policy configuration.
+  }
+
   grouping apply-policy-group {
     description
-      "configuration for applying policies";
+      "Top level container for routing policy applications. This
+      grouping is intended to be used in routing models where
+      needed.";
 
     container apply-policy {
       description
-        "Anchor point for routing policies in the configuration.
+        "Anchor point for routing policies in the model.
         Import and export policies are with respect to the local
         routing table, i.e., export (send) and import (receive),
         depending on the context.";
 
-      leaf-list import-policies {
-        type leafref {
-          path "/rpol:routing-policy/rpol:policy-definition" +
-              "/rpol:name";
-          require-instance true;
-        }
-        ordered-by user;
+      container config {
         description
-          "list of policy names in sequence to be applied on
-          receiving a routing update in the current context, e.g.,
-          for the current peer group, neighbor, address family,
-          etc.";
+          "Policy configuration data.";
+
+        uses apply-policy-config;
       }
 
-      leaf default-import-policy {
-        type default-policy-type;
-        default REJECT-ROUTE;
-        description
-          "explicitly set a default policy if no policy definition
-          in the import policy chain is satisfied.";
-      }
+      container state {
 
-      leaf-list export-policies {
-        type leafref {
-          path "/rpol:routing-policy/rpol:policy-definition" +
-              "/rpol:name";
-          require-instance true;
-        }
-        ordered-by user;
+        config false;
         description
-          "list of policy names in sequence to be applied on
-          sending a routing update in the current context, e.g.,
-          for the current peer group, neighbor, address family,
-          etc.";
-      }
+          "Operational state for routing policy";
 
-      leaf default-export-policy {
-        type default-policy-type;
-        default REJECT-ROUTE;
-        description
-          "explicitly set a default policy if no policy definition
-          in the export policy chain is satisfied.";
+        uses apply-policy-config;
+        uses apply-policy-state;
       }
     }
   }


### PR DESCRIPTION
Request to merge the revision of the OpenConfig BGP and routing policy models with changes based on implementor and user feedback.

Please see the pyang validation output below.  Note we are using an ad-hoc namespace, hence the warnings.

```
pyang --ietf --strict bgp/bgp.yang policy/routing-policy.yang bgp/bgp-policy.yang -p bgp -p policy

bgp/bgp.yang:1: warning: IETF rule (RFC 6087: 4.1): no module name prefix used, suggest ietf-bgp
bgp/bgp.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:bgp"
bgp/bgp-policy.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:bgp-policy"
policy/routing-policy.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:routing-policy"
```

thank you!