### PR TITLE
Check script for standard/ietf/RFC models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/einarnn/yang.svg)](https://travis-ci.org/einarnn/yang)
+
 YANG
 =====
 

--- a/vendor/cisco/check.sh
+++ b/vendor/cisco/check.sh
@@ -5,7 +5,7 @@
 #
 vendor_dir="vendor/cisco"
 to_check="xr/530 xr/531 xr/532"
-pyang_flags="--canonical"
+pyang_flags=""
 
 checkDir () {
     echo Checking yang files in $vendor_dir/$1
@@ -26,9 +26,7 @@ checkDir () {
 }
 
 echo Checking modules with pyang command:
-echo
-echo    pyang $pyang_flags MODULE
-echo
+printf "\n    pyang $pyang_flags MODULE\n\n"
 
 cd $vendor_dir
 for d in $to_check; do


### PR DESCRIPTION
Building on the travis integration in previous pull request, I added another check for the IETF RFC directory. I din't enable the "--ietf" flag as that would just cause too many errors.

Cheers,

Einar
