### PR TITLE
Merge OpenConfig interfaces and terminal optics models

### DIFF
--- a/experimental/openconfig/interfaces/openconfig-if-aggregate.yang
+++ b/experimental/openconfig/interfaces/openconfig-if-aggregate.yang
@@ -1,0 +1,525 @@
+module openconfig-if-aggregate {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/interface/aggregate";
+
+  prefix "lag";
+
+  // import some basic types
+  import openconfig-interfaces { prefix ocif; }
+  import openconfig-if-ethernet { prefix eth; }
+  import ietf-yang-types { prefix yang; }
+  import iana-if-type { prefix ift; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Model for managing aggregated interfaces, including LACP-
+    managed aggregates";
+
+  revision "2015-01-23" {
+    description
+      "Initial revision";
+    reference "TBD";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  typedef lacp-activity-type {
+    type enumeration {
+      enum ACTIVE {
+        description
+          "Interface is an active member, i.e., will detect and
+          maintain aggregates";
+      }
+      enum PASSIVE {
+        description
+          "Interface is a passive member, i.e., it participates
+          with an active partner";
+      }
+    }
+    description
+      "Describes the LACP membership type, active or passive, of the
+      interface in the aggregate";
+    reference "IEEE 802.1AX-2008";
+  }
+
+  typedef lacp-timeout-type {
+    type enumeration {
+      enum LONG {
+        description
+          "Participant wishes to use long timeouts to detect
+          status of the aggregate, i.e., will expect less frequent
+          transmissions. Long timeout is 90 seconds.";
+      }
+      enum SHORT {
+        description
+          "Participant wishes to use short timeouts, i.e., expects
+          frequent transmissions to aggressively detect status
+          changes. Short timeout is 3 seconds.";
+      }
+    }
+    description
+      "Type of timeout used, short or long, by LACP participants";
+    reference "IEEE 802.1AX-2008";
+  }
+
+  typedef lacp-synchronization-type {
+    type enumeration {
+      enum IN_SYNC {
+        description
+          "Participant is in sync with the system id and key
+          transmitted";
+      }
+      enum OUT_SYNC {
+        description
+          "Participant is not in sync with the system id and key
+          transmitted";
+      }
+    }
+    description
+      "Indicates LACP synchronization state of participant";
+    reference "IEEE 802.1AX-2008";
+  }
+
+  typedef lacp-period-type {
+    type enumeration {
+      enum FAST {
+        description "Send LACP packets every second";
+      }
+      enum SLOW {
+        description "Send LACP packets every 30 seconds";
+      }
+    }
+    description
+      "Defines the period options for the time between sending
+      LACP messages";
+    reference "IEEE 802.3ad";
+  }
+
+  typedef aggregation-type {
+    type enumeration {
+      enum LACP {
+        description "LAG managed by LACP";
+      }
+      enum STATIC {
+        description "Statically configured bundle / LAG";
+      }
+    }
+    description
+      "Type to define the lag-type, i.e., how the LAG is
+      defined and managed";
+  }
+
+  // grouping statements
+
+  grouping aggregation-lacp-config {
+    description
+      "Configuration data for LACP aggregate interfaces";
+
+    leaf interval {
+      type lacp-period-type;
+      default SLOW;
+      description
+        "Set the period between LACP messages -- uses
+        the lacp-period-type enumeration.";
+    }
+
+    leaf lacp-mode {
+      type lacp-activity-type;
+      default ACTIVE;
+      description
+        "ACTIVE is to initiate the transmission of LACP packets.
+         PASSIVE is to wait for peer to initiate the transmission of
+         LACP packets.";
+        //TODO:some implementations configure the LACP mode on each
+        //member interface rather than on the LAG interface.  There
+        //may be use cases for this identified at a later time.
+    }
+
+    leaf system-id-mac {
+      type yang:mac-address;
+      description
+        "The MAC address portion of the node's System ID. This is
+        combined with the system priority to construct the 8-octet
+        system-id";
+    }
+
+    leaf system-priority {
+      type uint16;
+      description
+        "Sytem priority used by the node on this LAG interface.
+        Lower value is higher priority for determining which node
+        is the controlling system.";
+    }
+  }
+
+  grouping aggregation-lacp-state {
+    description
+      "Operational data for LACP aggregate interfaces";
+
+  }
+
+  grouping aggregation-lacp-top {
+    description
+      "Top level configuration and state variable containers for
+      LACP data";
+
+    container lacp {
+      presence
+        "Presence of the container enables LACP protocol on
+        the aggregate interface";
+
+      description
+        "Configuration for LACP protocol operation on the
+        aggregate interface";
+      // TODO: need to add more parameters and operational state
+      // container
+
+      container config {
+        description
+          "Configuration data for LACP";
+
+        uses aggregation-lacp-config;
+      }
+
+      container state {
+
+        config false;
+        description
+          "Operational state data for LACP";
+
+        uses aggregation-lacp-config;
+        uses aggregation-lacp-state;
+      }
+
+      uses aggregation-lacp-members-top;
+
+    }
+  }
+
+  grouping aggregation-lacp-members-config {
+    description
+      "Configuration data for lacp member interfaces";
+
+    //currently a placeholder -- the list of member interfaces
+    //and their status is considered opstate only
+  }
+
+  grouping aggregation-lacp-members-state {
+    description
+      "Operational status data for the member interfaces";
+
+    leaf interface {
+      type ocif:interface-ref;
+      description
+        "Interface member of the LACP aggregate";
+    }
+
+    leaf activity {
+      type lacp-activity-type;
+      description "Indicates participant is active or passive";
+    }
+
+    leaf timeout {
+      type lacp-timeout-type;
+      description
+        "The timeout type (short or long) used by the
+        participant";
+    }
+
+    leaf synchronization {
+      type lacp-synchronization-type;
+      description
+        "Indicates whether the participant is in-sync or
+        out-of-sync";
+    }
+
+    leaf aggregatable {
+      type boolean;
+      description
+        "A true value indicates that the participant will allow
+        the link to be used as part of the aggregate. A false
+        value indicates the link should be used as an individual
+        link";
+    }
+
+    leaf collecting {
+      type boolean;
+      description
+        "If true, the participant is collecting incoming frames
+        on the link, otherwise false";
+    }
+
+    leaf distributing {
+      type boolean;
+      description
+        "When true, the participant is distributing outgoing
+        frames; when false, distribution is disabled";
+    }
+
+    leaf system-id {
+      type yang:mac-address;
+      description
+        "MAC address that defines the local system ID for the
+        aggregate interface";
+    }
+
+    leaf oper-key {
+      type uint16;
+      description
+        "Current operational value of the key for the aggregate
+        interface";
+    }
+
+    leaf partner-id {
+      type yang:mac-address;
+      description
+        "MAC address representing the protocol partner's interface
+        system ID";
+    }
+
+    leaf partner-key {
+      type uint16;
+      description
+        "Operational value of the protocol partner's key";
+    }
+
+    // TODO: rjs: unclear whether this is required, it is referenced
+    //            elsewhere under the state container. The grouping
+    //            does not exist.
+    // added the new group below to provide LACP statistics.
+    // uses aggregation-lacp-statistic;
+  }
+
+grouping aggregation-lacp-members-statistics {
+    description
+      "LACP packet statistics for the member interfaces";
+
+    container counters {
+      description
+        "LACP protocol counters";
+
+      leaf lacp-in-pkts {
+        type yang:counter64;
+        description
+          "Number of LACPDUs received";
+      }
+
+      leaf lacp-out-pkts {
+        type yang:counter64;
+        description
+          "Number of LACPDUs transmitted";
+      }
+
+      leaf lacp-rx-errors {
+        type yang:counter64;
+        description
+          "Number of LACPDU receive packet errors";
+      }
+
+      leaf lacp-tx-errors {
+        type yang:counter64;
+        description
+          "Number of LACPDU transmit packet errors";
+      }
+
+      leaf lacp-unknown-errors {
+        type yang:counter64;
+        description
+          "Number of LACPDU unknown packet errors";
+      }
+
+      leaf lacp-errors {
+        type yang:counter64;
+        description
+          "Number of LACPDU illegal packet errors";
+      }
+    }
+  }
+
+  grouping aggregation-lacp-members-top {
+    description
+      "Top-level grouping for aggregate members list";
+
+    container members {
+      config false;
+      description
+        "Enclosing container for the list of members interfaces of
+        the aggregate. This list is considered operational state
+        only so is labeled config false and has no config container";
+
+      list member {
+        key  interface;
+        description
+          "List of member interfaces and their associated status for
+          a LACP-controlled aggregate interface.  Member list is not
+          configurable here -- each interface indicates items
+          its participation in the LAG.";
+
+        leaf interface {
+          type leafref {
+            path "../state/interface";
+          }
+          description
+            "Reference to aggregate member interface";
+        }
+
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for aggregate members";
+
+          uses aggregation-lacp-members-state;
+          uses aggregation-lacp-members-statistics;
+        }
+      }
+    }
+  }
+
+
+  grouping aggregation-logical-config {
+    description
+      "Configuration data for aggregate interfaces";
+
+
+    leaf lag-type {
+      type aggregation-type;
+      description
+        "Sets the type of LAG, i.e., how it is
+        configured / maintained";
+    }
+
+    leaf min-links {
+      type uint16;
+      description
+        "Specifies the mininum number of member
+        interfaces that must be active for the aggregate interface
+        to be available";
+    }
+
+  }
+
+  grouping ethernet-if-aggregation-config {
+    description
+      "Adds configuration items for Ethernet interfaces
+      belonging to a logical aggregate / LAG";
+
+    leaf aggregate-id {
+      type ocif:interface-ref;
+      must "ocif:type = 'ift:ieee8023adLag'" {
+        description "The referenced interface must be a
+        LAG interface.";
+      }
+      description
+        "Specify the logical aggregate interface to which
+        this interface belongs";
+    }
+  }
+
+  grouping aggregation-logical-top {
+    description "Top-level data definitions for LAGs";
+
+    container aggregation {
+
+      presence "Sets the interface to be a logical aggregate / LAG";
+      description
+        "Options for logical interfaces representing
+        aggregates";
+
+      container config {
+        description
+          "Configuration variables for logical aggregate /
+          LAG interfaces";
+
+        uses aggregation-logical-config;
+      }
+
+      container state {
+
+        config false;
+        description
+          "Operational state variables for logical
+          aggregate / LAG interfaces";
+
+        uses aggregation-logical-config;
+        //TODO: identity other state variable as the LAG level
+
+        leaf-list members {
+          //TODO: this should be active only for non-LACP LAGs,
+          //otherwise the LAG state has the list of members and
+          // their status
+          when "lag:lag-type = 'STATIC'" {
+            description
+              "The simple list of member interfaces is active
+              when the aggregate is statically configured";
+          }
+          type ocif:interface-ref;
+          description
+            "List of current member interfaces for the aggregate,
+            expressed as references to existing interfaces";
+        }
+      }
+
+      uses aggregation-lacp-top;
+    }
+  }
+
+
+  // data definition statements
+
+  // augment statements
+
+  augment "/ocif:interfaces/ocif:interface" {
+    when "ocif:type = 'ift:ieee8023adLag'" {
+      description "active when the interface is set to type LAG";
+    }
+    description "Adds LAG configuration to the interface module";
+
+    uses aggregation-logical-top;
+  }
+
+  augment "/ocif:interfaces/ocif:interface/eth:ethernet/" +
+    "eth:config" {
+    when "ocif:type = 'ift:ethernetCsmacd'" {
+      description "active when the interface is Ethernet";
+    }
+    description "Adds LAG settings to individual Ethernet
+    interfaces";
+
+    uses ethernet-if-aggregation-config;
+  }
+
+  augment "/ocif:interfaces/ocif:interface/eth:ethernet/" +
+    "eth:state" {
+    when "ocif:type = 'ift:ethernetCsmacd'" {
+      description "active when the interface is Ethernet";
+    }
+    description "Adds LAG settings to individual Ethernet
+    interfaces";
+
+    uses ethernet-if-aggregation-config;
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/experimental/openconfig/interfaces/openconfig-if-ethernet.yang
+++ b/experimental/openconfig/interfaces/openconfig-if-ethernet.yang
@@ -1,0 +1,293 @@
+module openconfig-if-ethernet {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/interfaces/ethernet";
+
+  prefix "eth";
+
+  // import some basic types
+  import openconfig-interfaces { prefix ocif; }
+  import iana-if-type { prefix ift; }
+  import ietf-yang-types { prefix yang; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Model for managing Ethernet interfaces -- augments the IETF YANG
+    model for interfaces described by RFC 7223";
+
+  revision "2015-01-23" {
+    description
+      "Initial revision";
+    reference "TBD";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  identity ethernet-speed {
+    description "base type to specify available Ethernet link
+    speeds";
+  }
+
+  identity SPEED_10Mb {
+    base ethernet-speed;
+    description "10 Mbps Ethernet";
+  }
+
+  identity SPEED_100Mb {
+    base ethernet-speed;
+    description "100 Mbps Ethernet";
+  }
+
+  identity SPEED_1Gb {
+    base ethernet-speed;
+    description "1 Gbps Ethernet";
+  }
+
+  identity SPEED_10Gb {
+    base ethernet-speed;
+    description "10 Gbps Ethernet";
+  }
+
+  identity SPEED_25Gb {
+    base ethernet-speed;
+    description "25 Gbps Ethernet";
+  }
+
+  identity SPEED_40Gb {
+    base ethernet-speed;
+    description "40 Gbps Ethernet";
+  }
+
+  identity SPEED_50Gb {
+    base ethernet-speed;
+    description "50 Gbps Ethernet";
+  }
+
+  identity SPEED_100Gb {
+    base ethernet-speed;
+    description "100 Gbps Ethernet";
+  }
+
+  identity SPEED_UNKNOWN {
+    base ethernet-speed;
+    description
+      "Interface speed is unknown.  Systems may report
+      speed UNKNOWN when an interface is down or unpopuplated (e.g.,
+      pluggable not present).";
+  }
+
+  // typedef statements
+
+
+  // grouping statements
+
+  grouping ethernet-interface-config {
+    description "Configuration items for Ethernet interfaces";
+
+    leaf mac-address {
+      type yang:mac-address;
+      description
+        "Assigns a MAC address to the Ethernet interface.  If not
+        specified, the corresponding operational state leaf is
+        expected to show the system-assigned MAC address.";
+    }
+
+    leaf duplex-mode {
+      type enumeration {
+        enum AUTO {
+          description "Auto-negotiated duplex mode";
+        }
+        enum FULL {
+          description "Full duplex mode";
+        }
+        enum HALF {
+          description "Half duplex mode";
+        }
+      }
+      default AUTO;
+      description "Set the duplex mode of the interface to full-
+      or half-duplex operation.";
+    }
+
+    choice port-speed {
+      description "Port speed can either be auto-negotiated or set
+      explicitly";
+      case auto {
+        leaf auto {
+          type empty;
+          description "Set the link speed to auto-negotiate";
+        }
+      }
+      case manual {
+        leaf speed {
+          type identityref {
+            base ethernet-speed;
+          }
+          description "Set the link speed to a fixed value --
+          supported values are defined by ethernet-speed
+          identities";
+        }
+      }
+    }
+
+    leaf enable-flow-control {
+      type boolean;
+      default false;
+      description
+        "Enable or disable flow control for this interface.
+        Ethernet flow control is a mechanism by which a receiver
+        may send PAUSE frames to a sender to stop transmission for
+        a specified time.";
+      reference
+        "IEEE 802.3x";
+    }
+  }
+
+  grouping ethernet-interface-state-counters {
+    description
+      "Ethernet-specific counters and statistics";
+
+    // ingress counters
+
+    leaf in-mac-control-frames {
+      type yang:counter64;
+      description
+        "MAC layer control frames received on the interface";
+    }
+
+    leaf in-mac-pause-frames {
+      type yang:counter64;
+      description
+        "MAC layer PAUSE frames received on the interface";
+    }
+
+    leaf in-oversize-frames {
+      type yang:counter64;
+      description
+        "Number of oversize frames received on the interface";
+    }
+
+    leaf in-jabber-frames {
+      type yang:counter64;
+      description
+        "Number of jabber frames received on the
+        interface.  Jabber frames are typically defined as oversize
+        frames which also have a bad CRC.  Implementations may use
+        slightly different definitions of what constitutes a jabber
+        frame.  Often indicative of a NIC hardware problem.";
+    }
+
+    leaf in-fragment-frames {
+      type yang:counter64;
+      description
+        "Number of fragment frames received on the interface.";
+    }
+
+    leaf in-8021q-frames {
+      type yang:counter64;
+      description
+        "Number of 802.1q tagged frames received on the interface";
+    }
+
+    leaf in-crc-errors {
+      type yang:counter64;
+      description
+        "Number of receive error events due to FCS/CRC check
+        failure";
+    }
+
+    // egress counters
+
+    leaf out-mac-control-frames {
+      type yang:counter64;
+      description
+        "MAC layer control frames sent on the interface";
+    }
+
+    leaf out-mac-pause-frames {
+      type yang:counter64;
+      description
+        "MAC layer PAUSE frames sent on the interface";
+    }
+
+    leaf out-8021q-frames {
+      type yang:counter64;
+      description
+        "Number of 802.1q tagged frames sent on the interface";
+    }
+  }
+
+  grouping ethernet-interface-state {
+    description
+      "Grouping for defining Ethernet-specific operational state";
+
+    container counters {
+      description "Ethernet interface counters";
+
+      uses ethernet-interface-state-counters;
+
+    }
+
+  }
+
+  // data definition statements
+
+  grouping ethernet-top {
+    description "top-level Ethernet config and state containers";
+
+    container ethernet {
+      description
+        "Top-level container for ethernet configuration
+        and state";
+
+      container config {
+        description "Configuration data for ethernet interfaces";
+
+        uses ethernet-interface-config;
+
+      }
+
+      container state {
+
+        config false;
+        description "State variables for Ethernet interfaces";
+
+        uses ethernet-interface-config;
+        uses ethernet-interface-state;
+
+      }
+
+    }
+  }
+
+  // augment statements
+
+  augment "/ocif:interfaces/ocif:interface" {
+    when "ocif:type = 'ift:ethernetCsmacd'" {
+      description "Additional interface configuration parameters when
+      the interface type is Ethernet";
+    }
+    description "Adds addtional Ethernet-specific configuration to
+    interfaces model";
+
+    uses ethernet-top;
+  }
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/experimental/openconfig/interfaces/openconfig-if-ip.yang
+++ b/experimental/openconfig/interfaces/openconfig-if-ip.yang
@@ -1,0 +1,1070 @@
+module openconfig-if-ip {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/interfaces/ip";
+
+  prefix "ocip";
+
+  // import some basic types
+  import ietf-inet-types { prefix inet; }
+  import openconfig-interfaces { prefix ocif; }
+  import openconfig-vlan { prefix vlan; }
+  import ietf-yang-types { prefix yang; }
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Model for managing IP interfaces.
+
+    This model reuses most of the IETF YANG model for IP management
+    described by RFC 7277.  The primary differences are in the
+    structure of configuration and state data.";
+
+  revision "2015-01-23" {
+    description
+      "Initial revision";
+    reference "TBD";
+  }
+
+  // extension statements
+
+  // feature statements
+
+ feature ipv6-privacy-autoconf {
+    description
+      "Indicates support for Privacy Extensions for Stateless Address
+      Autoconfiguration in IPv6.";
+    reference
+      "RFC 4941: Privacy Extensions for Stateless Address
+                Autoconfiguration in IPv6
+      RFC 7277 - A YANG Data Model for IP Management";
+ }
+
+  // identity statements
+
+  // typedef statements
+
+  typedef ip-address-origin {
+    type enumeration {
+      enum OTHER {
+        description
+          "None of the following.";
+        }
+      enum STATIC {
+        description
+          "Indicates that the address has been statically
+          configured - for example, using NETCONF or a Command Line
+          Interface.";
+      }
+      enum DHCP {
+        description
+          "Indicates an address that has been assigned to this
+          system by a DHCP server.";
+      }
+      enum LINK_LAYER {
+        description
+          "Indicates an address created by IPv6 stateless
+          autoconfiguration that embeds a link-layer address in its
+          interface identifier.";
+      }
+      enum RANDOM {
+        description
+          "[adapted from RFC 7277]
+
+          Indicates an address chosen by the system at
+
+          random, e.g., an IPv4 address within 169.254/16, an
+          RFC 4941 temporary address, or an RFC 7217 semantically
+          opaque address.";
+        reference
+          "RFC 4941: Privacy Extensions for Stateless Address
+                    Autoconfiguration in IPv6
+          RFC 7217: A Method for Generating Semantically Opaque
+                    Interface Identifiers with IPv6 Stateless
+                    Address Autoconfiguration (SLAAC)";
+      }
+    }
+    description
+     "The origin of an address.";
+  }
+
+  typedef neighbor-origin {
+    type enumeration {
+      enum OTHER {
+       description
+         "None of the following.";
+      }
+      enum STATIC {
+       description
+         "Indicates that the mapping has been statically
+          configured - for example, using NETCONF or a Command Line
+          Interface.";
+      }
+      enum DYNAMIC {
+       description
+        "[adapted from RFC 7277]
+
+        Indicates that the mapping has been dynamically resolved
+        using, e.g., IPv4 ARP or the IPv6 Neighbor Discovery
+        protocol.";
+      }
+    }
+    description
+      "The origin of a neighbor entry.";
+  }
+
+  // grouping statements
+
+  grouping ipv4-config-global {
+    description "Configuration data for IPv4 interfaces across
+    all addresses assigned to the interface";
+    reference "RFC 7277 - A YANG Data Model for IP Management";
+
+    leaf enabled {
+     type boolean;
+     default true;
+     description
+       "Controls whether IPv4 is enabled or disabled on this
+        interface.  When IPv4 is enabled, this interface is
+        connected to an IPv4 stack, and the interface can send
+        and receive IPv4 packets.";
+    }
+
+    leaf mtu {
+     type uint16 {
+       range "68..max";
+     }
+     units octets;
+     description
+       "The size, in octets, of the largest IPv4 packet that the
+        interface will send and receive.
+
+        The server may restrict the allowed values for this leaf,
+        depending on the interface's type.
+
+        If this leaf is not configured, the operationally used MTU
+        depends on the interface's type.";
+     reference
+       "RFC 791: Internet Protocol";
+    }
+
+  }
+
+  grouping ipv4-config-address {
+
+    description
+      "Per IPv4 adresss configuration data for the
+      interface.";
+
+    leaf ip {
+       type inet:ipv4-address-no-zone;
+       description
+        "[adapted from IETF IP model RFC 7277]
+
+        The IPv4 address on the interface.";
+    }
+
+    leaf prefix-length {
+      type uint8 {
+       range "0..32";
+      }
+      description
+       "[adapted from IETF IP model RFC 7277]
+
+       The length of the subnet prefix.";
+    }
+  }
+
+  grouping ipv4-config-neighbor {
+    description
+      "[adapted from IETF IP model RFC 7277]
+
+      Per IPv4 neighbor configuration data. Neighbor
+      entries are analagous to static ARP entries, i.e., they
+      create a correspondence between IP and link-layer addresses";
+
+    leaf ip {
+     type inet:ipv4-address-no-zone;
+     description
+       "The IPv4 address of the neighbor node.";
+    }
+    leaf link-layer-address {
+     type yang:phys-address;
+     mandatory true;
+     description
+       "The link-layer address of the neighbor node.";
+    }
+  }
+
+  grouping ipv4-state-address {
+    description
+      "State variables for IPv4 addresses on the interface";
+
+    leaf origin {
+      type ip-address-origin;
+      description
+       "The origin of this address, e.g., statically configured,
+       assigned by DHCP, etc..";
+    }
+  }
+
+  grouping ipv4-state-neighbor {
+    description
+      "State variables for IPv4 neighbor entries on the interface.";
+
+    leaf origin {
+      type neighbor-origin;
+      description
+        "The origin of this neighbor entry, static or dynamic.";
+    }
+  }
+
+  grouping ipv6-config-global {
+    description
+      "Configuration data at the global level for each
+      IPv6 interface";
+
+    leaf enabled {
+      type boolean;
+      default true;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        Controls whether IPv6 is enabled or disabled on this
+        interface.  When IPv6 is enabled, this interface is
+        connected to an IPv6 stack, and the interface can send
+        and receive IPv6 packets.";
+    }
+
+    leaf mtu {
+      type uint32 {
+       range "1280..max";
+      }
+      units octets;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The size, in octets, of the largest IPv6 packet that the
+        interface will send and receive.
+
+        The server may restrict the allowed values for this leaf,
+        depending on the interface's type.
+
+        If this leaf is not configured, the operationally used MTU
+        depends on the interface's type.";
+      reference
+        "RFC 2460: Internet Protocol, Version 6 (IPv6) Specification
+                  Section 5";
+    }
+
+    leaf dup-addr-detect-transmits {
+      type uint32;
+      default 1;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The number of consecutive Neighbor Solicitation messages
+        sent while performing Duplicate Address Detection on a
+        tentative address.  A value of zero indicates that
+        Duplicate Address Detection is not performed on
+        tentative addresses.  A value of one indicates a single
+        transmission with no follow-up retransmissions.";
+      reference
+        "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+    }
+
+    container autoconf {
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        Parameters to control the autoconfiguration of IPv6
+        addresses, as described in RFC 4862.";
+      reference
+        "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+
+      leaf create-global-addresses {
+        type boolean;
+        default true;
+        description
+          "[adapted from IETF IP model RFC 7277]
+
+          If enabled, the host creates global addresses as
+          described in RFC 4862.";
+        reference
+          "RFC 4862: IPv6 Stateless Address Autoconfiguration
+                    Section 5.5";
+      }
+      leaf create-temporary-addresses {
+        if-feature ipv6-privacy-autoconf;
+        type boolean;
+        default false;
+        description
+        "[adapted from IETF IP model RFC 7277]
+
+        If enabled, the host creates temporary addresses as
+        described in RFC 4941.";
+        reference
+          "RFC 4941: Privacy Extensions for Stateless Address
+                    Autoconfiguration in IPv6";
+      }
+
+      leaf temporary-valid-lifetime {
+        if-feature ipv6-privacy-autoconf;
+        type uint32;
+        units "seconds";
+        default 604800;
+        description
+          "[adapted from IETF IP model RFC 7277]
+
+          The time period during which the temporary address
+          is valid.";
+        reference
+          "RFC 4941: Privacy Extensions for Stateless Address
+                    Autoconfiguration in IPv6
+                    - TEMP_VALID_LIFETIME";
+      }
+      leaf temporary-preferred-lifetime {
+        if-feature ipv6-privacy-autoconf;
+        type uint32;
+        units "seconds";
+        default 86400;
+        description
+          "[adapted from IETF IP model RFC 7277]
+
+          The time period during which the temporary address is
+          preferred.";
+        reference
+          "RFC 4941: Privacy Extensions for Stateless Address
+                    Autoconfiguration in IPv6
+                    - TEMP_PREFERRED_LIFETIME";
+      }
+    }
+  }
+
+  grouping ipv6-config-address {
+    description "Per-address configuration data for IPv6 interfaces";
+
+    leaf ip {
+      type inet:ipv6-address-no-zone;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The IPv6 address on the interface.";
+    }
+
+    leaf prefix-length {
+      type uint8 {
+        range "0..128";
+      }
+      mandatory true;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The length of the subnet prefix.";
+    }
+  }
+
+  grouping ipv6-state-address {
+    description
+      "Per-address operational state data for IPv6 interfaces";
+
+    leaf origin {
+      type ip-address-origin;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The origin of this address, e.g., static, dhcp, etc.";
+    }
+
+    leaf status {
+      type enumeration {
+        enum PREFERRED {
+          description
+            "This is a valid address that can appear as the
+            destination or source address of a packet.";
+        }
+        enum DEPRECATED {
+          description
+            "This is a valid but deprecated address that should
+            no longer be used as a source address in new
+            communications, but packets addressed to such an
+            address are processed as expected.";
+        }
+        enum INVALID {
+          description
+            "This isn't a valid address, and it shouldn't appear
+            as the destination or source address of a packet.";
+        }
+        enum INACCESSIBLE {
+          description
+            "The address is not accessible because the interface
+            to which this address is assigned is not
+            operational.";
+        }
+        enum UNKNOWN {
+          description
+            "The status cannot be determined for some reason.";
+        }
+        enum TENTATIVE {
+          description
+            "The uniqueness of the address on the link is being
+            verified.  Addresses in this state should not be
+            used for general communication and should only be
+            used to determine the uniqueness of the address.";
+        }
+        enum DUPLICATE {
+          description
+           "The address has been determined to be non-unique on
+            the link and so must not be used.";
+        }
+        enum OPTIMISTIC {
+          description
+            "The address is available for use, subject to
+            restrictions, while its uniqueness on a link is
+            being verified.";
+        }
+      }
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The status of an address.  Most of the states correspond
+        to states from the IPv6 Stateless Address
+        Autoconfiguration protocol.";
+      reference
+          "RFC 4293: Management Information Base for the
+                      Internet Protocol (IP)
+                      - IpAddressStatusTC
+            RFC 4862: IPv6 Stateless Address Autoconfiguration";
+    }
+  }
+
+  grouping ipv6-config-neighbor {
+    description
+      "Per-neighbor configuration data for IPv6 interfaces";
+
+    leaf ip {
+      type inet:ipv6-address-no-zone;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The IPv6 address of the neighbor node.";
+    }
+
+    leaf link-layer-address {
+      type yang:phys-address;
+      mandatory true;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The link-layer address of the neighbor node.";
+    }
+  }
+
+  grouping ipv6-state-neighbor {
+    description "Per-neighbor state variables for IPv6 interfaces";
+
+    leaf origin {
+      type neighbor-origin;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The origin of this neighbor entry.";
+    }
+    leaf is-router {
+      type empty;
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        Indicates that the neighbor node acts as a router.";
+    }
+    leaf neighbor-state {
+      type enumeration {
+        enum INCOMPLETE {
+          description
+          "Address resolution is in progress, and the link-layer
+                address of the neighbor has not yet been
+                determined.";
+        }
+        enum REACHABLE {
+          description
+          "Roughly speaking, the neighbor is known to have been
+                reachable recently (within tens of seconds ago).";
+        }
+        enum STALE {
+          description
+          "The neighbor is no longer known to be reachable, but
+                until traffic is sent to the neighbor no attempt
+                should be made to verify its reachability.";
+        }
+        enum DELAY {
+          description
+          "The neighbor is no longer known to be reachable, and
+                traffic has recently been sent to the neighbor.
+                Rather than probe the neighbor immediately, however,
+                delay sending probes for a short while in order to
+                give upper-layer protocols a chance to provide
+                reachability confirmation.";
+        }
+        enum PROBE {
+          description
+          "The neighbor is no longer known to be reachable, and
+                unicast Neighbor Solicitation probes are being sent
+                to verify reachability.";
+        }
+      }
+      description
+        "[adapted from IETF IP model RFC 7277]
+
+        The Neighbor Unreachability Detection state of this
+        entry.";
+      reference
+        "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+             Section 7.3.2";
+    }
+  }
+
+  grouping ip-vrrp-ipv6-config {
+    description
+      "IPv6-specific configuration data for VRRP on IPv6
+      interfaces";
+
+      leaf virtual-link-local {
+        type inet:ip-address;
+        description
+          "For VRRP on IPv6 interfaces, sets the virtual link local
+          address";
+      }
+  }
+
+  grouping ip-vrrp-ipv6-state {
+    description
+      "IPv6-specific operational state for VRRP on IPv6 interfaces";
+
+    uses ip-vrrp-ipv6-config;
+  }
+
+  grouping ip-vrrp-tracking-config {
+    description
+      "Configuration data for tracking interfaces
+      in a VRRP group";
+
+    leaf track-interface {
+      type leafref {
+        path "/ocif:interfaces/ocif:interface/ocif:name";
+        require-instance true;
+      }
+      // TODO: we may need to add some restriction to ethernet
+      // or IP interfaces.
+      description "Sets an interface that should be
+      tracked for up/down events to dynamically change the
+      priority state of the VRRP group, and potentially
+      change the mastership if the tracked interface going
+      down lowers the priority sufficiently";
+    }
+
+    leaf priority-decrement {
+      type uint8 {
+        range 0..254;
+      }
+      default 0;
+      description "Set the value to subtract from priority when
+      the tracked interface goes down";
+    }
+  }
+
+  grouping ip-vrrp-tracking-state {
+    description
+      "Operational state data for tracking interfaces in a VRRP
+      group";
+  }
+
+  grouping ip-vrrp-tracking-top {
+    description
+      "Top-level grouping for VRRP interface tracking";
+
+    container interface-tracking {
+      description
+        "Top-level container for VRRP interface tracking";
+
+      container config {
+        description
+          "Configuration data for VRRP interface tracking";
+
+        uses ip-vrrp-tracking-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for VRRP interface tracking";
+
+        uses ip-vrrp-tracking-config;
+        uses ip-vrrp-tracking-state;
+      }
+    }
+  }
+
+  grouping ip-vrrp-config {
+    description
+      "Configuration data for VRRP on IP interfaces";
+
+    leaf virtual-router-id {
+      type uint8 {
+        range 1..255;
+      }
+      description
+        "Set the virtual router id for use by the VRRP group.  This
+        usually also determines the virtual MAC address that is
+        generated for the VRRP group";
+    }
+
+    leaf-list virtual-address {
+      type inet:ip-address;
+      description "Configure one or more virtual addresses for the
+      VRRP group";
+    }
+
+    leaf priority {
+      type uint8 {
+        range 1..254;
+      }
+      default 100;
+      description "Specifies the sending VRRP interface's priority
+      for the virtual router.  Higher values equal higher
+      priority";
+    }
+
+    leaf preempt {
+      type boolean;
+      default true;
+      description "When set to true, enables preemption by a higher
+      priority backup router of a lower priority master router";
+    }
+
+    leaf preempt-delay {
+      type uint16 {
+        range 0..3600;
+      }
+      default 0;
+      description "Set the delay the higher priority router waits
+      before preempting";
+    }
+
+    leaf accept_mode {
+      type boolean;
+      // TODO: should we adopt the RFC default given the common
+      // operational practive of setting to true?
+      default false;
+      description "Configure whether packets destined for
+      virtual addresses are accepted even when the virtual
+      address is not owned by the router interface";
+    }
+
+    leaf advertisement-interval {
+      type uint16 {
+        range 1..4095;
+      }
+      // TODO this range is theoretical -- needs to be validated
+      // against major implementations.
+      units "centiseconds";
+      default 100;
+      description "Sets the interval between successive VRRP
+      advertisements -- RFC 5798 defines this as a 12-bit
+      value expressed as 0.1 seconds, with default 100, i.e.,
+      1 second.  Several implementation express this in units of
+      seconds";
+    }
+  }
+
+  grouping ip-vrrp-state {
+    description
+      "Operational state data for VRRP on IP interfaces";
+
+    leaf current-priority {
+      type uint8;
+      description "Operational value of the priority for the
+      interface in the VRRP group";
+    }
+  }
+
+  grouping ip-vrrp-top {
+    description
+      "Top-level grouping for Virtual Router Redundancy Protocol";
+
+    container vrrp {
+      description
+        "Enclosing container for VRRP groups handled by this
+        IP interface";
+
+      reference "RFC 5798 - Virtual Router Redundancy Protocol
+        (VRRP) Version 3 for IPv4 and IPv6";
+
+      list vrrp-group {
+        key virtual-router-id;
+        description
+          "List of VRRP groups, keyed by virtual router id";
+
+        leaf virtual-router-id {
+          type leafref {
+            path "../config/virtual-router-id";
+          }
+          description
+            "References the configured virtual router id for this
+            VRRP group";
+        }
+
+        container config {
+          description
+            "Configuration data for the VRRP group";
+
+          uses ip-vrrp-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for the VRRP group";
+
+          uses ip-vrrp-config;
+          uses ip-vrrp-state;
+        }
+
+        uses ip-vrrp-tracking-top;
+      }
+    }
+  }
+
+  grouping ipv4-top {
+    description "Top-level configuration and state for IPv4
+    interfaces";
+
+    container ipv4 {
+      presence
+       "Enables IPv4 unless the 'enabled' leaf
+        (which defaults to 'true') is set to 'false'";
+      description
+       "Parameters for the IPv4 address family.";
+
+      list address {
+        key ip;
+        description
+         "The list of configured IPv4 addresses on the interface.";
+
+        leaf ip {
+          type leafref {
+            path "../ocip:config/ocip:ip";
+          }
+          description "References the configured IP address";
+        }
+
+        container config {
+          description "Configuration data for each configured IPv4
+          address on the interface";
+
+          uses ipv4-config-address;
+
+        }
+
+        container state {
+
+          config false;
+          description "Operational state data for each IPv4 address
+          configured on the interface";
+
+          uses ipv4-config-address;
+          uses ipv4-state-address;
+        }
+
+      }
+
+      list neighbor {
+        key "ip";
+        description
+         "A list of mappings from IPv4 addresses to
+          link-layer addresses.
+
+          Entries in this list are used as static entries in the
+          ARP Cache.";
+        reference
+         "RFC 826: An Ethernet Address Resolution Protocol";
+
+        leaf ip {
+          type leafref  {
+            path "../ocip:config/ocip:ip";
+          }
+          description "References the configured IP address";
+        }
+
+        container config {
+          description "Configuration data for each configured IPv4
+          address on the interface";
+
+          uses ipv4-config-neighbor;
+
+        }
+
+        container state {
+
+          config false;
+          description "Operational state data for each IPv4 address
+          configured on the interface";
+
+          uses ipv4-config-neighbor;
+          uses ipv4-state-neighbor;
+        }
+      }
+
+      container config {
+        description
+          "Top-level IPv4 configuration data for the interface";
+
+        uses ipv4-config-global;
+      }
+
+      container state {
+
+        config false;
+        description
+          "Top level IPv4 operational state data";
+
+        uses ipv4-config-global;
+      }
+    }
+  }
+
+  grouping ipv6-top {
+    description "Top-level configuration and state for IPv6
+    interfaces";
+
+    container ipv6 {
+      presence
+       "Enables IPv6 unless the 'enabled' leaf
+        (which defaults to 'true') is set to 'false'";
+      description
+       "Parameters for the IPv6 address family.";
+
+      list address {
+        key "ip";
+        description
+         "The list of configured IPv6 addresses on the interface.";
+
+        leaf ip {
+          type leafref {
+            path "../ocip:config/ocip:ip";
+          }
+          description "References the configured IP address";
+        }
+
+        container config {
+          description
+            "Configuration data for each IPv6 address on
+            the interface";
+
+          uses ipv6-config-address;
+
+        }
+
+        container state {
+
+          config false;
+          description
+            "State data for each IPv6 address on the
+            interface";
+
+          uses ipv6-config-address;
+          uses ipv6-state-address;
+        }
+      }
+
+      list neighbor {
+        key "ip";
+        description
+          "A list of mappings from IPv6 addresses to
+          link-layer addresses.
+
+          Entries in this list are used as static entries in the
+          Neighbor Cache.";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
+
+        leaf ip {
+          type leafref {
+            path "../ocip:config/ocip:ip";
+          }
+          description
+            "References the configured IP neighbor address";
+        }
+
+        container config {
+          description "Configuration data for each IPv6 address on
+          the interface";
+
+          uses ipv6-config-neighbor;
+
+        }
+
+        container state {
+
+          config false;
+          description "State data for each IPv6 address on the
+          interface";
+
+          uses ipv6-config-neighbor;
+          uses ipv6-state-neighbor;
+        }
+
+      }
+
+      container config {
+        description "Top-level config data for the IPv6 interface";
+
+        uses ipv6-config-global;
+      }
+
+      container state {
+
+        config false;
+        description
+          "Top-level operational state data for the IPv6 interface";
+
+        uses ipv6-config-global;
+
+      }
+    }
+  }
+
+  // augment statements
+
+  augment "/ocif:interfaces/ocif:interface/ocif:subinterfaces/" +
+    "ocif:subinterface" {
+    description
+      "IPv4 addr family configuration for
+      interfaces";
+
+    uses ipv4-top;
+
+  }
+
+  augment "/ocif:interfaces/ocif:interface/ocif:subinterfaces/" +
+    "ocif:subinterface" {
+    description
+      "IPv6 addr family configuration for
+      interfaces";
+
+    uses ipv6-top;
+
+  }
+
+  // VRRP for IPv4 interfaces
+
+  augment "/ocif:interfaces/ocif:interface/ocif:subinterfaces/" +
+    "ocif:subinterface/ocip:ipv4/ocip:address" {
+    description
+      "Additional IP addr family configuration for
+      interfaces";
+
+    uses ip-vrrp-top;
+
+  }
+
+  // VRRP for IPv6 interfaces
+  augment "/ocif:interfaces/ocif:interface/ocif:subinterfaces/" +
+    "ocif:subinterface/ocip:ipv6/ocip:address" {
+     description
+      "Additional IP addr family configuration for
+      interfaces";
+
+    uses ip-vrrp-top;
+
+  }
+
+  augment "/ocif:interfaces/ocif:interface/ocif:subinterfaces/" +
+    "ocif:subinterface/ocip:ipv6/ocip:address/vrrp/vrrp-group/" +
+    "config" {
+      description
+        "Additional VRRP data for IPv6 interfaces";
+
+    uses ip-vrrp-ipv6-config;
+  }
+
+  augment "/ocif:interfaces/ocif:interface/ocif:subinterfaces/" +
+  "ocif:subinterface/ocip:ipv6/ocip:address/vrrp/vrrp-group/state" {
+      description
+        "Additional VRRP data for IPv6 interfaces";
+
+    uses ip-vrrp-ipv6-state;
+  }
+
+  // Augments for for routed VLANs
+
+  augment "/ocif:interfaces/ocif:interface/vlan:routed-vlan" {
+    description
+      "IPv4 addr family configuration for
+      interfaces";
+
+    uses ipv4-top;
+
+  }
+
+  augment "/ocif:interfaces/ocif:interface/vlan:routed-vlan" {
+    description
+      "IPv6 addr family configuration for
+      interfaces";
+
+    uses ipv6-top;
+
+  }
+
+  // VRRP for routed VLAN interfaces
+
+  augment "/ocif:interfaces/ocif:interface/vlan:routed-vlan/" +
+    "ocip:ipv4/ocip:address" {
+    description
+      "Additional IP addr family configuration for
+      interfaces";
+
+    uses ip-vrrp-top;
+
+  }
+
+  augment "/ocif:interfaces/ocif:interface/vlan:routed-vlan/" +
+    "ocip:ipv6/ocip:address" {
+     description
+      "Additional IP addr family configuration for
+      interfaces";
+
+    uses ip-vrrp-top;
+
+  }
+
+  augment "/ocif:interfaces/ocif:interface/vlan:routed-vlan/" +
+    "ocip:ipv6/ocip:address/vrrp/vrrp-group/config" {
+      description
+        "Additional VRRP data for IPv6 interfaces";
+
+    uses ip-vrrp-ipv6-config;
+  }
+
+  augment "/ocif:interfaces/ocif:interface/vlan:routed-vlan/" +
+    "ocip:ipv6/ocip:address/vrrp/vrrp-group/state" {
+      description
+        "Additional VRRP data for IPv6 interfaces";
+
+    uses ip-vrrp-ipv6-state;
+  }
+
+  // rpc statements
+
+  // notification statements
+}

--- a/experimental/openconfig/interfaces/openconfig-interfaces.yang
+++ b/experimental/openconfig/interfaces/openconfig-interfaces.yang
@@ -1,0 +1,803 @@
+module openconfig-interfaces {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/interfaces";
+
+  prefix "ocif";
+
+  // import some basic types
+  import ietf-interfaces { prefix if; }
+  import ietf-yang-types { prefix yang; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "Model for managing network interfaces.
+
+    This model reuses data items defined in the IETF YANG model for
+    interfaces described by RFC 7223 with an alternate structure
+    (particularly for operational state data) and with additional
+    configuration items.";
+
+  revision "2015-01-23" {
+    description
+      "Initial revision";
+    reference "TBD";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  typedef interface-ref {
+    type leafref {
+      path "/ocif:interfaces/ocif:interface/ocif:name";
+    }
+    description
+      "This type is used by data models that need to reference
+       configured interfaces.";
+  }
+
+  // grouping statements
+
+  grouping interface-common-config {
+    description
+      "Configuration data data nodes common to physical interfaces
+      and subinterfaces";
+
+    leaf name {
+      type string;
+      description
+        "[adapted from IETF interfaces model (RFC 7223)]
+
+        The name of the interface.
+
+        A device MAY restrict the allowed values for this leaf,
+        possibly depending on the type of the interface.
+        For system-controlled interfaces, this leaf is the
+        device-specific name of the interface.  The 'config false'
+        list interfaces/interface[name]/state contains the currently
+        existing interfaces on the device.
+
+        If a client tries to create configuration for a
+        system-controlled interface that is not present in the
+        corresponding state list, the server MAY reject
+        the request if the implementation does not support
+        pre-provisioning of interfaces or if the name refers to
+        an interface that can never exist in the system.  A
+        NETCONF server MUST reply with an rpc-error with the
+        error-tag 'invalid-value' in this case.
+
+        The IETF model in RFC 7223 provides YANG features for the
+        following (i.e., pre-provisioning and arbitrary-names),
+        however they are omitted here:
+
+          If the device supports pre-provisioning of interface
+          configuration, the 'pre-provisioning' feature is
+          advertised.
+
+          If the device allows arbitrarily named user-controlled
+          interfaces, the 'arbitrary-names' feature is advertised.
+
+        When a configured user-controlled interface is created by
+        the system, it is instantiated with the same name in the
+        /interfaces/interface[name]/state list.";
+      reference
+        "RFC 7223: A YANG Data Model for Interface Management";
+    }
+
+    leaf description {
+      type string;
+      description
+        "[adapted from IETF interfaces model (RFC 7223)]
+
+        A textual description of the interface.
+
+        A server implementation MAY map this leaf to the ifAlias
+        MIB object.  Such an implementation needs to use some
+        mechanism to handle the differences in size and characters
+        allowed between this leaf and ifAlias.  The definition of
+        such a mechanism is outside the scope of this document.
+
+        Since ifAlias is defined to be stored in non-volatile
+        storage, the MIB implementation MUST map ifAlias to the
+        value of 'description' in the persistently stored
+        datastore.
+
+        Specifically, if the device supports ':startup', when
+        ifAlias is read the device MUST return the value of
+        'description' in the 'startup' datastore, and when it is
+        written, it MUST be written to the 'running' and 'startup'
+        datastores.  Note that it is up to the implementation to
+
+        decide whether to modify this single leaf in 'startup' or
+        perform an implicit copy-config from 'running' to
+        'startup'.
+
+        If the device does not support ':startup', ifAlias MUST
+        be mapped to the 'description' leaf in the 'running'
+        datastore.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifAlias";
+    }
+
+    leaf enabled {
+      type boolean;
+      default "true";
+      description
+        "[adapted from IETF interfaces model (RFC 7223)]
+
+        This leaf contains the configured, desired state of the
+        interface.
+
+        Systems that implement the IF-MIB use the value of this
+        leaf in the 'running' datastore to set
+        IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+        has been initialized, as described in RFC 2863.
+
+        Changes in this leaf in the 'running' datastore are
+        reflected in ifAdminStatus, but if ifAdminStatus is
+        changed over SNMP, this leaf is not affected.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+    }
+
+  }
+
+  grouping interface-phys-config {
+    description
+      "Configuration data for physical interfaces";
+
+    leaf type {
+      type identityref {
+        base if:interface-type;
+      }
+      mandatory true;
+      description
+        "[adapted from IETF interfaces model (RFC 7223)]
+
+        The type of the interface.
+
+        When an interface entry is created, a server MAY
+        initialize the type leaf with a valid value, e.g., if it
+        is possible to derive the type from the name of the
+        interface.
+
+        If a client tries to set the type of an interface to a
+        value that can never be used by the system, e.g., if the
+        type is not supported or if the type does not match the
+        name of the interface, the server MUST reject the request.
+        A NETCONF server MUST reply with an rpc-error with the
+        error-tag 'invalid-value' in this case.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifType";
+    }
+
+    leaf mtu {
+      type uint16;
+      description
+        "Set the max transmission unit size in octets
+        for the physical interface.  If this is not set, the mtu is
+        set to the operational default -- e.g., 1514 bytes on an
+        Ethernet interface.";
+    }
+
+    uses interface-common-config;
+  }
+
+  grouping interface-phys-holdtime-config {
+    description
+      "Configuration data for interface hold-time settings --
+      applies to physical interfaces.";
+
+    leaf up {
+      type uint32;
+      default 0;
+      description
+        "Dampens advertisement when the interface
+        transitions from down to up.  A zero value means dampening
+        is turned off, i.e., immediate notification.";
+    }
+
+    leaf down {
+      type uint32;
+      default 0;
+      description
+        "Dampens advertisement when the interface transitions from
+        up to down.  A zero value means dampening is turned off,
+        i.e., immediate notification.";
+    }
+  }
+
+  grouping interface-phys-holdtime-state {
+    description
+      "Operational state data for interface hold-time.";
+  }
+
+  grouping interface-phys-holdtime-top {
+    description
+      "Top-level grouping for setting link transition
+      dampening on physical and other types of interfaces.";
+
+    container hold-time {
+      description
+        "Top-level container for hold-time settings to enable
+        dampening advertisements of interface transitions.";
+
+      container config {
+        description
+          "Configuration data for interface hold-time settings.";
+
+        uses interface-phys-holdtime-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for interface hold-time.";
+
+        uses interface-phys-holdtime-config;
+        uses interface-phys-holdtime-state;
+      }
+    }
+  }
+
+  grouping interface-common-state {
+    description
+      "Operational state data (in addition to intended configuration)
+      at the global level for this interface";
+
+    leaf ifindex {
+      type uint32;
+      description
+        "System assigned number for each interface.  Corresponds to
+        ifIndex object in SNMP Interface MIB";
+      reference
+        "RFC 2863 - The Interfaces Group MIB";
+    }
+
+    leaf admin-status {
+      type enumeration {
+        enum UP {
+          description
+            "Ready to pass packets.";
+        }
+        enum DOWN {
+          description
+            "Not ready to pass packets and not in some test mode.";
+        }
+        enum TESTING {
+          //TODO: This is generally not supported as a configured
+          //admin state, though it's in the standard interfaces MIB.
+          //Consider removing it.
+          description
+            "In some test mode.";
+        }
+      }
+      //TODO:consider converting to an identity to have the
+      //flexibility to remove some values defined by RFC 7223 that
+      //are not used or not implemented consistently.
+      mandatory true;
+      description
+        "[adapted from IETF interfaces model (RFC 7223)]
+
+        The desired state of the interface.  In RFC 7223 this leaf
+        has the same read semantics as ifAdminStatus.  Here, it
+        reflects the administrative state as set by enabling or
+        disabling the interface.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+    }
+
+    leaf oper-status {
+      type enumeration {
+        enum UP {
+          value 1;
+          description
+            "Ready to pass packets.";
+        }
+        enum DOWN {
+          value 2;
+          description
+            "The interface does not pass any packets.";
+        }
+        enum TESTING {
+          value 3;
+          description
+            "In some test mode.  No operational packets can
+             be passed.";
+        }
+        enum UNKNOWN {
+          value 4;
+          description
+            "Status cannot be determined for some reason.";
+        }
+        enum DORMANT {
+          value 5;
+          description
+            "Waiting for some external event.";
+        }
+        enum NOT-PRESENT {
+          value 6;
+          description
+            "Some component (typically hardware) is missing.";
+        }
+        enum LOWER-LAYER-DOWN {
+          value 7;
+          description
+            "Down due to state of lower-layer interface(s).";
+        }
+      }
+      //TODO:consider converting to an identity to have the
+      //flexibility to remove some values defined by RFC 7223 that
+      //are not used or not implemented consistently.
+      mandatory true;
+      description
+        "[adapted from IETF interfaces model (RFC 7223)]
+
+        The current operational state of the interface.
+
+         This leaf has the same semantics as ifOperStatus.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+    }
+
+    leaf last-change {
+      type yang:timeticks;
+      description
+        "Date and time of the last state change of the interface
+        (e.g., up-to-down transition).   This corresponds to the
+        ifLastChange object in the standard interface MIB.";
+      reference
+        "RFC 2863: The Interfaces Group MIB - ifLastChange";
+    }
+
+  }
+
+
+  grouping interface-counters-state {
+    description
+      "Operational state representing interface counters
+      and statistics.  Some of these are adapted from RFC 7223";
+
+      //TODO: we may need to break this list of counters into those
+      //that would appear for physical vs. subinterface or logical
+      //interfaces.  For now, just replicating the full stats
+      //grouping to both interface and subinterface.
+
+    container counters {
+      description
+        "A collection of interface-related statistics objects.";
+
+      reference
+        "RFC 7223 - A YANG Data Model for Interface
+        Management";
+
+      leaf in-octets {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+
+          The total number of octets received on the interface,
+          including framing characters.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+      }
+
+      leaf in-unicast-pkts {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+
+          The number of packets, delivered by this sub-layer to a
+          higher (sub-)layer, that were not addressed to a
+          multicast or broadcast address at this sub-layer.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+      }
+
+      leaf in-broadcast-pkts {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+
+          The number of packets, delivered by this sub-layer to a
+          higher (sub-)layer, that were addressed to a broadcast
+          address at this sub-layer.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifHCInBroadcastPkts";
+      }
+
+      leaf in-multicast-pkts {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+
+
+          The number of packets, delivered by this sub-layer to a
+          higher (sub-)layer, that were addressed to a multicast
+          address at this sub-layer.  For a MAC-layer protocol,
+          this includes both Group and Functional addresses.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifHCInMulticastPkts";
+      }
+
+      leaf in-discards {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+          Changed the counter type to counter64.
+
+          The number of inbound packets that were chosen to be
+          discarded even though no errors had been detected to
+          prevent their being deliverable to a higher-layer
+          protocol.  One possible reason for discarding such a
+          packet could be to free up buffer space.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+
+
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+      }
+
+      leaf in-errors {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+          Changed the counter type to counter64.
+
+          For packet-oriented interfaces, the number of inbound
+          packets that contained errors preventing them from being
+          deliverable to a higher-layer protocol.  For character-
+          oriented or fixed-length interfaces, the number of
+          inbound transmission units that contained errors
+          preventing them from being deliverable to a higher-layer
+          protocol.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifInErrors";
+      }
+
+      leaf in-unknown-protos {
+        type yang:counter32;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+          Changed the counter type to counter64.
+
+          For packet-oriented interfaces, the number of packets
+          received via the interface that were discarded because
+          of an unknown or unsupported protocol.  For
+          character-oriented or fixed-length interfaces that
+          support protocol multiplexing, the number of
+          transmission units received via the interface that were
+          discarded because of an unknown or unsupported protocol.
+          For any interface that does not support protocol
+          multiplexing, this counter is not present.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+      }
+
+      leaf out-octets {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+          Changed the counter type to counter64.
+
+          The total number of octets transmitted out of the
+          interface, including framing characters.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+      }
+
+      leaf out-unicast-pkts {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+
+          The total number of packets that higher-level protocols
+          requested be transmitted, and that were not addressed
+          to a multicast or broadcast address at this sub-layer,
+          including those that were discarded or not sent.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+      }
+
+      leaf out-broadcast-pkts {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+
+          The total number of packets that higher-level protocols
+          requested be transmitted, and that were addressed to a
+          broadcast address at this sub-layer, including those
+          that were discarded or not sent.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifHCOutBroadcastPkts";
+      }
+
+
+      leaf out-multicast-pkts {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+          Changed the counter type to counter64.
+
+          The total number of packets that higher-level protocols
+          requested be transmitted, and that were addressed to a
+          multicast address at this sub-layer, including those
+          that were discarded or not sent.  For a MAC-layer
+          protocol, this includes both Group and Functional
+          addresses.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifHCOutMulticastPkts";
+      }
+
+      leaf out-discards {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+          Changed the counter type to counter64.
+
+          The number of outbound packets that were chosen to be
+          discarded even though no errors had been detected to
+          prevent their being transmitted.  One possible reason
+          for discarding such a packet could be to free up buffer
+          space.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+      }
+
+      leaf out-errors {
+        type yang:counter64;
+        description
+          "[adapted from IETF interfaces model (RFC 7223)]
+          Changed the counter type to counter64.
+
+          For packet-oriented interfaces, the number of outbound
+          packets that could not be transmitted because of errors.
+          For character-oriented or fixed-length interfaces, the
+          number of outbound transmission units that could not be
+          transmitted because of errors.
+
+          Discontinuities in the value of this counter can occur
+          at re-initialization of the management system, and at
+          other times as indicated by the value of
+          'discontinuity-time'.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+      }
+
+      leaf last-clear {
+        type yang:date-and-time;
+        description
+          "Indicates the last time the interface counters were
+          cleared.";
+      }
+    }
+  }
+
+  // data definition statements
+
+  grouping subinterfaces-config {
+    description
+      "Configuration data for subinterfaces";
+
+    leaf index {
+      type uint32;
+      default 0;
+      description
+        "The index of the subinterface, or logical interface number.
+        On systems with no support for subinterfaces, or not using
+        subinterfaces, this value should default to 0, i.e., the
+        default subinterface.";
+    }
+
+    leaf unnumbered {
+      type boolean;
+      default false;
+      description
+        "Indicates whether the subinterface is unnumbered, i.e.,
+        does not have an IP address assigned.";
+    }
+
+    uses interface-common-config;
+
+  }
+
+  grouping subinterfaces-state {
+    description
+      "Operational state data for subinterfaces";
+
+    uses interface-common-state;
+    uses interface-counters-state;
+  }
+
+  grouping subinterfaces-top {
+    description
+      "Subinterface data for logical interfaces associated with a
+      given interface";
+
+    container subinterfaces {
+      description
+        "Enclosing container for the list of subinterfaces associated
+        with a physical interface";
+
+      list subinterface {
+        key index;
+
+        description
+          "The list of subinterfaces (logical interfaces) associated
+          with a physical interface";
+
+        leaf index {
+          type leafref {
+            path "../ocif:config/ocif:index";
+          }
+          description
+            "The index number of the subinterface -- used to address
+            the logical interface";
+        }
+
+        container config {
+          description
+            "Configurable items at the subinterface level";
+
+          uses subinterfaces-config;
+        }
+
+        container state {
+
+          config false;
+          description
+            "Operational state data for logical interfaces";
+
+          uses subinterfaces-config;
+          uses subinterfaces-state;
+        }
+      }
+    }
+  }
+
+  grouping interfaces-top {
+    description
+      "Top-level grouping for interface configuration and
+      operational state data";
+
+    container interfaces {
+      description
+        "Top level container for interfaces, including configuration
+        and state data.";
+
+
+      list interface {
+        key name;
+
+        description
+          "The list of named interfaces on the device.";
+
+        leaf name {
+          type leafref {
+            path "../ocif:config/ocif:name";
+          }
+          description
+            "References the configured name of the interface";
+            //TODO: need to consider whether this should actually
+            //reference the name in the state subtree, which
+            //presumably would be the system-assigned name, or the
+            //configured name.  Points to the config/name now
+            //because of YANG 1.0 limitation that the list
+            //key must have the same "config" as the list, and
+            //also can't point to a non-config node.
+        }
+
+        container config {
+          description
+            "Configurable items at the global, physical interface
+            level";
+
+          uses interface-phys-config;
+        }
+
+        container state {
+
+          config false;
+          description
+            "Operational state data at the global interface level";
+
+          uses interface-phys-config;
+          uses interface-common-state;
+          uses interface-counters-state;
+        }
+
+        uses interface-phys-holdtime-top;
+        uses subinterfaces-top;
+      }
+    }
+  }
+
+  uses interfaces-top;
+
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/experimental/openconfig/openconfig-types.yang
+++ b/experimental/openconfig/openconfig-types.yang
@@ -1,0 +1,77 @@
+module openconfig-types {
+	yang-version "1";
+
+	namespace "http://openconfig.net/yang/openconfig-types";
+
+	prefix "openconfig-types";
+
+	// meta
+	organization
+    "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module contains a set of general type definitions that
+    are used across OpenConfig models. It can be imported by modules
+    that make use of these types.";
+
+  revision "2015-08-14" {
+    description "Initial revision";
+    reference "TBD";
+  }
+
+  typedef percentage {
+    type uint8 {
+      range "0..100";
+    }
+    description
+      "Integer indicating a percentage value";
+  }
+
+  typedef std-regexp {
+    type string;
+    description
+      "This type definition is a placeholder for a standard
+      definition of a regular expression that can be utilised in
+      OpenConfig models. Further discussion is required to
+      consider the type of regular expressions that are to be
+      supported. An initial straw-man proposal is POSIX compatible.";
+  }
+
+  grouping avg-min-max-stats-precision1 {
+    description
+      "Common nodes for recording average, minimum, and
+      maximum values for a statistic.  These values all have
+      fraction-digits set to 1.";
+
+    leaf avg {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      description
+        "The arithmetic mean value of the statistic over the
+        sampling period.";
+    }
+
+    leaf min {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      description
+        "The minimum value of the statistic over the sampling
+        period";
+    }
+
+    leaf max {
+      type decimal64 {
+        fraction-digits 1;
+      }
+      description
+        "The maximum value of the statitic over the sampling
+        period";
+    }
+  }
+}

--- a/experimental/openconfig/optical-transport/openconfig-terminal-device.yang
+++ b/experimental/openconfig/optical-transport/openconfig-terminal-device.yang
@@ -1,0 +1,1212 @@
+module openconfig-terminal-device {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/terminal-device";
+
+  prefix "opt-term";
+
+  // import some basic types
+  import openconfig-transport-types { prefix opt-types; }
+  import ietf-yang-types { prefix yang; }
+  import openconfig-if-ethernet { prefix eth; }
+  import openconfig-types { prefix oc-types; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This module describes a terminal optics device model for
+    managing the terminal systems (client and line side) in a
+    DWDM transport network.
+
+    Elements of the model:
+
+    physical client port: corresponds to a physical, pluggable client
+    port on the terminal device. Examples includes 10G, 40G, 100G
+    (e.g., 10x10G, 4x25G or 1x100G) and 400G/1T in the future.
+    Physical client ports will have associated operational state or
+    PMs.
+
+    physical client channel: a physical lane or channel in the
+    physical client port.  Each physical client port has 1 or more
+    channels. An example is 100GBASE-LR4 client physical port having
+    4x25G channels. Channels have their own optical PMs and can be
+    monitored independently within a client physical port (e.g.,
+    channel power).  Physical client channels are defined in the
+    model as part of a physical client port, and are modeled
+    primarily for reading their PMs.
+
+    logical channel: a logical grouping of logical grooming elements
+    that may be assigned to subsequent grooming stages for
+    multiplexing / de-multiplexing, or to an optical channel for
+    line side transmission.  The logical channels can represent, for
+    example, an ODU/OTU logical packing of the client
+    data onto the line side.  Tributaries are similarly logical
+    groupings of demand that can be represented in this structure and
+    assigned to an optical channel.  Note that different types of
+    logical channels may be present, each with their corresponding
+    PMs.
+
+    optical channel:  corresponds to an optical carrier and is
+    assigned a wavelength/frequency.  Optical channels have PMs
+    such as power, BER, and operational mode.
+
+    physical line port: represent the physical line-side ports on
+    the terminal device.  Line ports act as containers for optical
+    channels.
+
+    Directionality:
+
+    To maintain simplicity in the model, the configuration is
+    described from client-to-line direction.  The assumption is that
+    equivalent reverse configuration is implicit, resulting in
+    the same line-to-client configuration.
+
+    Physical layout:
+
+    The model does not assume a particular physical layout of client
+    and line ports on the terminal device (e.g., such as number of
+    ports per linecard, separate linecards for client and line ports,
+    etc.).";
+
+  revision "2015-08-17" {
+    description
+      "Initial revision";
+    reference "TBD";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // grouping statements
+
+  grouping terminal-output-optical-power {
+    description
+      "Reusable leaves related to optical output power -- this is
+      typically configurable on line side and read-only on the
+      client-side";
+
+    leaf output-power {
+      type uint64;
+      units dBm;
+      description
+        "The output optical power of this port in units of 0.01dBm.
+        If the port is an aggregate of multiple physical channels,
+        this attribute is the total power or sum of all channels.";
+    }
+  }
+
+  grouping terminal-output-optical-frequency {
+    description
+      "Reusable leaves related to optical output power -- this is
+      typically configurable on line side and read-only on the
+      client-side";
+
+    leaf output-frequency {
+      type uint64;
+      units dBm;
+      description
+        "The frequency in MHz of the individual physical channel
+        (e.g. ITU C50 - 195.0THz and would be reported as
+        195,000,000 MHz in this model). This attribute is not
+        configurable on most client ports.";
+    }
+  }
+
+  grouping terminal-input-optical-power {
+    description
+      "Reusable leaves related to input optical power";
+
+    leaf input-power {
+      type uint64;
+      units dBm;
+      description
+        "The input optical power of this port in units of 0.01dBm.
+        If the port is an aggregate of multiple physical channels,
+        this attribute is the total power or sum of all channels.";
+    }
+  }
+
+  grouping terminal-ethernet-protocol-stats {
+    description
+      "Ethernet-specific counters when logical channel
+      framing is using Ethernet protocol, e.g., 10GE, 100GE";
+
+    container ethernet {
+      description
+        "PMs and counters for Ethernet protocol channels";
+
+      uses eth:ethernet-interface-state-counters;
+    }
+
+  }
+
+  grouping terminal-otn-protocol-stats {
+    description
+      "OTU statistics when logical channel
+      framing is using an OTU protocol, e.g., OTU1, OTU3, etc.";
+
+    container otn {
+      description
+        "PMs and statistics for OTN protocol channels";
+
+      container pre-fec-ber {
+        description
+          "Bit error rate before forward error correction -- computed
+          value";
+
+        uses oc-types:avg-min-max-stats-precision1;
+
+      }
+
+      container post-fec-ber {
+        description
+          "Bit error rate after forward error correction -- computed
+          value";
+
+        uses oc-types:avg-min-max-stats-precision1;
+      }
+
+      leaf tti-msg {
+        type string;
+        description
+          "Trail trace identifier (TTI) message received";
+      }
+
+      leaf rdi-msg {
+        type string;
+        description
+          "Remote defect indication (RDI) message received";
+      }
+    }
+  }
+
+  grouping terminal-client-physical-channel-config {
+    description
+      "Configuration data for physical client channels";
+
+    leaf index {
+      type uint16 {
+        range 0..max;
+      }
+      description
+        "Index of the physical channnel or lane within a physical
+        client port";
+    }
+
+    leaf description {
+      type string;
+      description
+        "Text description for the client physical channel";
+    }
+
+    leaf tx-laser {
+      type boolean;
+      description
+        "Enable (true) or disable (false) the transmit label for the
+        channel";
+    }
+  }
+
+  grouping terminal-client-physical-channel-state {
+    description
+      "Operational state data for client channels.";
+
+      uses terminal-output-optical-power;
+      uses terminal-output-optical-frequency;
+
+  }
+
+  grouping terminal-client-physical-channel-top {
+    description
+      "Top-level grouping for physical client channels";
+
+    container physical-channels {
+      description
+        "Enclosing container for client channels";
+
+      list channel {
+        key index;
+        description
+          "List of client channels, keyed by index within a physical
+          client port.  A physical port with a single channel would
+          have a single zero-indexed element";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "Reference to the index number of the client channel";
+        }
+
+        container config {
+          description
+            "Configuration data ";
+
+          uses terminal-client-physical-channel-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for client channels";
+
+          uses terminal-client-physical-channel-config;
+          uses terminal-client-physical-channel-state;
+        }
+      }
+    }
+  }
+
+  grouping terminal-client-port-assignment-config {
+    description
+      "Configuration data for assigning physical client ports to
+      logical channels";
+
+    leaf index {
+      type uint32;
+      description
+        "Index of the client port assignment";
+    }
+
+    leaf description {
+      type string;
+      description
+        "Descriptive name for the client port-to-logical channel
+        mapping";
+    }
+
+    leaf logical-channel {
+      type leafref {
+        path "../../../../../../logical-channels/channel/" +
+          "index";
+      }
+      description
+        "Reference to the logical channel for this
+        assignment";
+    }
+
+    leaf allocation {
+      type decimal64 {
+        fraction-digits 3;
+      }
+      units Gbps;
+      description
+        "Allocation of the client physical port to the assigned
+        logical channel expressed in Gbps.  In most cases,
+        the full client physical port rate is assigned to a single
+        logical channel.";
+    }
+
+  }
+
+  grouping terminal-client-port-assignment-state {
+    description
+      "Operational state data for assigning physical client ports
+      to logical channels";
+  }
+
+  grouping terminal-client-port-assignment-top {
+    description
+      "Top-level grouping for the assigment of client physical ports
+      to logical channels";
+    //TODO: this grouping could be removed, instead reusing a common
+    //grouping for logical client assignment pointers
+
+    container logical-channel-assignments {
+      description
+        "Enclosing container for client port to logical client
+        mappings";
+
+      list assignment {
+        key index;
+        description
+          "List of assignments to logical clients";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "Reference to the index of this logical client
+            assignment";
+        }
+
+        container config {
+          description
+            "Configuration data for the logical client assignment";
+
+          uses terminal-client-port-assignment-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for the logical client
+            assignment";
+
+          uses terminal-client-port-assignment-config;
+          uses terminal-client-port-assignment-state;
+        }
+      }
+    }
+  }
+
+  grouping terminal-client-port-transceiver-config {
+    description
+      "Configuration data for client port transceivers";
+
+    leaf enabled {
+      type boolean;
+      description
+        "Turns power on / off to the transceiver -- provides a means
+        to power on/off the transceiver (in the case of SFP, SFP+,
+        QSFP,...) or enable high-power mode (in the case of CFP,
+        CFP2, CFP4) and is optionally supported (device can choose to
+        always enable).  True = power on / high power, False =
+        powered off";
+    }
+  }
+
+  grouping terminal-client-port-transceiver-state {
+    description
+      "Operational state data for client port transceivers";
+
+    leaf present {
+      type enumeration {
+        enum PRESENT {
+          description
+            "Transceiver is present on the port";
+        }
+        enum NOT_PRESENT {
+          description
+            "Transceiver is not present on the port";
+        }
+      }
+      description
+        "Indicates whether a transceiver is present in
+        the specified client port.";
+    }
+
+    leaf form-factor {
+      type identityref {
+        base opt-types:transceiver-form-factor-type;
+      }
+      description
+        "Indicates the type of optical transceiver used on this
+        port.  If the client port is built into the device and not
+        plugable, then non-pluggable is the corresponding state. If
+        a device port supports multiple form factors (e.g. QSFP28
+        and QSFP+, then the value of the transceiver installed shall
+        be reported. If no transceiver is present, then the value of
+        the highest rate form factor shall be reported
+        (QSFP28, for example).";
+    }
+
+    leaf connector-type {
+      type identityref {
+        base opt-types:fiber-connector-type;
+      }
+      description
+        "Connector type used on this port";
+    }
+
+    leaf internal-temp {
+      type int16 {
+        range -40..125;
+      }
+      description
+        "Internally measured temperature in degrees Celsius. MSA
+        valid range is between –40 and +125C. Accuracy shall be
+        better than +/- 3 degC over the whole temperature range.";
+    }
+
+    leaf vendor {
+      type string {
+        length 1..16;
+      }
+      description
+        "Full name of transceiver vendor. 16-octet field that
+        contains ASCII characters, left-aligned and padded on the
+        right with ASCII spaces (20h)";
+    }
+
+    leaf vendor-part {
+      type string {
+        length 1..16;
+      }
+      description
+        "Transceiver vendor’s part number. 16-octet field that
+        contains ASCII characters, left-aligned and padded on the
+        right with ASCII spaces (20h). If part number is undefined,
+        all 16 octets = 0h";
+    }
+
+    leaf vendor-rev {
+      type string {
+        length 1..2;
+      }
+      description
+        "Transceiver vendor’s revision number. 2-octet field that
+        contains ASCII characters, left-aligned and padded on the
+        right with ASCII spaces (20h)";
+    }
+
+    leaf serial-no {
+      type string {
+        length 1..16;
+      }
+      description
+        "Transceiver serial number. 16-octet field that contains
+        ASCII characters, left-aligned and padded on the right with
+        ASCII spaces (20h). If part serial number is undefined, all
+        16 octets = 0h";
+    }
+
+    leaf date-code {
+      type yang:date-and-time;
+      description
+        "Representation of the transceiver date code, typically
+        stored as YYMMDD.  The time portion of the value is
+        undefined and not intended to be read.";
+    }
+
+    leaf fault-condition {
+      type boolean;
+      description
+        "Indicates if a fault condition exists in the transceiver";
+    }
+
+  }
+
+  grouping terminal-client-port-transceiver-top {
+    description
+      "Top-level grouping for client port transceiver data";
+
+    container transceiver {
+      description
+        "Top-level container for client port transceiver data";
+
+      container config {
+        description
+          "Configuration data for client port transceivers";
+
+        uses terminal-client-port-transceiver-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for client port transceivers";
+
+        uses terminal-client-port-transceiver-config;
+        uses terminal-client-port-transceiver-state;
+      }
+    }
+  }
+
+  grouping terminal-client-port-config {
+    description
+      "Configuration data for physical client-side ports";
+
+    leaf name {
+      type string;
+      description
+        "Name of the physical client port";
+    }
+
+    leaf description {
+      type string;
+      description
+        "Text description for the physical client port";
+    }
+
+  }
+
+  grouping terminal-client-port-state {
+    description
+      "Operational state data for physical client ports";
+
+    uses terminal-output-optical-power;
+    uses terminal-input-optical-power;
+
+    //TODO: these leaves should be active based on the type of
+    //interface
+    leaf ethernet-compliance-code {
+      type identityref {
+        base opt-types:ethernet-pmd-type;
+      }
+      description
+        "Ethernet PMD that the transceiver supports. The SFF/QSFP
+        MSAs have registers for this and CFP MSA has similar.";
+    }
+
+    leaf sonet-sdh-compliance-code {
+      type identityref {
+        base opt-types:sonet-application-code;
+      }
+      description
+        "SONET/SDH application code supported by the port";
+    }
+
+    leaf otn-compliance-code {
+      type identityref {
+        base opt-types:otn-application-code;
+      }
+      description
+        "OTN application code supported by the port";
+    }
+  }
+
+  grouping terminal-client-port-top {
+    description
+      "Top-level grouping for physical client ports";
+
+    container client-ports {
+      description
+        "Enclosing container for the list of client ports";
+
+      list port {
+        key name;
+        description
+          "List of client physical ports on the terminal device";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name of the client port";
+        }
+
+        container config {
+          description
+            "Configuration data for client physical ports";
+
+          uses terminal-client-port-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for client physical ports";
+
+          uses terminal-client-port-config;
+          uses terminal-client-port-state;
+        }
+
+        uses terminal-client-port-transceiver-top;
+        uses terminal-client-physical-channel-top;
+        uses terminal-client-port-assignment-top;
+      }
+    }
+  }
+
+  grouping terminal-logical-chan-assignment-config {
+    description
+      "Configuration data for assigning client logical channels
+      to line-side tributaries";
+
+    leaf index {
+      type uint32;
+      description
+        "Index of the current logical client channel to tributary
+        mapping";
+    }
+
+    leaf description {
+      type string;
+      description
+        "Name assigned to the logical client channel";
+    }
+
+    choice assignment-type {
+      description
+        "Each logical channel element may be assigned to subsequent
+        stages of logical elements to implement further grooming, or
+        can be assigned to a line-side optical channel for
+        transmission.  Each assignment also has an associated
+        bandwidth allocation.";
+
+      leaf logical-channel {
+        type leafref {
+          path "../../../../../../logical-channels/" +
+            "channel/index";
+        }
+        description
+          "Reference to another stage of logical channel elements.";
+      }
+
+      leaf optical-channel {
+        type leafref {
+          path "../../../../../../optical-channels/optical-channel" +
+            "/index";
+        }
+        description
+          "Reference to the line-side optical channel that should
+          carry the current logical channel element.  Use this
+          reference to exit the logical element stage.";
+      }
+    }
+
+    leaf allocation {
+      type decimal64 {
+        fraction-digits 3;
+      }
+      units Gbps;
+      description
+        "Allocation of the logical client channel to the tributary
+        or sub-channel, expressed in Gbps";
+    }
+
+  }
+
+  grouping terminal-logical-chan-assignment-state {
+    description
+      "Operational state data for the assignment of logical client
+      channel to line-side tributary";
+  }
+
+  grouping terminal-logical-chan-assignment-top {
+    description
+      "Top-level grouping for the list of logical client channel-to-
+      tributary assignments";
+
+    container logical-channel-assignments {
+      //TODO: we need a commonly understood name for this logical
+      //channel structure
+      description
+        "Enclosing container for tributary assignments";
+
+      list assignment {
+        key index;
+        description
+          "Logical channel elements may be assigned directly to
+          optical channels for line-side transmission, or can be
+          further groomed into additional stages of logical channel
+          elements.  The grooming can multiplex (i.e., split the
+          current element into multiple elements in the subsequent
+          stage) or de-multiplex (i.e., combine the current element
+          with other elements into the same element in the subsequent
+          stage) logical elements in each stage.
+
+          Note that to support the ability to groom the logical
+          elements, the list of logical channel elements should be
+          populated with an entry for the logical elements at
+          each stage, starting with the initial assignment from the
+          respective client physical port.
+
+          Each logical element assignment consists of a pointer to
+          an element in the next stage, or to an optical channel,
+          along with a bandwidth allocation for the corresponding
+          assignment (e.g., to split or combine signal).";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "Reference to the index for the current tributary
+            assignment";
+        }
+
+        container config {
+          description
+            "Configuration data for tributary assignments";
+
+          uses terminal-logical-chan-assignment-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for tributary assignments";
+
+          uses terminal-logical-chan-assignment-config;
+          uses terminal-logical-chan-assignment-state;
+        }
+      }
+    }
+  }
+
+  grouping terminal-logical-channel-config {
+    description
+      "Configuration data for logical client channels";
+
+    leaf index {
+      type uint32;
+      description
+        "Index of the current logical client channel";
+    }
+
+    leaf description {
+      type string;
+      description
+        "Description of the client logical channel";
+    }
+
+    leaf trib-rate-class {
+      type identityref {
+        base opt-types:tributary-rate-class-type;
+      }
+      description
+        "Rounded bit rate of the tributary signal. Exact bit rate
+        will be refined by protocol selection.";
+    }
+
+    leaf trib-protocol {
+      type identityref {
+        base opt-types:tributary-protocol-type;
+      }
+      description
+        "Protocol framing of the tributary signal. If this
+        LogicalChannel is directly connected to a Client-Port or
+        Optical-Channel, this is the protocol of the associated port.
+        If the LogicalChannel is connected to other LogicalChannels,
+        the TributaryProtocol of the LogicalChannels will define a
+        specific mapping/demapping or multiplexing/demultiplexing
+        function.
+
+        Not all protocols are valid, depending on the value
+        of trib-rate-class.  The expectation is that the NMS
+        will validate that a correct combination of rate class
+        and protocol are specfied.  Basic combinations are:
+
+        rate class: 1G
+        protocols: 1GE
+
+        rate class: 2.5G
+        protocols: OC48, STM16
+
+        rate class: 10G
+        protocols:  10GE LAN, 10GE WAN, OC192, STM64, OTU2, OTU2e,
+                    OTU1e, ODU2, ODU2e, ODU1e
+
+        rate class: 40G
+        protocols:  40GE, OC768, STM256, OTU3, ODU3
+
+        rate class: 100G
+        protocols:  100GE, 100G MLG, OTU4, OTUCn, ODU4";
+    }
+
+    leaf protocol-type {
+      type identityref {
+        base opt-types:logical-element-protocol-type;
+      }
+      description
+        "The type / stage of the logical element determines the
+        configuration and operational state parameters (PMs)
+        available for the logical element";
+    }
+
+  }
+
+
+  grouping terminal-logical-channel-state {
+    description
+      "Operational state data for logical client channels";
+
+    leaf link-state {
+      type enumeration {
+        enum UP {
+          description
+            "Logical channel is operationally up";
+        }
+        enum DOWN {
+          description
+            "Logical channel is operationally down";
+        }
+      }
+      description
+        "Link-state of the Ethernet protocol on the logical channel,
+        SONET / SDH framed signal, etc.";
+    }
+
+    uses terminal-ethernet-protocol-stats {
+      when "../config/protocol-type = prot-ethernet" {
+        description
+          "Include the Ethernet protocol statistics only when the
+          protocol used by the link is Ethernet.";
+      }
+    }
+
+    uses terminal-otn-protocol-stats {
+      when "../config/protocol-type = prot-otn" {
+        description
+          "Include the Ethernet protocol statistics only when the
+          protocol used by the link is Ethernet.";
+      }
+    }
+  }
+
+  grouping terminal-logical-channel-top {
+    description
+      "Top-level grouping for logical channels";
+
+    container logical-channels {
+      description
+        "Enclosing container the list of logical channels";
+
+      list channel {
+        key index;
+        description
+          "List of logical channels";
+        //TODO: naming for this list of logical elements should be
+        //revisited.
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            "Reference to the index of the logical client channel";
+        }
+
+        container config {
+          description
+            "Configuration data for logical client channels";
+
+          uses terminal-logical-channel-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for logical client channels";
+
+          uses terminal-logical-channel-config;
+          uses terminal-logical-channel-state;
+        }
+
+        uses terminal-logical-chan-assignment-top;
+      }
+    }
+  }
+
+
+  grouping terminal-optical-channel-config {
+    description
+      "Configuration data for describing optical channels";
+
+    leaf index {
+      type uint64;
+      description
+        "Index number assigned to the optical channel.  The index
+        must be unique on the local system.";
+    }
+
+    leaf frequency {
+      type uint64;
+      units THz;
+      description
+        "Frequency of the optical channel";
+    }
+
+    leaf power {
+      type uint64;
+      units dBm;
+      description
+        "Power level of the optical channel";
+    }
+
+    leaf operational-mode {
+      type uint16;
+      // this must statement checks for existence of the
+      // operational mode in the list of supported operational
+      // modes
+      must "boolean(../../../../operational-modes/state/" +
+        "supported-modes[mode-id=current()])" {
+        description
+          "The referenced operational mode must exist in the list of
+          supported operational modes supplied by the device";
+      }
+      description
+        "Vendor-specific mode identifier -- sets the operational
+        mode for the channel";
+    }
+
+    leaf line-port {
+      type leafref {
+        path "../../../../line-ports/port/name";
+      }
+      description
+        "Reference to the line-side physical port that carries
+        this optical channel";
+    }
+  }
+
+  grouping terminal-optical-channel-state {
+    description
+      "Operational state data ";
+  }
+
+  grouping terminal-optical-channel-top {
+    description
+      "Top-level grouping ";
+
+    container optical-channels {
+      description
+        "Enclosing container ";
+
+      list optical-channel {
+        key index;
+        description
+          "List of ";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+          description
+            " ";
+        }
+
+        container config {
+          description
+            "Configuration data ";
+
+          uses terminal-optical-channel-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data ";
+
+          uses terminal-optical-channel-config;
+          uses terminal-optical-channel-state;
+        }
+      }
+    }
+  }
+
+
+  grouping terminal-line-physical-port-config {
+    description
+      "Configuration data for physical line ports";
+
+    leaf name {
+      type string;
+      description
+        "Name of the line port";
+    }
+
+    uses terminal-output-optical-power;
+  }
+
+  grouping terminal-line-physical-port-state {
+    description
+      "Operational state data for physical line ports";
+  }
+
+  grouping terminal-line-physical-port-top {
+    description
+      "Top-level grouping for physical line ports";
+
+    container line-ports {
+      description
+        "Enclosing container for line ports";
+
+      list port {
+        key name;
+        description
+          "List of line ports";
+
+        leaf name {
+          type leafref {
+            path "../config/name";
+          }
+          description
+            "Reference to the name of the line port";
+        }
+
+        container config {
+          description
+            "Configuration data for each physical line port";
+
+          uses terminal-line-physical-port-config;
+        }
+
+        container state {
+
+          config false;
+
+          description
+            "Operational state data for each physical line port";
+
+          uses terminal-line-physical-port-config;
+          uses terminal-line-physical-port-state;
+        }
+      }
+    }
+  }
+
+  grouping terminal-operational-mode-config {
+    description
+      "Configuration data for vendor-supported operational modes";
+  }
+
+  grouping terminal-operational-mode-state {
+    description
+      "Operational state data for vendor-supported operational
+      modes";
+
+    list supported-modes {
+
+      key mode-id;
+      description
+        "List of supported modes and their associated metadata";
+
+      leaf mode-id {
+        type uint16;
+        description
+          "Two-octet encoding of the vendor-defined operational
+          mode";
+      }
+
+      leaf description {
+        type string;
+        description
+          "Vendor-supplied textual description of the characteristics
+          of this operational mode to enable operators to select the
+          appropriate mode for the application.";
+      }
+
+      //TODO: examples of the kind of info that would be useful to
+      //report in the operational mode:
+      //Symbol rate (32G, 40G, 43G, 64G, etc.)
+      //Modulation (QPSK, 8-QAM, 16-QAM, etc.)
+      //Differential encoding (on, off/pilot symbol, etc)
+      //State of polarization tracking mode (default, med.
+      //high-speed, etc.)
+      //Pulse shaping (RRC, RC, roll-off factor)
+      //FEC mode (SD, HD, % OH)
+
+      leaf vendor-id {
+        type string;
+        description
+          "Identifier to represent the vendor / supplier of the
+          platform and the associated operational mode information";
+      }
+    }
+  }
+
+  grouping terminal-operational-mode-top {
+    description
+      "Top-level grouping for supported vendor-specifid operational
+      mode";
+
+    container operational-modes {
+      description
+        "Top-level container for vendor-specific operational mode
+        information";
+
+      container config {
+        description
+          "Configuration data for operational modes.  This should
+          generally be empty, i.e., operational mode information
+          is supplied by the platform vendor and is expected to be
+          read-only";
+
+        uses terminal-operational-mode-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for vendor-specific operational
+          modes";
+
+        uses terminal-operational-mode-config;
+        uses terminal-operational-mode-state;
+      }
+    }
+  }
+
+  grouping terminal-device-config {
+    description
+      "Configuration data for transport terminal devices at a
+      device-wide level";
+  }
+
+  grouping terminal-device-state {
+    description
+      "Operational state data for transport terminal devices at a
+      device-wide level";
+  }
+
+  grouping terminal-device-top {
+    description
+      "Top-level grouping for data for terminal devices";
+
+    container terminal-device {
+      description
+        "Top-level container for the terminal device";
+
+      container config {
+        description
+          "Configuration data for global terminal-device";
+
+        uses terminal-device-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data for global terminal device";
+
+        uses terminal-device-config;
+        uses terminal-device-state;
+      }
+
+      uses terminal-client-port-top;
+      uses terminal-logical-channel-top;
+      uses terminal-optical-channel-top;
+      uses terminal-line-physical-port-top;
+      uses terminal-operational-mode-top;
+
+    }
+  }
+
+  // data definition statements
+
+  uses terminal-device-top;
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/experimental/openconfig/optical-transport/openconfig-transport-types.yang
+++ b/experimental/openconfig/optical-transport/openconfig-transport-types.yang
@@ -1,0 +1,503 @@
+module openconfig-transport-types {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/transport-types";
+
+  prefix "opt-types";
+
+  // import some basic types
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    www.openconfig.net";
+
+  description
+    "This ";
+
+  revision "2015-08-17" {
+    description
+      "Initial revision";
+    reference "TBD";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  identity tributary-protocol-type {
+    description
+      "Base identity for protocol framing used by tributary
+      signals.";
+  }
+
+  identity prot-1GE {
+    base tributary-protocol-type;
+    description "1G Ethernet protocol";
+  }
+
+  identity prot-OC48 {
+    base tributary-protocol-type;
+    description "OC48 protocol";
+  }
+
+  identity prot-STM16 {
+    base tributary-protocol-type;
+    description "STM 16 protocol";
+  }
+
+  identity prot-10GE_LAN {
+    base tributary-protocol-type;
+    description "10G Ethernet LAN protocol";
+  }
+
+  identity prot-10GE_WAN {
+    base tributary-protocol-type;
+    description "10G Ethernet WAN protocol";
+  }
+
+  identity prot-OC192 {
+    base tributary-protocol-type;
+    description "OC 192 (9.6GB) port protocol";
+  }
+
+  identity prot-STM64 {
+    base tributary-protocol-type;
+    description "STM 64 protocol";
+  }
+
+  identity prot-OTU2 {
+    base tributary-protocol-type;
+    description "OTU 2 protocol";
+  }
+
+  identity prot-OTU2e {
+    base tributary-protocol-type;
+    description "OTU 2e protocol";
+  }
+
+  identity prot-OTU1e {
+    base tributary-protocol-type;
+    description "OTU 1e protocol";
+  }
+
+  identity prot-ODU2 {
+    base tributary-protocol-type;
+    description "ODU 2 protocol";
+  }
+
+  identity prot-ODU2e {
+    base tributary-protocol-type;
+    description "ODU 2e protocol";
+  }
+
+  identity prot-40GE {
+    base tributary-protocol-type;
+    description "40G Ethernet port protocol";
+  }
+
+  identity prot-OC768 {
+    base tributary-protocol-type;
+    description "OC 768 protocol";
+  }
+
+  identity prot-STM256 {
+    base tributary-protocol-type;
+    description "STM 256 protocol";
+  }
+
+  identity prot-OTU3 {
+    base tributary-protocol-type;
+    description "OTU 3 protocol";
+  }
+
+  identity prot-ODU3 {
+    base tributary-protocol-type;
+    description "ODU 3 protocol";
+  }
+
+  identity prot-100GE {
+    base tributary-protocol-type;
+    description "100G Ethernet protocol";
+  }
+
+  identity prot-100G_MLG {
+    base tributary-protocol-type;
+    description "100G MLG protocol";
+  }
+
+  identity prot-OTU4 {
+    base tributary-protocol-type;
+    description "OTU4 signal protocol (112G) for transporting
+    100GE signal";
+  }
+
+  identity prot-OTUCn {
+    base tributary-protocol-type;
+    description "OTU Cn protocol";
+  }
+
+  identity prot-ODU4 {
+    base tributary-protocol-type;
+    description "ODU 4 protocol";
+  }
+
+  identity transceiver-form-factor-type {
+    description
+      "Base identity for identifying the type of pluggable optic
+      transceiver (i.e,. form factor) used in a port.";
+  }
+
+  identity CFP {
+    base transceiver-form-factor-type;
+    description
+      "C form-factor pluggable, that can support up to a
+      100 Gb/s signal with 10x10G or 4x25G physical channels";
+  }
+
+  identity CFP2 {
+    base transceiver-form-factor-type;
+    description
+      "1/2 C form-factor pluggable, that can support up to a
+      200 Gb/s signal with 10x10G, 4x25G, or 8x25G physical
+      channels";
+  }
+
+  identity CFP4 {
+    base transceiver-form-factor-type;
+    description
+      "1/4 C form-factor pluggable, that can support up to a
+      100 Gb/s signal with 10x10G or 4x25G physical channels";
+  }
+
+  identity QSFP {
+    base transceiver-form-factor-type;
+    description
+      "Quad Small Form-factor Pluggable transceiver that can support
+      up to 4x10G physical channels";
+  }
+
+  identity QSFP28 {
+    base transceiver-form-factor-type;
+    description
+      "QSFP pluggable optic with support for up to 4x28G physical
+      channels";
+  }
+
+  identity SFP {
+    base transceiver-form-factor-type;
+    description
+      "Small form-factor pluggable transceiver supporting up to
+      10 Gb/s signal";
+  }
+
+  identity SFP_plus {
+    base transceiver-form-factor-type;
+    description
+      "Enhanced small form-factor pluggable transceiver supporting
+      up to 16 Gb/s signals, including 10 GbE and OTU2";
+  }
+
+  identity XFP {
+    base transceiver-form-factor-type;
+    description
+      "10 Gigabit small form factor pluggable transceiver supporting
+      10 GbE and OTU2";
+  }
+
+  identity X2 {
+    base transceiver-form-factor-type;
+    description
+      "10 Gigabit small form factor pluggable transceiver supporting
+      10 GbE using a XAUI inerface and 4 data channels.";
+  }
+
+  identity non-pluggable {
+    base transceiver-form-factor-type;
+    description
+      "Represents a port that does not require a pluggable optic,
+      e.g., with on-board optics like COBO";
+  }
+
+  identity other {
+    base transceiver-form-factor-type;
+    description
+      "Represents a transceiver form factor not otherwise listed";
+  }
+
+  identity fiber-connector-type {
+    description
+      "Type of optical fiber connector";
+  }
+
+  identity sc-connector {
+    base fiber-connector-type;
+    description
+      "SC type fiber connector";
+  }
+
+  identity lc-connector {
+    base fiber-connector-type;
+    description
+      "LC type fiber connector";
+  }
+
+  identity mpo-connector {
+    base fiber-connector-type;
+    description
+      "MPO (multi-fiber push-on/pull-off) type fiber connector
+      1x12 fibers";
+  }
+
+  identity ethernet-pmd-type {
+    description
+      "Ethernet compliance codes (PMD) supported by transceivers";
+  }
+
+  identity eth-10GBASE-LRM {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 10GBASE-LRM";
+  }
+
+  identity eth-10GBASE-LR {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 10GBASE-LR";
+  }
+
+  identity eth-10GBASE-ZR {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 10GBASE-ZR";
+  }
+
+  identity eth-10GBASE-ER {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 10GBASE-ER";
+  }
+
+  identity eth-10GBASE-SR {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 10GBASE-SR";
+  }
+
+  identity eth-40GBASE-CR4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 40GBASE-CR4";
+  }
+
+  identity eth-40GBASE-SR4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 40GBASE-SR4";
+  }
+
+  identity eth-40GBASE-LR4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 40GBASE-LR4";
+  }
+
+  identity eth-40GBASE-ER4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 40GBASE-ER4";
+  }
+
+  identity eth-40GBASE-PSM4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 40GBASE-PSM4";
+  }
+
+  identity eth-4x10GBASE-LR {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 4x10GBASE-LR";
+  }
+
+  identity eth-4x10GBASE-SR {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 4x10GBASE-SR";
+  }
+
+  identity eth-100G_AOC {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100G_AOC";
+  }
+
+  identity eth-100G_ACC {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100G_ACC";
+  }
+
+  identity eth-100GBASE-SR10 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100GBASE-SR10";
+  }
+
+  identity eth-100GBASE-SR4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100GBASE-SR4";
+  }
+
+  identity eth-100GBASE-LR4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100GBASE-LR4";
+  }
+
+  identity eth-100GBASE-ER4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100GBASE-ER4";
+  }
+
+  identity eth-100GBASE-CWDM4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100GBASE-CWDM4";
+  }
+
+  identity eth-100GBASE-CLR4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100GBASE-CLR4";
+  }
+
+  identity eth-100GBASE-PSM4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100GBASE-PSM4";
+  }
+
+  identity eth-100GBASE-CR4 {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: 100GBASE-CR4";
+  }
+
+  identity eth-undefined {
+    base ethernet-pmd-type;
+    description "Ethernet compliance code: undefined";
+  }
+
+  identity sonet-application-code {
+    description
+      "Supported SONET/SDH application codes";
+  }
+
+  identity VSR2000-3R2 {
+    base sonet-application-code;
+    description
+      "SONET/SDH application code: VSR2000-3R2";
+  }
+
+  identity VSR2000-3R3 {
+    base sonet-application-code;
+    description
+      "SONET/SDH application code: VSR2000-3R3";
+  }
+
+  identity VSR2000-3R5 {
+    base sonet-application-code;
+    description
+      "SONET/SDH application code: VSR2000-3R5";
+  }
+
+  identity sonet-undefined {
+    base sonet-application-code;
+    description
+      "SONET/SDH application code: undefined";
+  }
+
+  identity otn-application-code {
+    description
+      "Supported OTN application codes";
+  }
+
+  identity P1L1-2D1 {
+    base otn-application-code;
+    description
+      "OTN application code: P1L1-2D1";
+  }
+
+  identity P1S1-2D2 {
+    base otn-application-code;
+    description
+      "OTN application code: P1S1-2D2";
+  }
+
+  identity P1L1-2D2 {
+    base otn-application-code;
+    description
+      "OTN application code: P1L1-2D2";
+  }
+
+  identity otn-undefined {
+    base otn-application-code;
+    description
+      "OTN application code: undefined";
+  }
+
+  identity tributary-rate-class-type {
+    description
+      "Rate of tributary signal -- identities will typically reflect
+      rounded bit rate.";
+  }
+
+  identity trib-rate-1G {
+    base tributary-rate-class-type;
+    description
+      "1G tributary signal rate";
+  }
+
+  identity trib-rate-2.5G {
+    base tributary-rate-class-type;
+    description
+      "2.5G tributary signal rate";
+  }
+
+  identity trib-rate-10G {
+    base tributary-rate-class-type;
+    description
+      "10G tributary signal rate";
+  }
+
+  identity trib-rate-40G {
+    base tributary-rate-class-type;
+    description
+      "40G tributary signal rate";
+  }
+
+  identity trib-rate-100G {
+    base tributary-rate-class-type;
+    description
+      "100G tributary signal rate";
+  }
+
+  identity logical-element-protocol-type {
+    description
+      "Type of protocol framing used on the logical channel or
+      tributary";
+  }
+
+  identity prot-ethernet {
+    base logical-element-protocol-type;
+    description
+      "Ethernet protocol framing";
+  }
+
+  identity prot-otn {
+    base logical-element-protocol-type;
+    description
+      "OTN protocol framing";
+  }
+
+  // typedef statements
+
+  // grouping statements
+
+  // data definition statements
+
+  // augment statements
+
+  // rpc statements
+
+  // notification statements
+
+}

--- a/experimental/openconfig/vlan/openconfig-vlan.yang
+++ b/experimental/openconfig/vlan/openconfig-vlan.yang
@@ -1,0 +1,510 @@
+module openconfig-vlan {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/vlan";
+
+  prefix "vlan";
+
+  // import some basic types
+  import openconfig-interfaces { prefix ocif; }
+  import openconfig-if-ethernet { prefix eth; }
+  import openconfig-if-aggregate { prefix lag; }
+  import iana-if-type { prefix ift; }
+
+
+  // meta
+  organization "OpenConfig working group";
+
+  contact
+    "OpenConfig working group
+    netopenconfig@googlegroups.com";
+
+  description
+    "This module defines configuration and state variables for VLANs,
+    in addition to VLAN parameters associated with interfaces";
+
+  revision "2014-07-07" {
+    description
+      "Initial revision";
+    reference "TBD";
+  }
+
+  // extension statements
+
+  // feature statements
+
+  // identity statements
+
+  // typedef statements
+
+  // TODO: typedefs should be defined in a vlan-types.yang file.
+  typedef vlan-id {
+    type uint16 {
+      range 1..4094;
+    }
+    description
+      "Type definition representing a single-tagged VLAN";
+  }
+
+  typedef vlan-range {
+    type string {
+      // range specified as [lower]..[upper]
+      pattern "(409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"       +
+              "[1-9][0-9]{1,2}|[1-9])\.\.(409[0-4]|"        +
+              "40[0-8][0-9]|[1-3][0-9]{3}|[1-9][0-9]{1,2}|" +
+              "[1-9])";
+    }
+    description
+      "Type definition representing a range of single-tagged
+      VLANs. A range is specified as x..y where x and y are
+      valid VLAN IDs (1 <= vlan-id <= 4094). The range is
+      assumed to be inclusive, such that any VLAN-ID matching
+      x <= VLAN-ID <= y falls within the range.";
+  }
+
+  typedef qinq-id {
+    type string {
+      pattern
+        "(409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"       +
+        "[1-9][0-9]{1,2}|[1-9])\."                    +
+        "((409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"      +
+        "[1-9][0-9]{1,2}|[1-9])|\*)";
+    }
+    description
+      "Type definition representing a single double-tagged/QinQ VLAN
+      identifier. The format of a QinQ VLAN-ID is x.y where X is the
+      'outer' VLAN identifier, and y is the 'inner' VLAN identifier.
+      Both x and y must be valid VLAN IDs (1 <= vlan-id <= 4094)
+      with the exception that y may be equal to a wildcard (*). In
+      cases where y is set to the wildcard, this represents all inner
+      VLAN identifiers where the outer VLAN identifier is equal to
+      x";
+  }
+
+  typedef qinq-id-range {
+    type union {
+      type string {
+        // match cases where the range is specified as x..y.z
+        pattern
+          "(409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"    +
+          "[1-9][0-9]{1,2}|[1-9])\.\."               +
+          "(409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"    +
+          "[1-9][0-9]{1,2}|[1-9])\."                 +
+          "((409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"   +
+          "[1-9][0-9]{1,2}|[1-9])|\*)";
+      }
+      type string {
+        // match cases where the range is specified as x.y..z
+        pattern
+          "(\*|(409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"    +
+          "[1-9][0-9]{1,2}|[1-9]))\."                 +
+          "(409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"    +
+          "[1-9][0-9]{1,2}|[1-9])\.\."               +
+          "(409[0-4]|40[0-8][0-9]|[1-3][0-9]{3}|"    +
+          "[1-9][0-9]{1,2}|[1-9])";
+      }
+    }
+    description
+      "A type definition representing a range of double-tagged/QinQ
+      VLAN identifiers. The format of a QinQ VLAN-ID range can be
+      specified in three formats. Where the range is outer VLAN IDs
+      the range is specified as x..y.z. In this case outer VLAN
+      identifiers meeting the criteria x <= outer-vlan-id <= y are
+      accepted iff the inner VLAN-ID is equal to y - or any inner-tag
+      if the wildcard is specified. Alternatively the range can be
+      specified as x.y..z. In this case only VLANs with an
+      outer-vlan-id qual to x are accepted (x may again be the
+      wildcard). Inner VLANs are accepted if they meet the inequality
+      y <= inner-vlan-id <= z.";
+  }
+
+  typedef vlan-mode-type {
+    type enumeration {
+      enum ACCESS {
+        description "Access mode VLAN interface (No 802.1q header)";
+      }
+      enum TRUNK {
+        description "Trunk mode VLAN interface";
+      }
+    }
+    description
+      "VLAN interface mode (trunk or access)";
+  }
+
+  typedef vlan-ref {
+    type union {
+      type vlan-id;
+      type string;
+      // TODO: string should be changed to leafref to reference
+      // an existing VLAN.  this is not allowed in YANG 1.0 but
+      // is expected to be in YANG 1.1.
+      // type leafref {
+      //  path "vlan:vlans/vlan:vlan/vlan:config/vlan:name";
+      // }
+    }
+    description
+      "Reference to a VLAN by name or id";
+  }
+
+  // grouping statements
+
+  grouping vlan-config {
+    description "VLAN configuration container.";
+
+    leaf vlan-id {
+      type vlan-id;
+      description "Interface VLAN id.";
+    }
+
+    leaf name {
+      type string;
+      description "Interface VLAN name.";
+    }
+
+    leaf status {
+      type enumeration {
+        enum ACTIVE {
+          description "VLAN is active";
+        }
+        enum SUSPENDED {
+          description "VLAN is inactive / suspended";
+        }
+      }
+      default ACTIVE;
+      description "Admin state of the VLAN";
+    }
+
+  }
+
+  grouping vlan-state {
+    description "State variables for VLANs";
+
+    leaf-list member-ports {
+	    type ocif:interface-ref;
+      description
+         "List of current member ports including access ports
+          and trunk ports that support this vlan";
+    }
+  }
+
+  grouping vlan-ethernet-config {
+    description
+      "VLAN related configuration that is part of the physical
+      Ethernet interface.";
+
+    leaf interface-mode {
+        type vlan-mode-type;
+        description "Set the interface to access or trunk mode for
+        VLANs";
+    }
+
+    leaf native-vlan {
+      when "interface-mode = 'TRUNK'" {
+        description
+          "Native VLAN is valid for trunk mode interfaces";
+      }
+      type union {
+        type vlan-id;
+        type qinq-id;
+      }
+      description
+        "Set the native VLAN id for untagged frames arriving on
+        a trunk interface.  This configuration is only valid on
+        a trunk interface.";
+    }
+
+  leaf access-vlan {
+      when "interface-mode = 'ACCESS'" {
+        description
+          "Access VLAN assigned to the interfaces";
+      }
+      type union {
+        type vlan-id;
+        type qinq-id;
+      }
+      description
+        "Assign the access vlan to the access port.";
+    }
+
+    leaf-list trunk-vlans {
+      when "interface-mode = 'TRUNK'" {
+        description
+          "Allowed VLANs may be specified for trunk mode
+          interfaces.";
+      }
+      type union {
+        type vlan-id;
+        type vlan-range;
+        type qinq-id;
+        type qinq-id-range;
+      }
+      description
+        "Specify VLANs, or ranges thereof, that the interface may
+        carry when in trunk mode.  If not specified, all VLANs are
+        allowed on the interface. Ranges are specified in the form
+        x..y, where x<y - ranges are assumed to be inclusive (such
+        that the VLAN range is x <= range <= y.";
+    }
+  }
+
+  grouping vlan-ethernet-state {
+    description
+      "VLAN related operational state that is part of Ethernet
+      interface state data";
+
+    //TODO: placeholder for operational state related to VLANs
+    //on the physical interface
+  }
+
+  grouping vlan-ethernet-top {
+    description
+      "Top-level grouping for VLAN data associated with an
+      Ethernet interface";
+
+    container vlan {
+      description
+        "Enclosing container for VLAN interface-specific
+        data on Ethernet interfaces";
+
+      container config {
+          description "Configuration parameters for VLANs";
+
+          uses vlan-ethernet-config;
+        }
+
+        container state {
+
+          config false;
+          description "State variables for VLANs";
+
+          uses vlan-ethernet-config;
+          uses vlan-ethernet-state;
+        }
+    }
+  }
+
+  grouping vlan-logical-config {
+    description
+      "VLAN related configuration that is part of subinterface
+      (logical interface) configuration";
+
+    choice local-global {
+      description
+        "VLAN may be locally scoped to a subinterface, or reference
+        a globally defined device-wide VLAN.  In the case of local
+        scoping, the VLAN id may be duplicated in multiple
+        subinterfaces.";
+
+      case global {
+
+        leaf global-vlan-id {
+          type vlan-ref;
+          description
+            "VLAN id for the subinterface -- references a global
+            VLAN by name or id.";
+        }
+      }
+
+      case local {
+
+        leaf vlan-id {
+          type union {
+            type vlan-id;
+            type qinq-id;
+          }
+          description
+            "VLAN id for the subinterface -- specified inline for the
+            case of a local VLAN";
+        }
+      }
+    }
+  }
+
+  grouping vlan-logical-state {
+    description
+      "VLAN related operational state that is part of logical
+      interface state data";
+
+    //TODO: placeholder to add VLAN-specific state variables on
+    //the subinterface
+  }
+
+  grouping vlan-top {
+    description "Top-level grouping for VLAN configuration";
+
+    container vlans {
+      description "Container for VLAN configuration and state
+      variables";
+
+      list vlan {
+        key vlan-id;
+
+        description "Configured VLANs keyed by id";
+
+        leaf vlan-id {
+          type leafref {
+            path "/vlan:vlans/vlan:vlan/vlan:config/vlan:vlan-id";
+          }
+          description "references the configured vlan-id";
+        }
+
+        container config {
+          description "Configuration parameters for VLANs";
+
+          uses vlan-config;
+        }
+
+        container state {
+
+          config false;
+          description "State variables for VLANs";
+
+          uses vlan-config;
+          uses vlan-state;
+        }
+      }
+    }
+  }
+
+  grouping vlan-logical-top {
+    description
+      "Top-level grouping for VLAN data associated with a
+      logical interface or subinterface";
+
+    container vlan {
+      description
+        "Enclosing container for VLAN interface-specific
+        data on subinterfaces";
+
+      container config {
+          description "Configuration parameters for VLANs";
+
+          uses vlan-logical-config;
+        }
+
+        container state {
+
+          config false;
+          description "State variables for VLANs";
+
+          uses vlan-logical-config;
+          uses vlan-logical-state;
+        }
+    }
+  }
+
+  grouping vlan-routed-config {
+    description
+      "Configuration data for routed vlans (SVI, IRB, etc.)";
+
+    leaf vlan {
+      type union {
+        // TODO: in YANG 1.1, unions support leafref types which
+        // should be used here to reference a configured VLAN by
+        // id or name
+        type uint16;
+        type string;
+      }
+      description
+        "References the VLAN for which this IP interface
+        provides routing services -- similar to a switch virtual
+        interface (SVI), or integrated routing and bridging interface
+        (IRB) in some implementations.";
+    }
+
+  }
+
+  grouping vlan-routed-state {
+    description
+      "Operational state data for routed vlan interfaces.";
+  }
+
+  grouping vlan-routed-top {
+    description
+      "Top-level grouping for routed vlan logical interfaces";
+
+    container routed-vlan {
+      description
+        "Top-level container for routed vlan interfaces.  These
+        logical interfaces are also known as SVI (switched virtual
+        interface), IRB (integrated routing and bridging), RVI
+        (routed VLAN interface)";
+
+      container config {
+        description
+          "Configuration data for routed vlan interfaces";
+
+        uses vlan-routed-config;
+      }
+
+      container state {
+
+        config false;
+
+        description
+          "Operational state data ";
+
+        uses vlan-routed-config;
+        uses vlan-routed-state;
+      }
+    }
+  }
+
+  // data definition statements
+
+  uses vlan-top;
+
+  // augment statements
+
+  augment "/ocif:interfaces/ocif:interface/ocif:subinterfaces/" +
+    "ocif:subinterface" {
+    //TODO: augmentation path will need to be updated for
+    //full device model
+    description "Adds VLAN settings to individual subinterfaces";
+
+    uses vlan-logical-top;
+  }
+
+  augment "/ocif:interfaces/ocif:interface/eth:ethernet" {
+    //TODO: augmentation path will need to be updated for
+    //full device model
+    when "ocif:type = 'ift:ethernetCsmacd'" {
+      description "Active when the interface is Ethernet";
+    }
+    description "Adds VLAN settings to individual Ethernet
+    interfaces";
+
+    uses vlan-ethernet-top;
+  }
+
+  augment "/ocif:interfaces/ocif:interface/lag:aggregation" {
+    //TODO: augmentation path will need to be updated for
+    //full device model
+    when "ocif:type = 'ift:ieee8023adLag'" {
+      description "Active when the interface is a LAG";
+    }
+    description "Adds VLAN settings to a LAG interface";
+
+    uses vlan-ethernet-top;
+  }
+
+  augment "/ocif:interfaces/ocif:interface" {
+    when "ocif:type = 'ift:l3ipvlan'" {
+      description
+        "Active when the interface is a logical interface providing
+        L3 routing for VLANs";
+    }
+    description
+      "Adds configuration and state for routed VLAN interfaces";
+
+    uses vlan-routed-top;
+  }
+
+
+  // rpc statements
+
+  // notification statements
+
+}


### PR DESCRIPTION
Requesting to merge the initial versions of the OpenConfig models for interfaces and terminal optics.  Please see pyang output below -- namespace warnings are due to use of an pre standards-track ad-hoc namespace per guidelines in RFC 6087/RFC 6020.

```
pyang openconfig-terminal-device.yang -p .. -p ../interfaces/ --strict --ietf

openconfig-terminal-device.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:openconfig-terminal-device"
```

```
pyang --strict ./openconfig-interfaces.yang openconfig-if-ethernet.yang openconfig-if-aggregate.yang openconfig-if-ip.yang ../vlan/openconfig-vlan.yang  -p ../vlan/   --ietf

./openconfig-interfaces.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:openconfig-interfaces"
../vlan/openconfig-vlan.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:openconfig-vlan"
openconfig-if-aggregate.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:openconfig-if-aggregate"
openconfig-if-ethernet.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:openconfig-if-ethernet"
openconfig-if-ip.yang:6: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:openconfig-if-ip"
```