### PR TITLE
Comment out all require-instance properties

### DIFF
--- a/experimental/openconfig/bgp/bgp-policy.yang
+++ b/experimental/openconfig/bgp/bgp-policy.yang
@@ -129,7 +129,9 @@ module bgp-policy {
           path "/rpol:routing-policy/rpol:defined-sets/" +
             "bgp-pol:bgp-defined-sets/bgp-pol:community-sets/" +
             "bgp-pol:community-set/bgp-pol:community-set-name";
-          require-instance true;
+          //TODO: require-instance should be added when it's
+          //supported in YANG 1.1
+          //require-instance true;
         }
         description
           "References a defined community set";
@@ -152,7 +154,9 @@ module bgp-policy {
             "bgp-pol:bgp-defined-sets/bgp-pol:ext-community-sets/" +
             "bgp-pol:ext-community-set/" +
             "bgp-pol:ext-community-set-name";
-          require-instance true;
+          //TODO: require-instance should be added when it's
+          //supported in YANG 1.1
+          //require-instance true;
         }
         description "References a defined extended community set";
       }
@@ -173,7 +177,9 @@ module bgp-policy {
           path "/rpol:routing-policy/rpol:defined-sets/" +
             "bgp-pol:bgp-defined-sets/bgp-pol:as-path-sets/" +
             "bgp-pol:as-path-set/bgp-pol:as-path-set-name";
-          require-instance true;
+          //TODO: require-instance should be added when it's
+          //supported in YANG 1.1
+          //require-instance true;
         }
         description "References a defined AS path set";
       }
@@ -423,7 +429,9 @@ module bgp-policy {
                   "bgp-pol:bgp-defined-sets/" +
                   "bgp-pol:community-sets/bgp-pol:community-set/" +
                   "bgp-pol:community-set-name";
-                require-instance true;
+                //TODO: require-instance should be added when it's
+                //supported in YANG 1.1
+                //require-instance true;
               }
               description
                 "References a defined community set by name";
@@ -472,7 +480,9 @@ module bgp-policy {
                   "bgp-pol:ext-community-sets/" +
                   "bgp-pol:ext-community-set/" +
                   "bgp-pol:ext-community-set-name";
-                require-instance true;
+                //TODO: require-instance should be added when it's
+                //supported in YANG 1.1
+                //require-instance true;
               }
               description
                 "References a defined extended community set by

--- a/experimental/openconfig/bgp/bgp.yang
+++ b/experimental/openconfig/bgp/bgp.yang
@@ -416,7 +416,9 @@ module bgp {
       type leafref {
         // we are at /bgp/neighbors/neighbor/
         path "/bgp/peer-groups/peer-group/peer-group-name";
-        require-instance true;
+        //TODO: require-instance should be added when it's
+        //supported in YANG 1.1
+        //require-instance true;
       }
       description
         "The peer-group with which this neighbor is associated";

--- a/experimental/openconfig/interfaces/openconfig-if-ip.yang
+++ b/experimental/openconfig/interfaces/openconfig-if-ip.yang
@@ -558,7 +558,9 @@ module openconfig-if-ip {
     leaf track-interface {
       type leafref {
         path "/ocif:interfaces/ocif:interface/ocif:name";
-        require-instance true;
+        //TODO: require-instance should be added when it's
+        //supported in YANG 1.1
+        //require-instance true;
       }
       // TODO: we may need to add some restriction to ethernet
       // or IP interfaces.

--- a/experimental/openconfig/mpls/mpls-te.yang
+++ b/experimental/openconfig/mpls/mpls-te.yang
@@ -525,7 +525,9 @@ submodule mpls-te {
         type leafref {
           path "/mpls/lsps/constrained-path/"
             + "paths/path/config/path-name";
-          require-instance true;
+          //TODO: require-instance should be added when it's
+          //supported in YANG 1.1
+          //require-instance true;
         }
           description "reference to a defined path";
       }
@@ -577,7 +579,9 @@ submodule mpls-te {
         type leafref {
           path "/mpls/lsps/constrained-path/"
             + "path-name/config/path/path-name";
-          require-instance true;
+          //TODO: require-instance should be added when it's
+          //supported in YANG 1.1
+          //require-instance true;
         }
 	  description "Path name of a named path";
       }
@@ -625,7 +629,9 @@ submodule mpls-te {
           type leafref {
             path "/mpls/lsps/constrained-path/"
             + "paths/path/config/path-name";
-            require-instance true;
+            //TODO: require-instance should be added when it's
+            //supported in YANG 1.1
+            //require-instance true;
           }
 	  description "definition for naming an LSP path";
 
@@ -649,7 +655,9 @@ submodule mpls-te {
           type leafref {
             path "/mpls/lsps/constrained-path/"
               + "paths/hops/config/address";
-            require-instance true;
+            //TODO: require-instance should be added when it's
+            //supported in YANG 1.1
+            //require-instance true;
           }
         description "definition of hop address";
 


### PR DESCRIPTION
Comment out all require-instance properties just like they are in
experimental/openconfig/policy/routing-policy.yang

In YANG 1.0, which the models currently adhere to, require-instance is
only allowed under type instance-identifier nodes. When YANG 1.1, which
allows require-instance for leafrefs etc, is released this can be
enabled again.