### PR TITLE
Initial version of the BFD and TWAMP YANG model.

### DIFF
--- a/standard/ietf/DRAFT/ietf-bfd.yang
+++ b/standard/ietf/DRAFT/ietf-bfd.yang
@@ -1,0 +1,718 @@
+module ietf-bfd {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-bfd";
+  // replace with IANA namespace when assigned
+  prefix "bfd";
+  import ietf-interfaces {
+    prefix "if";
+  }
+  import ietf-inet-types {
+    prefix "inet";
+  }
+  import ietf-yang-types {
+    prefix "yang";
+  }
+  import ietf-routing {
+    prefix "rt";
+  }
+  organization "IETF BFD Working Group";
+  contact
+    "WG Web:   <http://tools.ietf.org/wg/bfd>
+     WG List:  <rtg-bfd@ietf.org>
+     WG Chair: Jeff Haas
+     WG Chair: Nobo Akiya
+     Editor:   Lianshu Zheng and Reshad Rahman";
+  description
+    "This module contains the YANG definition for BFD parameters as
+     per RFC5880, RFC5881 and RFC5883";
+  revision 2015-07-01 {
+    description "Initial revision.";
+    reference "RFC XXXX: A YANG data model for BFD";
+  }
+  identity bfd {
+    base "rt:routing-protocol";
+    description "BFD protocol";
+  }
+  typedef discriminator {
+    type uint32 {
+      range 1..4294967295;
+    }
+    description "BFD discriminator";
+  }
+  typedef diagnostic {
+    type enumeration {
+      enum none {
+        value 0;
+        description "None";
+      }
+      enum controlExpiry {
+        value 1;
+        description "Control timer expiry";
+      }
+      enum echoFailed {
+        value 2;
+        description "Echo failure";
+      }
+      enum nborDown {
+        value 3;
+        description "Neighbor down";
+      }
+      enum fwdingReset {
+        value 4;
+        description "Forwarding reset";
+      }
+      enum pathDown {
+        value 5;
+        description "Path down";
+      }
+      enum concPathDown {
+        value 6;
+        description "Concatenated path down";
+      }
+      enum adminDown {
+        value 7;
+        description "Admin down";
+      }
+      enum reverseConcPathDown {
+        value 8;
+        description "Reverse concatenated path down";
+      }
+    }
+    description "BFD diagnostic";
+  }
+  typedef state {
+    type enumeration {
+      enum adminDown {
+        value 0;
+        description "admindown";
+      }
+      enum down {
+        value 1;
+        description "down";
+      }
+      enum init {
+        value 2;
+        description "init";
+      }
+      enum up {
+        value 3;
+        description "up";
+      }
+    }
+    description "BFD state";
+  }
+  typedef multiplier {
+    type uint8 {
+      range 1..255;
+    }
+    description "Multiplier";
+  }
+  typedef ttl {
+    type uint8 {
+      range 1..255;
+    }
+    description "Time To Live";
+  }
+  typedef bfd-session-type {
+    type enumeration {
+      enum ip-single-hop {
+        description "IP single hop";
+      }
+      enum ip-multi-hop {
+        description "IP multi hop";
+      }
+      enum te-tunnel {
+        description "Traffic Engineering tunnes";
+      }
+      enum ldp-lsp {
+        description "LDP Label Switched Path";
+      }
+      enum lag {
+        description "Micro-BFD on LAG member links";
+      }
+    }
+    description
+      "BFD session type, this indicates the path type that BFD is
+       running on";
+  }
+  typedef bfd-auth-algorithm {
+    type enumeration {
+      enum simple-password {
+        description
+          "Simple password";
+      }
+      enum keyed-md5 {
+        description
+          "Keyed message Digest 5";
+      }
+      enum meticulous-keyed-md5 {
+        description
+          "Meticulous keyed message Digest 5";
+      }
+      enum keyed-sha-1 {
+        description
+          "Keyed secure hash algorithm (SHA1) ";
+      }
+      enum meticulous-keyed-sha-1 {
+        description
+          "Meticulous keyed secure hash algorithm (SHA1) ";
+      }
+    }
+    description "Authentication algorithm";
+  }
+  feature bfd-interface-config {
+    description "BFD per-interface config supported";
+  }
+  feature bfd-authentication {
+    description "BFD authentication supported";
+  }
+  grouping bfd-grouping-base-cfg-parms {
+    description "BFD grouping for base config parameters";
+    leaf local-multiplier {
+      type multiplier;
+      default 3;
+      description "Multiplier transmitted by local system";
+    }
+    choice interval-config-type {
+      description
+        "Two interval values or 1 value used for both tx and rx";
+      case tx-rx-intervals {
+        leaf desired-min-tx-interval {
+          type uint32;
+          units microseconds;
+          mandatory true;
+          description
+            "Desired minimum transmit interval of control packets";
+        }
+        leaf required-min-rx-interval {
+          type uint32;
+          units microseconds;
+          mandatory true;
+          description
+            "Required minimum receive interval of control packets";
+        }
+      }
+      case single-interval {
+        leaf min-interval {
+          type uint32;
+          units microseconds;
+          mandatory true;
+          description
+            "Desired minimum transmit interval and required " +
+            "minimum receive interval of control packets";
+        }
+      }
+    }
+  }
+  grouping bfd-grouping-common-cfg-parms {
+    description "BFD grouping for common config parameters";
+    uses bfd-grouping-base-cfg-parms;
+    leaf demand-enabled {
+      type boolean;
+      default false;
+      description "To enbale demand mode";
+    }
+    leaf enable-authentication {
+      type boolean;
+      default false;
+      description
+        "If set, the Authentication Section is present and the
+         session is to be authenticated (see RFC5880 section 6.7
+         for details).";
+    }
+    container authentication-parms {
+      if-feature bfd-authentication;
+      description "Parameters for authentication";
+      leaf key-chain-name {
+        type string;
+        must "../algorithm" {
+          error-message
+            "May not be configured without algorithm";
+          description "Requires algorithm";
+        }
+        description
+          "Key chain name";
+      }
+      leaf algorithm {
+        type bfd-auth-algorithm;
+        must "../key-chain" {
+          error-message
+            "May not be configured without key-chain";
+          description "Requires key-chain";
+        }
+        description "Authentication algorithm to be used";
+      }
+    }
+  }
+  grouping bfd-grouping-echo-cfg-parms {
+    description "BFD grouping for echo config parameters";
+    leaf desired-min-echo-tx-interval {
+      type uint32;
+      units microseconds;
+      default 0;
+      description "Desired minumum transmit interval for echo";
+    }
+    leaf required-min-echo-rx-interval {
+      type uint32;
+      units microseconds;
+      default 0;
+      description "Required minimum receive interval for echo";
+    }
+  }
+  grouping bfd-client-base-cfg-parms {
+    description
+      "BFD grouping for base config parameters which could be used
+       by a protocol which is a client of BFD";
+    container bfd-cfg {
+      description "BFD configuration";
+      leaf enabled {
+        type boolean;
+        default false;
+        description "True if BFD is enabled";
+      }
+      uses bfd-grouping-base-cfg-parms;
+    }
+  }
+  grouping bfd-all-session {
+    description "BFD session operational information";
+    leaf session-type {
+      type bfd-session-type;
+      description
+        "BFD session type, this indicates the path type that BFD is
+        running on";
+    }
+    leaf local-discriminator {
+      type discriminator;
+      description "Local discriminator";
+    }
+    leaf remote-discriminator {
+      type discriminator;
+      description "Remote discriminator";
+    }
+    leaf remote-multiplier {
+      type multiplier;
+      description "Remote multiplier";
+    }
+    leaf out-interface {
+      type if:interface-ref;
+      description "Outgoing physical interface name";
+    }
+    leaf demand-capability {
+      type boolean;
+      description "Local demand mode capability";
+    }
+    leaf source-port {
+      type inet:port-number;
+      description "Source UDP port";
+    }
+    leaf dest-port {
+      type inet:port-number;
+      description "Destination UDP port";
+    }
+    list session-running {
+      description "BFD session running information";
+      leaf session-index {
+        type uint32;
+        description
+          "An index used to uniquely identify BFD sessions";
+      }
+      leaf local-state {
+        type state;
+        description "Local state";
+      }
+      leaf remote-state {
+        type state;
+        description "Remote state";
+      }
+      leaf local-diagnostic {
+        type diagnostic;
+        description "Local diagnostic";
+      }
+      leaf remote-diagnostic {
+        type diagnostic;
+        description "Remote diagnostic";
+      }
+      leaf detection-mode {
+        type enumeration {
+          enum async-with-echo {
+            value "1";
+            description "Async with echo";
+          }
+          enum async-without-echo {
+            value "2";
+            description "Async without echo";
+          }
+          enum demand-with-echo {
+            value "3";
+            description "Demand with echo";
+          }
+          enum demand-without-echo {
+            value "4";
+            description "Demand without echo";
+          }
+        }
+        description "Detection mode";
+      }
+      leaf negotiated-tx-interval {
+        type uint32;
+        units microseconds;
+        description "Negotiated transmit interval";
+      }
+      leaf negotiated-rx-interval {
+        type uint32;
+        units microseconds;
+        description "Negotiated receive interval";
+      }
+      leaf negotiated-echo-tx-interval {
+        type uint32;
+        units microseconds;
+        description "Negotiated echo transmit interval";
+      }
+      leaf detection-time {
+        type uint32;
+        units microseconds;
+        description "Detection time";
+      }
+    }
+    list sesssion-statistics {
+      description "BFD session statistics";
+      leaf create-time {
+        type yang:date-and-time;
+        description
+          "Time and date when session was created";
+      }
+      leaf last-down-time {
+        type yang:date-and-time;
+        description
+          "Time and date of last time the session went down";
+      }
+      leaf last-up-time {
+        type yang:date-and-time;
+        description
+          "Time and date of last time the session went up";
+      }
+      leaf down-count {
+        type uint32;
+        description "Session Down Count";
+      }
+      leaf admin-down-count {
+        type uint32;
+        description "Session Admin-Down Count";
+      }
+      leaf receive-packet-count {
+        type uint64;
+        description "Received Packet Count";
+      }
+      leaf send-packet-count {
+        type uint64;
+        description "Sent Packet Count";
+      }
+      leaf receive-bad-packet {
+        type uint64;
+        description "Received bad packet count";
+      }
+      leaf send-failed-packet {
+        type uint64;
+        description "Packet Failed to Send Count";
+      }
+    }
+  }
+  augment "/rt:routing/rt:routing-instance/rt:routing-protocols/"
+    + "rt:routing-protocol" {
+    when "rt:type = 'bfd:bfd'" {
+      description
+        "This augment is only valid for a protocol instance
+        of BFD.";
+    }
+    description "BFD augmentation.";
+    container bfd {
+      description "BFD top-level container";
+      container bfd-cfg {
+        description "BFD configuration";
+        container bfd-session-cfg {
+          description "BFD session configuration";
+          list session-ip-mh {
+            key "source-addr dest-addr";
+            description "List of IP multi-hop sessions";
+            leaf source-addr {
+              type inet:ip-address;
+              description
+                "Local IP address";
+            }
+            leaf dest-addr {
+              type inet:ip-address;
+              description
+                "IP address of the peer";
+            }
+            leaf admin-down {
+              type boolean;
+              default false;
+              description
+                "Is the BFD session administratively down";
+            }
+            uses bfd-grouping-common-cfg-parms;
+            leaf tx-ttl {
+              type ttl;
+              default 255;
+              description "TTL of outgoing BFD control packets";
+            }
+            leaf rx-ttl {
+              type ttl;
+              mandatory true;
+              description
+                "Minimum allowed TTL value for incoming BFD control
+                 packets";
+            }
+          }
+        }
+        list bfd-interface-cfg {
+          if-feature bfd-interface-config;
+          key interface;
+          description "Per-interface BFD configuration";
+          leaf interface {
+            type if:interface-ref;
+            description "Interface";
+          }
+          uses bfd-grouping-common-cfg-parms;
+          uses bfd-grouping-echo-cfg-parms;
+        }
+      }
+      container bfd-oper {
+        config "false";
+        description "BFD operational container";
+        container bfd-session-statistics {
+          description "BFD session counters";
+          leaf ip-sh-session-num {
+            type uint32;
+            description "IP single hop session number";
+          }
+          leaf ip-mh-session-num {
+            type uint32;
+            description "IP multi hop session Number";
+          }
+          leaf total-session-num {
+            type uint32;
+            description "Total session number";
+          }
+          leaf session-up-num {
+            type uint32;
+            description "Session up number";
+          }
+          leaf sess-down-num {
+            type uint32;
+            description "Session down number";
+          }
+          leaf sess-admin-down-num {
+            type uint32;
+            description "Session admin-down number";
+          }
+        }
+        container bfd-session-lists {
+          description
+            "Contains multiple session lists, one per type";
+          list session-ip-sh {
+            key "interface dest-addr";
+            description "BFD IP single-hop sessions";
+            leaf interface {
+              type if:interface-ref;
+              description
+                "Interface on which the BFD session is running.";
+            }
+            leaf dest-addr {
+              type inet:ip-address;
+              description "BFD peer address";
+            }
+            leaf source-addr {
+              type inet:ip-address;
+              description "BFD source address";
+            }
+            uses bfd-all-session;
+          }
+          list session-ip-mh-group {
+            key "source-addr dest-addr";
+            description
+              "BFD IP multi-hop group of sessions. A group of " +
+              "sessions is between 1 source and 1 destination, " +
+              "each session uses a different source UDP port for " +
+              "ECMP.";
+            leaf source-addr {
+              type inet:ip-address;
+              description "BFD source address";
+            }
+            leaf dest-addr {
+              type inet:ip-address;
+              description "BFD peer address";
+            }
+            list session-ip-mh {
+              key "source-port";
+              description
+                "The BFD sessions between a source and a. " +
+                "destination. Source UDP port is unique for " +
+                "each session in the group.";
+              leaf ttl {
+                type ttl;
+                description "TTL of outgoing packets";
+              }
+              uses bfd-all-session;
+            }
+          }
+          list session-te-tunnel {
+            key "tunnel-name";
+            description "BFD over TE tunnel";
+            leaf tunnel-name {
+              type string;
+              description "Name of TE tunnel";
+            }
+            uses bfd-all-session;
+          }
+          list session-ldp-lsp-group {
+            key "ldp-fec";
+            description
+              "BFD over LDP LSP group of sessions. A group of " +
+              "sessions is to one LDP FEC, each session uses a " +
+              "different source UDP port for ECMP.";
+            leaf ldp-fec {
+              type inet:ip-prefix;
+              description "LDP FEC";
+            }
+            list session-ldp-lsp {
+              key "source-port";
+              description
+                "The BFD sessions on an LDP FEC. Source UDP " +
+                "port is unique for each session in the group.";
+              leaf ttl {
+                type ttl;
+                description "TTL of outgoing packets";
+              }
+              uses bfd-all-session;
+            }
+          }
+          list session-lag {
+            key "lag-name";
+            description "A LAG interface on which BFD is running";
+            leaf lag-name {
+              type if:interface-ref ;
+              description "Name of the LAG";
+            }
+            list session-lag-micro {
+            key "member-link";
+              description
+                "Micro-BFD over LAG. This represents BFD " +
+                "over one member link";
+              leaf member-link {
+                type if:interface-ref;
+                description
+                  "Member link on which micro-BFD is running";
+              }
+              uses bfd-all-session;
+            }
+          }
+        }
+      }
+    }
+  }
+  grouping bfd-notification-parms {
+    description
+      "This group describes common parameters that will be sent " +
+      "as part of BFD notification";
+    leaf local-discr {
+      type discriminator;
+      description "BFD local discriminator";
+    }
+    leaf remote-discr {
+      type discriminator;
+      description "BFD remote discriminator";
+    }
+    leaf new-state {
+      type state;
+      description "Current BFD state";
+    }
+    leaf state-change-reason {
+      type string;
+      description "BFD state change reason";
+    }
+    leaf time-in-previous-state {
+      type string;
+      description
+        "How long the BFD session was in the previous state";
+    }
+    leaf dest-addr {
+      type inet:ip-address;
+      description "BFD peer address";
+    }
+    leaf source-addr {
+      type inet:ip-address;
+      description "BFD local address";
+    }
+    leaf session-index {
+      type uint32;
+      description "An index used to uniquely identify BFD sessions";
+    }
+    leaf session-type {
+      type bfd-session-type;
+      description "BFD session type";
+    }
+  }
+  notification bfd-singlehop-notification {
+    description
+      "Notification for BFD single-hop session state change. An " +
+      "implementation may rate-limit notifications, e.g. when a" +
+      "session is continuously changing state.";
+    uses bfd-notification-parms;
+    leaf interface {
+      type if:interface-ref;
+      description "Interface to which this BFD session belongs to";
+    }
+    leaf echo-enabled {
+      type boolean;
+      description "Was echo enabled for BFD";
+    }
+  }
+  notification bfd-multihop-notification {
+    description
+      "Notification for BFD multi-hop session state change. An " +
+      "implementation may rate-limit notifications, e.g. when a" +
+      "session is continuously changing state.";
+    uses bfd-notification-parms;
+  }
+  notification bfd-te-tunnel-notification {
+    description
+      "Notification for BFD over TE tunnel session state change. " +
+      "An implementation may rate-limit notifications, e.g. when a" +
+      "session is continuously changing state.";
+    uses bfd-notification-parms;
+    leaf tunnel-name {
+      type string;
+      description "TE tunnel to which this BFD session belongs to";
+    }
+  }
+  notification bfd-ldp-lsp-notification {
+    description
+      "Notification for BFD over LDP LSP session state change. " +
+      "An implementation may rate-limit notifications, e.g. when a" +
+      "session is continuously changing state.";
+    uses bfd-notification-parms;
+    leaf ldp-fec {
+      type inet:ip-prefix;
+      description "LDP FEC";
+    }
+    leaf source-port {
+      type inet:port-number;
+      description "Source UDP port";
+    }
+  }
+  notification bfd-lag-notification {
+    description
+      "Notification for BFD over LAG session state change. " +
+      "An implementation may rate-limit notifications, e.g. when a" +
+      "session is continuously changing state.";
+    uses bfd-notification-parms;
+    leaf lag-name {
+      type if:interface-ref;
+      description "LAG interface name";
+    }
+    leaf member-link {
+      type if:interface-ref;
+      description "Member link on which BFD is running";
+    }
+  }
+}

--- a/standard/ietf/DRAFT/ietf-bfd.yang
+++ b/standard/ietf/DRAFT/ietf-bfd.yang
@@ -677,8 +677,8 @@ module ietf-bfd {
   notification bfd-te-tunnel-notification {
     description
       "Notification for BFD over TE tunnel session state change. " +
-      "An implementation may rate-limit notifications, e.g. when a" +
-      "session is continuously changing state.";
+      "An implementation may rate-limit notifications, e.g. " +
+      "when a session is continuously changing state.";
     uses bfd-notification-parms;
     leaf tunnel-name {
       type string;
@@ -688,8 +688,8 @@ module ietf-bfd {
   notification bfd-ldp-lsp-notification {
     description
       "Notification for BFD over LDP LSP session state change. " +
-      "An implementation may rate-limit notifications, e.g. when a" +
-      "session is continuously changing state.";
+      "An implementation may rate-limit notifications, e.g. " +
+      "when a session is continuously changing state.";
     uses bfd-notification-parms;
     leaf ldp-fec {
       type inet:ip-prefix;
@@ -703,8 +703,8 @@ module ietf-bfd {
   notification bfd-lag-notification {
     description
       "Notification for BFD over LAG session state change. " +
-      "An implementation may rate-limit notifications, e.g. when a" +
-      "session is continuously changing state.";
+      "An implementation may rate-limit notifications, e.g. " +
+      "when a session is continuously changing state.";
     uses bfd-notification-parms;
     leaf lag-name {
       type if:interface-ref;

--- a/standard/ietf/DRAFT/ietf-twamp.yang
+++ b/standard/ietf/DRAFT/ietf-twamp.yang
@@ -1,0 +1,699 @@
+module ietf-twamp {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-twamp";
+   //namespace need to be assigned by IANA
+  prefix "ietf-twamp";
+  import ietf-inet-types {
+    prefix inet;
+  }
+  organization "IETF IPPM (IP Performance Metrics) Working Group";
+  contact "draft-cmzrjp-ippm-twamp-yang@tools.ietf.org";
+  description "TWAMP Data Model";
+  revision "2015-06-30" {
+    description "01 version. RFC5357, RFC5618, RFC5938 and RFC6038
+    is covered. draft-ietf-ippm-metric-registry is also considered";
+  reference "draft-cmzrjp-ippm-twamp-yang";
+  }
+  feature control-client {
+    description "This feature relates to the device functions as
+    the TWAMP Control-Client.";
+  }
+  feature server {
+    description "This feature relates to the device functions as
+    the TWAMP Server.";
+  }
+  feature session-sender {
+    description "This feature relates to the device functions as
+    the TWAMP Session-Sender.";
+  }
+  feature session-reflector {
+    description "This feature relates to the device functions as
+    the TWAMP Session-Reflector.";
+  }
+  typedef ctrl-connection-state {
+    type enumeration {
+      enum active {
+        description "Control session is active.";
+      }
+      enum idle {
+        description "Control session is idle.";
+      }
+    }
+    description "Control connection state";
+  }
+  typedef mode {
+    type bits {
+      bit unauthenticated {
+        position "0";
+        description "Unauthenticated";
+      }
+      bit authenticated {
+        position "1";
+        description "Authenticated";
+      }
+      bit encrypted {
+        position "2";
+        description "Encrypted";
+      }
+      bit unauth-test-encrpyt-control {
+        position "3";
+        description "Mixed Security Mode per RFC 5618. Test
+        protocol security mode in Unauthenticated mode,
+        Control protocol in Encrypted mode.";
+      }
+      bit individual-session-control {
+        position "4";
+        description "Individual session control per RFC5938.";
+      }
+      bit reflect-octets {
+        position "5";
+        description "Reflect octets capability per RFC6038.";
+      }
+      bit symmetrical-size {
+        position "6";
+        description "Symmetrical size per RFC6038.";
+      }
+    }
+    description "Authentication mode bit mask";
+  }
+  typedef test-session-state {
+    type enumeration {
+      enum ok {
+        value 0;
+        description "Test session is accepted.";
+      }
+      enum failed {
+        value 1;
+        description "Failure, reason unspecified (catch-all).";
+      }
+      enum internal-error {
+        value 2;
+        description "Internal error.";
+      }
+      enum not-supported {
+        value 3;
+        description "Some aspect of request is not supported.";
+      }
+      enum permanent-resource-limit {
+        value 4;
+        description "Cannot perform request due to
+        permanent resource limitations.";
+      }
+      enum temp-resource-limit {
+        value 5;
+        description "Cannot perform request due to
+        temporary resource limitations.";
+      }
+    }
+    description "Test session state";
+  }
+  typedef server-ctrl-connection-state {
+    type enumeration {
+      enum "active" {
+        description "Active";
+      }
+      enum "servwait" {
+        description "Servwait";
+      }
+    }
+    description "Server control connection state";
+  }
+  typedef fill-mode {
+    type enumeration {
+      enum zero {
+        description "Zero";
+      }
+      enum random {
+        description "Random";
+      }
+    }
+    description "Indicates whether the padding added to the
+    UDP test packets will contain pseudo-random numbers, or
+    whether it should consist of all zeroes.";
+  }
+  typedef units  {
+    type enumeration {
+      enum seconds {
+        description "Seconds";
+      }
+      enum milliseconds {
+        description "Milliseconds";
+      }
+      enum microseconds {
+        description "Microseconds";
+      }
+      enum nanoseconds {
+        description "Nanoseconds";
+      }
+    }
+    description "Time units";
+  }
+  typedef sender-session-state {
+    type enumeration {
+      enum setup {
+        description "Test session is active.";
+      }
+      enum failure {
+        description "Test session is idle.";
+      }
+    }
+    description "Sender session state.";
+  }
+  grouping maintenance-statistics {
+    description "Maintenance statistics grouping";
+    leaf sent-packets {
+      type uint32;
+      config "false";
+      description "Packets sent";
+    }
+    leaf rcv-packets {
+      type uint32;
+      config "false";
+      description "Packets received";
+    }
+    leaf last-sent-seq {
+      type uint32;
+      config "false";
+      description "Last sent sequence number";
+    }
+    leaf last-rcv-seq {
+      type uint32;
+      config "false";
+      description "Last received sequence number";
+    }
+  }
+  container twamp {
+    description "Top level container";
+    container twamp-client {
+      if-feature control-client;
+      presence "twamp-client";
+      description "Twamp client container";
+      leaf client-admin-state {
+        type boolean;
+        mandatory "true";
+        description "Indicates whether this device is allowed to run
+        TWAMP to initiate control/test sessions";
+      }
+      list mode-preference-chain {
+        key "priority";
+        unique "mode";
+        leaf priority {
+          type uint16;
+          description "priority";
+        }
+        leaf mode {
+          type mode;
+          description "Authentication mode bit mask";
+        }
+        description "Authentication mode preference";
+      }
+      list key-chain {
+        key "key-id";
+        leaf key-id {
+          type string {
+            length "1..80";
+          }
+          description "Key ID";
+        }
+        leaf secret-key {
+          type string;
+          description "Secret key";
+        }
+        description "Key chain";
+      }
+      list twamp-client-ctrl-connection {
+        key "ctrl-connection-name";
+        description "Twamp client control connections";
+        leaf ctrl-connection-name {
+          type string;
+          description "A unique name used as a key to identify this
+            individual TWAMP control connection on the
+            Control-Client device.";
+        }
+        leaf client-ip {
+          type inet:ip-address;
+          description "Client IP address";
+        }
+        leaf server-ip {
+          type inet:ip-address;
+          mandatory "true";
+          description "Server IP address";
+        }
+        leaf server-tcp-port {
+          type inet:port-number;
+          default "862";
+          description "Server tcp port";
+        }
+        leaf dscp{
+          type inet:dscp;
+          default "0";
+          description "The DSCP value to be placed in the IP header
+            of the TWAMP TCP Control packets generated
+            by the Control-Client";
+        }
+        leaf key-id {
+          type string {
+            length "1..80";
+          }
+          description "Key ID";
+        }
+        leaf max-count {
+          type uint32 {
+            range 1024..4294967295;
+          }
+          default 32768;
+          description "Max count value.";
+        }
+        leaf client-tcp-port {
+          type inet:port-number;
+          config "false";
+          description "Client TCP port";
+        }
+        leaf server-start-time {
+          type uint64;
+          config "false";
+          description "The Start-Time advertized by the Server in
+          the Server-Start message";
+        }
+        leaf ctrl-connection-state {
+          type ctrl-connection-state;
+          config "false";
+          description "Control connection state";
+        }
+        leaf selected-mode {
+          type mode;
+          config "false";
+          description "The TWAMP mode that the Control-Client has
+          chosen for this control connection as set in the Mode
+          field of the Set-Up-Response message";
+        }
+        leaf token {
+            type binary {
+            length "64";
+          }
+          config "false";
+          description "64 octets, containing the concatenation of a
+            16-octet challenge, a 16-octet AES Session-key used
+            for encryption, and a 32-octet HMAC-SHA1 Session-key
+            used for authentication";
+        }
+        leaf client-iv{
+          type binary {
+            length "16";
+          }
+          config "false";
+          description "16 octets, Client-IV is generated randomly
+            by the Control-Client.";
+        }
+        list twamp-session-request {
+          key "test-session-name";
+          description "Twamp session requests";
+          leaf test-session-name {
+            type string;
+            description "A unique name for this test session to be
+            used as a key for this test session on the
+            Control-Client.";
+          }
+          leaf sender-ip {
+            type inet:ip-address;
+            description "Sender IP address";
+          }
+          leaf sender-udp-port {
+            type inet:port-number;
+            description "Sender UDP port";
+          }
+          leaf reflector-ip {
+            type inet:ip-address;
+            mandatory "true";
+            description "Reflector IP address.";
+          }
+          leaf reflector-udp-port {
+            type inet:port-number;
+            description "Reflector UDP port. If this value is not
+            set, the device shall use the same port number as
+            defined in the server-tcp-port parameter of this
+            twamp-session-request's
+            parent client-control-connection.";
+          }
+          leaf timeout {
+            type uint64;
+            default "2";
+            description "The time (in seconds)Session-Reflector MUST
+            wait after receiving a Stop-Session message.";
+          }
+          leaf padding-length {
+            type uint32{
+              range "64..4096";
+            }
+            description "The number of bytes of padding that should
+                be added to the UDP test packets generated by the
+                sender. Jumbo sized packets supported.";
+          }
+          leaf dscp {
+            type inet:dscp;
+            description "The DSCP value to be placed in the UDP
+            header of TWAMP-Test packets generated by the
+            Session-Sender, and in the UDP header of the TWAMP-Test
+            response packets generated by the Session-Reflector
+            for this test session.";
+          }
+          leaf start-time {
+            type uint64;
+            default "0";
+            description "Time when the session is to be started
+            (but not before the Start-Sessions command is issued).
+            This value is placed in the Start Time field of the
+            Request-TW-Session message. The default value of 0
+            indicates that the session will be started as soon
+            as the Start-Sessions message is received.";
+          }
+          leaf repeat {
+            type boolean;
+            default "false";
+            description "If the test session is to be run repeatedly.
+            The default value of repeat is False, indicating that
+            once the session has completed, it will not be
+            renegotiated and restarted";
+          }
+          leaf repeat-interval  {
+            when "../repeat='true'" {
+              description "When repeat is true";
+            }
+            type uint32;
+            description "Repeat interval (in minutes)";
+          }
+          list pm-reg-list {
+            key "pm-index";
+            leaf pm-index {
+              type uint16;
+              description "One or more Numerical index values of a
+              Registered Metric in the Performance Metric Registry";
+            }
+            description "A list of one or more pm-index values,
+            which communicate packet stream characteristics and one
+            or more metrics to be measured.";
+          }
+          leaf test-session-state {
+            type test-session-state;
+            config "false";
+            description "Test session state";
+          }
+          leaf sid{
+            type string;
+            config "false";
+            description "The SID allocated by the Server for
+            this test session";
+          }
+        }
+      }
+    }
+    container twamp-server{
+      if-feature server;
+      presence "twamp-server";
+      description "Twamp sever container";
+      leaf server-admin-state{
+        type boolean;
+        mandatory "true";
+        description "Indicates whether this device is allowed to run
+          TWAMP to respond to control/test sessions";
+      }
+      leaf server-tcp-port {
+        type inet:port-number;
+        default "862";
+        description "This parameter defines the well known TCP port
+        number that is used by TWAMP.";
+      }
+      leaf servwait {
+        type uint32 {
+          range 1..604800;
+        }
+        default 900;
+        description "SERVWAIT (TWAMP Control (TCP) session timeout),
+          default value is 900";
+      }
+      leaf dscp {
+        type inet:dscp;
+        description "The DSCP value to be placed in the IP header of
+        TCP TWAMP-Control packets generated by the Server";
+      }
+      leaf count {
+        type uint32 {
+          range 1024..4294967295;
+        }
+        description "Parameter used in deriving a key from a
+        shared secret ";
+      }
+      leaf max-count {
+        type uint32 {
+          range 1024..4294967295;
+        }
+        default 32768;
+        description "Max count value.";
+      }
+      leaf modes {
+        type mode;
+        description "The bit mask of TWAMP Modes this Server
+        instance is willing to support.";
+      }
+      list key-chain {
+        key "key-id";
+        leaf key-id {
+          type string {
+            length "1..80";
+          }
+          description "Key IDs.";
+        }
+        leaf secret-key {
+          type string;
+          description "Secret keys.";
+        }
+        description "KeyIDs with the respective secret keys.";
+      }
+      list twamp-server-ctrl-connection {
+        key "client-ip client-tcp-port server-ip server-tcp-port";
+        config "false";
+        description "Twamp server control connections";
+        leaf client-ip {
+          type inet:ip-address;
+          description "Client IP address";
+        }
+        leaf client-tcp-port {
+          type inet:port-number;
+          description "Client TCP port";
+        }
+        leaf server-ip {
+          type inet:ip-address;
+          description "Server IP address";
+        }
+        leaf server-tcp-port {
+          type inet:port-number;
+          description "Server TCP port";
+        }
+        leaf server-ctrl-connection-state {
+          type server-ctrl-connection-state;
+          description "Server control connection state";
+        }
+        leaf dscp {
+          type inet:dscp;
+          description "The DSCP value used in the IP header of the
+          TCP control packets sent by the Server for this control
+          connection. This will usually be the same value as is
+          configured for twamp-server:dscp under the twamp-server.
+          However, in the event that the user re-configures
+          twamp-server:dscp after this control connection is already
+          in progress, this read-only value will show the actual
+          dscp value in use by this control connection.";
+        }
+        leaf selected-mode {
+          type mode;
+          description "The mode that was chosen for this control
+          connection as set in the Mode field of the
+          Set-Up-Response message.";
+        }
+        leaf key-id {
+          type string {
+            length "1..80";
+          }
+          description "The key-id value that is in use by this
+                  control connection.";
+        }
+        leaf count {
+          type uint32 {
+            range 1024..4294967295;
+          }
+          description "The count value that is in use by this control
+            connection. This will usually be the same value as is
+            configured under twamp-server. However, in the event that
+            the user re-configured twamp-server:count after this
+            control connection is already in progress, this read-only
+            value will show the different count that is in use for
+            this control connection.";
+        }
+        leaf max-count {
+          type uint32 {
+            range 1024..4294967295;
+          }
+          description "The max-count value that is in use by this
+            control connection. This will usually be the same value
+            as is configured under twamp-server. However, in the
+            event that the user re-configured twamp-server:max-count
+            after this control connection is already in progress,
+            this read-only value will show the different max-count
+            that is in use for this control connection.";
+        }
+        leaf salt{
+          type binary {
+            length "16";
+          }
+          description "Salt MUST be generated pseudo-randomly";
+        }
+        leaf server-iv {
+          type binary {
+            length "16";
+          }
+          description "16 octets, Server-IV is generated randomly
+          by the Control-Client.";
+        }
+        leaf challenge {
+          type binary {
+            length "16";
+          }
+          description "Challenge is a random sequence of octets
+          generated by the Server";
+        }
+      }
+    }
+    container twamp-session-sender{
+      if-feature session-sender;
+      description "Twamp session sender container";
+      list twamp-sender-test-session{
+        key "test-session-name";
+        description "Twamp sender test sessions";
+        leaf test-session-name {
+          type string;
+          description "A unique name for this test session to be
+          used as a key for this test session by the Session-Sender
+          logical entity.";
+        }
+        leaf ctrl-connection-name {
+          type string;
+          config "false";
+          description "The name of the parent control connection
+          that is responsible for negotiating this test session.";
+        }
+        leaf fill-mode {
+          type fill-mode;
+          default zero;
+          description "Indicates whether the padding added to the
+          UDP test packets will contain pseudo-random numbers, or
+          whether it should consist of all zeroes.";
+        }
+        leaf number-of-packets {
+          type uint32;
+          description "The overall number of UDP test packets to be
+            transmitted by the sender for this test session.";
+        }
+        choice packet-distribution {
+          description "Packet distributions, poisson or periodic";
+          case periodic {
+            leaf periodic-interval {
+              type uint32;
+              description "Periodic interval";
+            }
+            leaf periodic-interval-units  {
+              type units;
+              description "Periodic interval units";
+            }
+          }
+          case poisson {
+            leaf lambda{
+              type uint32;
+              description "The average rate of
+                          packet transmission.";
+            }
+            leaf lambda-units{
+              type uint32;
+              description "Lambda units.";
+            }
+            leaf max-interval{
+              type uint32;
+              description "maximum time between packet
+              transmissions.";
+            }
+            leaf truncation-point-units{
+              type units;
+              description "Truncation point units";
+            }
+          }
+        }
+        leaf sender-session-state {
+          type sender-session-state;
+          config "false";
+          description "Sender session state.";
+        }
+        uses maintenance-statistics;
+      }
+    }
+    container twamp-session-reflector {
+      if-feature session-reflector;
+      description "Twamp session reflector container";
+      leaf refwait {
+        type uint32 {
+          range 1..604800;
+        }
+        default 900;
+        description "REFWAIT (TWAMP test session timeout),
+          the default value is 900";
+      }
+      list twamp-reflector-test-session {
+        key "sender-ip sender-udp-port reflector-ip
+            reflector-udp-port";
+        config "false";
+        description "Twamp reflector test sessions";
+        leaf sid{
+          type string;
+          description "An auto-allocated identifier for this test
+          session, that is unique within the context of this
+          Server/Session-Reflector device only. ";
+        }
+        leaf sender-ip {
+          type inet:ip-address;
+          description "Sender IP address.";
+        }
+        leaf sender-udp-port {
+          type inet:port-number;
+          description "Sender UDP port.";
+        }
+        leaf reflector-ip {
+          type inet:ip-address;
+          description "Reflector IP address.";
+        }
+        leaf reflector-udp-port {
+          type inet:port-number;
+          description "Reflector UDP port.";
+        }
+        leaf parent-connection-client-ip {
+          type inet:ip-address;
+          description "Parent connction client IP address.";
+        }
+        leaf parent-connection-client-tcp-port {
+          type inet:port-number;
+          description "Parent connection client TCP port.";
+        }
+        leaf parent-connection-server-ip {
+          type inet:ip-address;
+          description "Parent connection server IP address.";
+        }
+        leaf parent-connection-server-tcp-port {
+          type inet:port-number;
+          description "Parent connection server TCP port";
+        }
+        leaf dscp {
+          type inet:dscp;
+          description "The DSCP value present in the IP header of
+          TWAMP UDP test packets belonging to this test session.";
+        }
+        uses maintenance-statistics;
+      }
+    }
+  }
+}


### PR DESCRIPTION
And here is the tree diagram for the model.

module: ietf-bfd
augment /rt:routing/rt:routing-instance/rt:routing-protocols/rt:routing-protocol:
   +--rw bfd
      +--rw bfd-cfg
      |  +--rw bfd-session-cfg
      |  |  +--rw session-ip-mh* [source-addr dest-addr]
      |  |     +--rw source-addr                 inet:ip-address
      |  |     +--rw dest-addr                   inet:ip-address
      |  |     +--rw admin-down?                 boolean
      |  |     +--rw local-multiplier?           multiplier
      |  |     +--rw (interval-config-type)?
      |  |     |  +--:(tx-rx-intervals)
      |  |     |  |  +--rw desired-min-tx-interval     uint32
      |  |     |  |  +--rw required-min-rx-interval    uint32
      |  |     |  +--:(single-interval)
      |  |     |     +--rw min-interval                uint32
      |  |     +--rw demand-enabled?             boolean
      |  |     +--rw enable-authentication?      boolean
      |  |     +--rw authentication-parms {bfd-authentication}?
      |  |     |  +--rw key-chain-name?   string
      |  |     |  +--rw algorithm?        bfd-auth-algorithm
      |  |     +--rw tx-ttl?                     ttl
      |  |     +--rw rx-ttl                      ttl
      |  +--rw bfd-interface-cfg* [interface] {bfd-interface-config}?
      |     +--rw interface                        if:interface-ref
      |     +--rw local-multiplier?                multiplier
      |     +--rw (interval-config-type)?
      |     |  +--:(tx-rx-intervals)
      |     |  |  +--rw desired-min-tx-interval          uint32
      |     |  |  +--rw required-min-rx-interval         uint32
      |     |  +--:(single-interval)
      |     |     +--rw min-interval                     uint32
      |     +--rw demand-enabled?                  boolean
      |     +--rw enable-authentication?           boolean
      |     +--rw authentication-parms {bfd-authentication}?
      |     |  +--rw key-chain-name?   string
      |     |  +--rw algorithm?        bfd-auth-algorithm
      |     +--rw desired-min-echo-tx-interval?    uint32
      |     +--rw required-min-echo-rx-interval?   uint32
      +--ro bfd-oper
         +--ro bfd-session-statistics
         |  +--ro ip-sh-session-num?     uint32
         |  +--ro ip-mh-session-num?     uint32
         |  +--ro total-session-num?     uint32
         |  +--ro session-up-num?        uint32
         |  +--ro sess-down-num?         uint32
         |  +--ro sess-admin-down-num?   uint32
         +--ro bfd-session-lists
            +--ro session-ip-sh* [interface dest-addr]
            |  +--ro interface               if:interface-ref
            |  +--ro dest-addr               inet:ip-address
            |  +--ro source-addr?            inet:ip-address
            |  +--ro session-type?           bfd-session-type
            |  +--ro local-discriminator?    discriminator
            |  +--ro remote-discriminator?   discriminator
            |  +--ro remote-multiplier?      multiplier
            |  +--ro out-interface?          if:interface-ref
            |  +--ro demand-capability?      boolean
            |  +--ro source-port?            inet:port-number
            |  +--ro dest-port?              inet:port-number
            |  +--ro session-running*
            |  |  +--ro session-index?                 uint32
            |  |  +--ro local-state?                   state
            |  |  +--ro remote-state?                  state
            |  |  +--ro local-diagnostic?              diagnostic
            |  |  +--ro remote-diagnostic?             diagnostic
            |  |  +--ro detection-mode?                enumeration
            |  |  +--ro negotiated-tx-interval?        uint32
            |  |  +--ro negotiated-rx-interval?        uint32
            |  |  +--ro negotiated-echo-tx-interval?   uint32
            |  |  +--ro detection-time?                uint32
            |  +--ro sesssion-statistics*
            |     +--ro create-time?            yang:date-and-time
            |     +--ro last-down-time?         yang:date-and-time
            |     +--ro last-up-time?           yang:date-and-time
            |     +--ro down-count?             uint32
            |     +--ro admin-down-count?       uint32
            |     +--ro receive-packet-count?   uint64
            |     +--ro send-packet-count?      uint64
            |     +--ro receive-bad-packet?     uint64
            |     +--ro send-failed-packet?     uint64
            +--ro session-ip-mh-group* [source-addr dest-addr]
            |  +--ro source-addr      inet:ip-address
            |  +--ro dest-addr        inet:ip-address
            |  +--ro session-ip-mh* [source-port]
            |     +--ro ttl?                    ttl
            |     +--ro session-type?           bfd-session-type
            |     +--ro local-discriminator?    discriminator
            |     +--ro remote-discriminator?   discriminator
            |     +--ro remote-multiplier?      multiplier
            |     +--ro out-interface?          if:interface-ref
            |     +--ro demand-capability?      boolean
            |     +--ro source-port             inet:port-number
            |     +--ro dest-port?              inet:port-number
            |     +--ro session-running*
            |     |  +--ro session-index?                 uint32
            |     |  +--ro local-state?                   state
            |     |  +--ro remote-state?                  state
            |     |  +--ro local-diagnostic?              diagnostic
            |     |  +--ro remote-diagnostic?             diagnostic
            |     |  +--ro detection-mode?                enumeration
            |     |  +--ro negotiated-tx-interval?        uint32
            |     |  +--ro negotiated-rx-interval?        uint32
            |     |  +--ro negotiated-echo-tx-interval?   uint32
            |     |  +--ro detection-time?                uint32
            |     +--ro sesssion-statistics*
            |        +--ro create-time?            yang:date-and-time
            |        +--ro last-down-time?         yang:date-and-time
            |        +--ro last-up-time?           yang:date-and-time
            |        +--ro down-count?             uint32
            |        +--ro admin-down-count?       uint32
            |        +--ro receive-packet-count?   uint64
            |        +--ro send-packet-count?      uint64
            |        +--ro receive-bad-packet?     uint64
            |        +--ro send-failed-packet?     uint64
            +--ro session-te-tunnel* [tunnel-name]
            |  +--ro tunnel-name             string
            |  +--ro session-type?           bfd-session-type
            |  +--ro local-discriminator?    discriminator
            |  +--ro remote-discriminator?   discriminator
            |  +--ro remote-multiplier?      multiplier
            |  +--ro out-interface?          if:interface-ref
            |  +--ro demand-capability?      boolean
            |  +--ro source-port?            inet:port-number
            |  +--ro dest-port?              inet:port-number
            |  +--ro session-running*
            |  |  +--ro session-index?                 uint32
            |  |  +--ro local-state?                   state
            |  |  +--ro remote-state?                  state
            |  |  +--ro local-diagnostic?              diagnostic
            |  |  +--ro remote-diagnostic?             diagnostic
            |  |  +--ro detection-mode?                enumeration
            |  |  +--ro negotiated-tx-interval?        uint32
            |  |  +--ro negotiated-rx-interval?        uint32
            |  |  +--ro negotiated-echo-tx-interval?   uint32
            |  |  +--ro detection-time?                uint32
            |  +--ro sesssion-statistics*
            |     +--ro create-time?            yang:date-and-time
            |     +--ro last-down-time?         yang:date-and-time
            |     +--ro last-up-time?           yang:date-and-time
            |     +--ro down-count?             uint32
            |     +--ro admin-down-count?       uint32
            |     +--ro receive-packet-count?   uint64
            |     +--ro send-packet-count?      uint64
            |     +--ro receive-bad-packet?     uint64
            |     +--ro send-failed-packet?     uint64
            +--ro session-ldp-lsp-group* [ldp-fec]
            |  +--ro ldp-fec            inet:ip-prefix
            |  +--ro session-ldp-lsp* [source-port]
            |     +--ro ttl?                    ttl
            |     +--ro session-type?           bfd-session-type
            |     +--ro local-discriminator?    discriminator
            |     +--ro remote-discriminator?   discriminator
            |     +--ro remote-multiplier?      multiplier
            |     +--ro out-interface?          if:interface-ref
            |     +--ro demand-capability?      boolean
            |     +--ro source-port             inet:port-number
            |     +--ro dest-port?              inet:port-number
            |     +--ro session-running*
            |     |  +--ro session-index?                 uint32
            |     |  +--ro local-state?                   state
            |     |  +--ro remote-state?                  state
            |     |  +--ro local-diagnostic?              diagnostic
            |     |  +--ro remote-diagnostic?             diagnostic
            |     |  +--ro detection-mode?                enumeration
            |     |  +--ro negotiated-tx-interval?        uint32
            |     |  +--ro negotiated-rx-interval?        uint32
            |     |  +--ro negotiated-echo-tx-interval?   uint32
            |     |  +--ro detection-time?                uint32
            |     +--ro sesssion-statistics*
            |        +--ro create-time?            yang:date-and-time
            |        +--ro last-down-time?         yang:date-and-time
            |        +--ro last-up-time?           yang:date-and-time
            |        +--ro down-count?             uint32
            |        +--ro admin-down-count?       uint32
            |        +--ro receive-packet-count?   uint64
            |        +--ro send-packet-count?      uint64
            |        +--ro receive-bad-packet?     uint64
            |        +--ro send-failed-packet?     uint64
            +--ro session-lag* [lag-name]
               +--ro lag-name             if:interface-ref
               +--ro session-lag-micro* [member-link]
                  +--ro member-link             if:interface-ref
                  +--ro session-type?           bfd-session-type
                  +--ro local-discriminator?    discriminator
                  +--ro remote-discriminator?   discriminator
                  +--ro remote-multiplier?      multiplier
                  +--ro out-interface?          if:interface-ref
                  +--ro demand-capability?      boolean
                  +--ro source-port?            inet:port-number
                  +--ro dest-port?              inet:port-number
                  +--ro session-running*
                  |  +--ro session-index?                 uint32
                  |  +--ro local-state?                   state
                  |  +--ro remote-state?                  state
                  |  +--ro local-diagnostic?              diagnostic
                  |  +--ro remote-diagnostic?             diagnostic
                  |  +--ro detection-mode?                enumeration
                  |  +--ro negotiated-tx-interval?        uint32
                  |  +--ro negotiated-rx-interval?        uint32
                  |  +--ro negotiated-echo-tx-interval?   uint32
                  |  +--ro detection-time?                uint32
                  +--ro sesssion-statistics*
                     +--ro create-time?            yang:date-and-time
                     +--ro last-down-time?         yang:date-and-time
                     +--ro last-up-time?           yang:date-and-time
                     +--ro down-count?             uint32
                     +--ro admin-down-count?       uint32
                     +--ro receive-packet-count?   uint64
                     +--ro send-packet-count?      uint64
                     +--ro receive-bad-packet?     uint64
                     +--ro send-failed-packet?     uint64
notifications:
   +---n bfd-singlehop-notification
   |  +--ro local-discr?              discriminator
   |  +--ro remote-discr?             discriminator
   |  +--ro new-state?                state
   |  +--ro state-change-reason?      string
   |  +--ro time-in-previous-state?   string
   |  +--ro dest-addr?                inet:ip-address
   |  +--ro source-addr?              inet:ip-address
   |  +--ro session-index?            uint32
   |  +--ro session-type?             bfd-session-type
   |  +--ro interface?                if:interface-ref
   |  +--ro echo-enabled?             boolean
   +---n bfd-multihop-notification
   |  +--ro local-discr?              discriminator
   |  +--ro remote-discr?             discriminator
   |  +--ro new-state?                state
   |  +--ro state-change-reason?      string
   |  +--ro time-in-previous-state?   string
   |  +--ro dest-addr?                inet:ip-address
   |  +--ro source-addr?              inet:ip-address
   |  +--ro session-index?            uint32
   |  +--ro session-type?             bfd-session-type
   +---n bfd-te-tunnel-notification
   |  +--ro local-discr?              discriminator
   |  +--ro remote-discr?             discriminator
   |  +--ro new-state?                state
   |  +--ro state-change-reason?      string
   |  +--ro time-in-previous-state?   string
   |  +--ro dest-addr?                inet:ip-address
   |  +--ro source-addr?              inet:ip-address
   |  +--ro session-index?            uint32
   |  +--ro session-type?             bfd-session-type
   |  +--ro tunnel-name?              string
   +---n bfd-ldp-lsp-notification
   |  +--ro local-discr?              discriminator
   |  +--ro remote-discr?             discriminator
   |  +--ro new-state?                state
   |  +--ro state-change-reason?      string
   |  +--ro time-in-previous-state?   string
   |  +--ro dest-addr?                inet:ip-address
   |  +--ro source-addr?              inet:ip-address
   |  +--ro session-index?            uint32
   |  +--ro session-type?             bfd-session-type
   |  +--ro ldp-fec?                  inet:ip-prefix
   |  +--ro source-port?              inet:port-number
   +---n bfd-lag-notification
      +--ro local-discr?              discriminator
      +--ro remote-discr?             discriminator
      +--ro new-state?                state
      +--ro state-change-reason?      string
      +--ro time-in-previous-state?   string
      +--ro dest-addr?                inet:ip-address
      +--ro source-addr?              inet:ip-address
      +--ro session-index?            uint32
      +--ro session-type?             bfd-session-type
      +--ro lag-name?                 if:interface-ref
      +--ro member-link?              if:interface-ref