### PR TITLE
Description fix for leaf remote-address/remote-port.

### DIFF
--- a/experimental/openconfig/bgp/bgp-operational.yang
+++ b/experimental/openconfig/bgp/bgp-operational.yang
@@ -247,15 +247,15 @@ module bgp-operational {
     leaf remote-address {
       type inet:ip-address;
       description
-        "Remote port being used by the peer for the TCP session
-        supporting the BGP session";
+        "Remote address to which the BGP session has been
+        established";
     }
 
     leaf remote-port {
       type inet:port-number;
       description
-        "Remote address to which the BGP session has been
-        established";
+        "Remote port being used by the peer for the TCP session
+        supporting the BGP session";
     }
   }
 


### PR DESCRIPTION
This is small fix for description of leaf remote-address and remote-port.
The description was opposite.