### PR TITLE
Create directory for experimental ieee and add in ethernet.yang

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a collection of YANG modules:
 
   * IETF standards-track YANG modules
   * Open Daylight open source YANG modules
+  * IEEE experimental YANG modules
   * Vendor specific YANG modules
   * Open source YANG tools
 
@@ -16,6 +17,8 @@ Directory Structure
 The following directories are maintained [license note in brackets]:
 
   **yang/experimental**: contains experimental YANG modules [any]
+
+  **yang/experimental/ieee**: experimental modules intended for IEEE submission [3]
 
   **yang/experimental/ietf**: experimental modules intended for IETF submission [1]
 
@@ -37,13 +40,13 @@ The following directories are maintained [license note in brackets]:
 
   **yang/vendor**: contains vendor-specific YANG modules [any]
 
-  **yang/vendor/brocade** : Brocade YANG modules [3]
+  **yang/vendor/brocade** : Brocade YANG modules [4]
   
-  **yang/vendor/cisco** : Cisco YANG modules [3] 
+  **yang/vendor/cisco** : Cisco YANG modules [4] 
 
-  **yang/vendor/netconfcentral**: Netconf Central YANG modules [3]
+  **yang/vendor/netconfcentral**: Netconf Central YANG modules [4]
 
-  **yang/vendor/yumaworks**: YumaWorks YANG modules [3]
+  **yang/vendor/yumaworks**: YumaWorks YANG modules [4]
 
 ***
 
@@ -62,12 +65,19 @@ License Information
 
    * All files contained within this sub-directory are provided under the terms of the [Eclipse Public License](https://www.eclipse.org/legal/epl-v10.html):
 
+####[3]  **IEEE License**:
 
-####[3]  **Vendor Specific License**:
+   * All files contained within this sub-directory are considered to be intended as IEEE Contributions.
+   * All issues entered into the trouble ticket system for this directory are considered to be intended as IEEE Contributions.
+   * All pull requests submitted for this directory are considered to be intended as IEEE Contributions.
+   * All contributions to IEEE standards development (whether for an individual or entity standard) shall meet the requirements outlined in the [IEEE-SA Copyright Policy](https://standards.ieee.org/develop/policies/bylaws/sect6-7.html#7)
+   * Copyright release for YANG modules: Users may freely reproduce the YANG modules contained under /experimental/ieee/ so that they can be used for their intended purpose.
+
+####[4]  **Vendor Specific License**:
 
   * All files contained within this sub-directory are provided under the terms of a license specified by the vendor that owns the YANG modules.
 
-####[4] Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+####[5] Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 ***
 

--- a/experimental/ieee/8023/ethernet.yang
+++ b/experimental/ieee/8023/ethernet.yang
@@ -1,0 +1,367 @@
+module ethernet {
+  namespace "urn:ieee:params:xml:ns:yang:ethernet";
+  prefix eth;
+
+  import ietf-interfaces {
+    prefix if;
+  }
+
+  import iana-if-type {
+    prefix ianaift;
+  }
+
+  organization
+    "Cisco Systems, Inc.
+     Customer Service
+
+     Postal: 170 W Tasman Drive
+     San Jose, CA 95134
+
+     Tel: +1 1800 553-NETS
+     
+     E-mail: cs-yang@cisco.com";
+
+  contact
+    "Robert Wilton - rwilton@cisco.com";
+  
+  description
+    "This module contains YANG definitions for configuring 802.3
+     Ethernet Interfaces, with the hope that it forms the basis of a
+     standardized 802.3 Ethernet interface configuration YANG
+     model.";
+  
+  revision 2015-05-07 {
+    description
+      "Proposed, restructured to incorporate ideas from Mahesh that
+       have formed part of a previous proposal for a standardized
+       model.";
+    reference "IEEE 802.3 2012";
+  }
+  
+  identity eth-if-speed {
+    description "Representing the configured or negotiated speed of
+                 an Ethernet interface.  Definitions are only
+                 required for PHYs that can run at different speeds
+                 (e.g. BASE-T).";
+  }
+  identity eth-if-speed-10mb {
+    base eth-if-speed;
+    description "10 Mb/s";
+  }
+  identity eth-if-speed-100mb {
+    base eth-if-speed;
+    description "100 Mb/s";
+  }
+  identity eth-if-speed-1gb {
+    base eth-if-speed;
+    description "1 Gb/s";
+  }
+  identity eth-if-speed-10gb {
+    base eth-if-speed;
+    description "10 Gb/s";
+  }
+  identity eth-if-speed-40gb {
+    base eth-if-speed;
+    description "40 Gb/s";
+  }
+
+  typedef flow-control-settings {
+    description
+      "Enumerates the possible flow control settings that can be
+       used in explicit configuration, or when reporting the
+       operational state";
+    type enumeration {
+      enum "disabled" {
+        description 
+          "Flow-control disabled in both ingress and egress
+           directions. I.e. PAUSE frames are not transmitted and
+           PAUSE frames received on ingress are discarded without
+           processing";
+      }
+      enum "ingress-only" {
+        description
+         "Flow control is enabled in the ingress direction only.
+          I.e. PAUSE frames may be transmitted to reduce the ingress
+          traffic flow, but PAUSE frames received on ingress are
+          dicarded without reducing the egress traffic rate";
+      }
+      enum "egress-only" {
+        description
+          "Flow control is enabled in the egress direction only.
+           I.e. PAUSE frames are not transmitted, but PAUSE frames
+           received on ingress are processed to reduce the egress
+           traffic rate.";
+      }
+      enum "bi-directional" {
+        description
+         "Flow control is enabled in both ingress and egress
+          directions. I.e. PAUSE frames may be transmitted to reduce
+          the ingress traffic flow, and PAUSE frames received on
+          ingress are processed to reduce the egress traffic rate.";
+      }
+    }
+  }
+
+  augment "/if:interfaces/if:interface" {
+    when "if:type = 'ianaift:ethernetCsmacd'" {
+      description "Applies to all Ethernet interfaces";
+    }
+    description "Augment interface model with 803.2 Ethernet
+                 specific configuration nodes";
+
+    container ethernet {
+      description
+        "Contains all Ethernet interface related configuration";
+      choice transmission-mode {
+        description
+          "Indicates whether the transmission parameters are manually
+           configured or automatically negotiated with the peer
+           device";
+        case auto-negotiation {
+          description "Transmission parameters are automatically
+                       negotiated";
+          container auto-negotiation {
+            description
+              "Contains auto-negotiation transmission parameters";
+            reference "IEEE 802.3-2012 section 28 and annexes 28A-D";
+            
+            leaf status {
+              type enumeration {
+                enum "enabled" {
+                  description
+                    "Auto-negotiation function is enabled";
+                }
+                enum "disabled" {
+                  description
+                    "Auto-negotiation function is disabled";
+                }
+              }
+              
+              description
+                "Allows auto-negotiation to be explicitly
+                 enabled/disabled.  If the leaf is not present then
+                 the default behaviour is vendor/interface
+                 specific.";
+            }
+            
+            leaf duplex {
+              type enumeration {
+                enum "full" {
+                  description
+                    "Restricts auto-negotiation to advertising full
+                     duplex only.  Negotiation will fail, and the
+                     link will not come up, if the peer device only
+                     allows for half duplex during negotiation.";
+                }
+                enum "half" {
+                  description
+                    "Restricts auto-negotiation to advertising half
+                     duplex only.  Negotiation will fail, and the
+                     link will not come up, if the peer device only
+                     allows for full duplex during negotiation.";
+                }
+              }
+              description
+                "Allows the advertised duplex value in the
+                 negotiation to be restricted.  Half duplex can
+                 only be negotiated for some interface types - as
+                 specified in 802.3, annex section 28B.3.  If not
+                 specified then the default behaviour is to
+                 negotiate all available values for the particular
+                 type of Ethernet PHY associated with the
+                 interface.";
+            }
+            
+            leaf speed {
+              type identityref {
+                base eth-if-speed;
+              }
+              description
+                "Allows the advertised speed value in the negotiation
+                 to be restricted. Speed is only negotiated for some
+                 PHYs, many higher speed PHYs operate at a fixed
+                 speed.  If this leaf is not set then the default
+                 behaviour is to negotiate all available speeds,
+                 generally choosing the fastest speed as per 802.3
+                 Annex 28B.3.";
+              reference "IEEE 802.3-2012 Annex section 28B.3";
+            }
+            
+            leaf advertised-flow-control {
+              type enumeration {
+                enum "disabled" {
+                  description
+                    "Explicitly prevents ingress or egress
+                     flow-control from being negotiated with the peer
+                     device.";
+                  reference "IEEE 802.3-2012 Table 28B-2,
+                             Capability: No PAUSE";
+                  
+                }
+                enum "ingress-only" {
+                  description
+                    "Allows only ingress flow-control to be
+                     negotiated with the peer device";
+                  reference
+                    "IEEE 802.3-2012 Table 28B-2, Capability: 
+                     Asymmetric PAUSE towards link partner";
+                  
+                }
+                enum "bi-directional-only" {
+                  description
+                    "Allows only bi-directional flow-control to be
+                     negotiated with the peer device.";
+                  reference
+                    "IEEE 802.3-2012 Table 28B-2, Capability:
+                     Symmetric PAUSE";
+                }
+              }
+              description
+                "By default, the flow control capabilities that are
+                 negotiated allows for bi-directional or egress-only
+                 flow control to be negotiated (depending on the peer
+                 device capabilities/configuration).";
+              reference
+                "IEEE 802.3-2012 Table 28B-2, Capability:
+                 Both Symmetric PAUSE and Asymmetric PAUSE toward
+                 local device";
+            }
+            
+            leaf forced-flow-control {
+              type flow-control-settings;
+              description
+                "Explicitly force the local flow control settings
+                 regardless of what has been negotiated.  Since the
+                 auto-negotiation of flow-control settings doesn't
+                 allow all sane combinations to be negotiated (e.g.
+                 consider a device that is only capable of sending
+                 PAUSE frames connected to a peer device that is only
+                 capable of receiving and acting on PAUSE frames) and
+                 failing to agree on the flow-control settings
+                 doesn't cause the auto-negotation to fail
+                 completely, then it is sometimes useful to be able
+                 to explicitly enable particular flow control
+                 settings on the local device regardless of what is
+                 being advertised or negotiated";
+              reference
+                "IEEE 802.3-2012 Table 28B-3-Pause resolution";
+            }
+          }
+        }
+        
+        case manual {
+          description
+            "Transmission parameters are manually configured (as
+             required)";
+          container manual {
+            description
+              "Manually configured transmission parameters";
+            leaf duplex {
+              type enumeration {
+                enum "full" {
+                  description
+                    "Forces the interface to run in full duplex
+                     mode.";
+                  
+                }
+                enum "half" {
+                  description
+                    "Forces the interface to run in half duplex mode.
+                     Not applicable to many PHY types.";
+                }
+              }
+              default "full";
+              description "Configures the interface to run in either
+                           full or half duplex mode.";
+            }
+            
+            leaf speed {
+              type identityref {
+                base eth-if-speed;
+              }
+              description
+                "For PHY types that may operate at various speeds,
+                 this leaf allows the interface to be forced to
+                 operate at a particular speed.  Without any explicit
+                 configuration, Ethernet interfaces run at the
+                 maximum speed that they are capable of operating
+                 at";
+            }
+            
+            leaf flow-control {
+              type flow-control-settings;
+              description
+                "The default flow-control capabilities are
+                 vendor/interface specific";
+            }
+          }
+        }
+      }
+    }
+  }
+  
+  /*
+   * Operational State.
+   */
+  augment "/if:interfaces-state/if:interface" {
+    when "if:type = 'ianaift:ethernetCsmacd'" {
+      description "Applies to all Ethernet interfaces";
+    }
+    description "Augments interfaces-state model with 803.2 Ethernet
+                 specific operational state nodes";
+
+    container ethernet {
+      description
+        "Contains operational state for Ethernet interfaces";
+
+      container auto-negotiation {
+        presence "Indicates that auto-negotiation is enabled";
+        description "Contains auto-negotiation status";
+        
+        leaf status {
+          description
+            "The status of the auto-negotiation protocol";
+          type enumeration {
+            enum "successful" {
+              description
+                "Auto-negotation has completed successfully";
+            }
+            enum "failed" {
+              description "Auto-negotiation has failed";
+            }
+            enum "unknown" {
+              description
+                "The auto-negotiation status is not currently known,
+                 this may be because it is still negotiating or the
+                 protocol cannot run (e.g. if no medium is present)";
+            }
+          }
+        } 
+      }
+
+      leaf duplex {
+        description "Operational duplex setting of the interface";
+        type enumeration {
+          enum "full" {
+            description "Full duplex";
+          }
+          enum "half" {
+            description "Half duplex";
+          }
+        } 
+      }
+      
+      leaf speed {
+        description "Operational speed setting of the interface";
+        units "Mb/s";
+        type uint64;
+      }
+      
+      leaf flow-control {
+        description
+          "Operation flow-control setting on the interface"; 
+        type flow-control-settings;
+      }
+    }
+  }
+}

--- a/experimental/ieee/README
+++ b/experimental/ieee/README
@@ -1,0 +1,1 @@
+IEEE experimental drafts

--- a/experimental/ietf/README
+++ b/experimental/ietf/README
@@ -1,1 +1,1 @@
-IETF experiemntal drafts 
+IETF experimental drafts 


### PR DESCRIPTION
Adding experimental/ieee directory, adding IEEE license text agreed with 802.3 WG chair, adding ethernet.yang as a proposed ieee 802.3 YANG configuration draft.

MAC address configuration will come separately in an ethernet-like.yang draft as part on an IETF contribution since it applies to other interface types as well.

Thanks,
Rob