### PR TITLE
Add 802.3 Ethernet Link OAM modules from Cisco

### DIFF
--- a/experimental/ieee/802.3/ethernet-link-oam.yang
+++ b/experimental/ieee/802.3/ethernet-link-oam.yang
@@ -81,7 +81,7 @@ module ethernet-link-oam {
     description
       "Enumeration of the valid threshold event types";
     reference	
-        "[802.3] 57.5.3";
+      "[802.3] 57.5.3";
     type enumeration {
       enum symbol-period-event {
         value 1;
@@ -205,7 +205,8 @@ module ethernet-link-oam {
     description
       "Operational state of an interface";
     reference	
-        "[RFC-4878] dot3OamOperStatus, [802.3] 57.3.2.1";
+        "[RFC-4878] dot3OamOperStatus, [802.3] 30.3.6.1.4,
+         30.3.6.1.10, 30.3.6.1.11";
     type enumeration {
       enum disabled {
         value 1;
@@ -288,6 +289,8 @@ module ethernet-link-oam {
       default active;
       description
         "The mode (active/passive) in which Link OAM should run";
+      reference
+        "[802.3] 30.3.6.1.3";
     }
     leaf mib-retrieval {
       type boolean;
@@ -338,6 +341,8 @@ module ethernet-link-oam {
           description
             "The type of threshold event for which this list entry is
              specifying the configuration.";
+          reference
+            "[802.3] 57.5.3";
         }
 
         leaf window {
@@ -374,6 +379,9 @@ module ethernet-link-oam {
                Min: 10 seconds
                Max: 900 seconds
              ";
+          reference
+            "[802.3] 30.3.6.1.34, 30.3.6.1.36, 30.3.6.1.38,
+             30.3.6.1.40";
         }
         
         leaf threshold {
@@ -408,6 +416,9 @@ module ethernet-link-oam {
                Min: 1
                Max: unspecified
              ";
+          reference
+            "[802.3] 30.3.6.1.34, 30.3.6.1.36, 30.3.6.1.38,
+             30.3.6.1.40";
         }
       }
     }
@@ -419,9 +430,12 @@ module ethernet-link-oam {
        specific to Ethernet Link OAM";
 
     container link-oam {
-      presence "Enables Ethernet Link OAM on the interface";
-
-      description "Ethernet Link OAM Interface Configuration";
+      presence
+        "Enables Ethernet Link OAM on the interface";
+      description
+        "Ethernet Link OAM Interface Configuration";
+      reference
+        "[802.3], 30.3.6.1.2";
 
       uses intf-config;
     }
@@ -465,6 +479,8 @@ module ethernet-link-oam {
       }
       description
         "Type of event that occurred";
+      reference
+        "[802.3], 30.3.6.1.10";
     }
     container threshold {
       description
@@ -480,6 +496,8 @@ module ethernet-link-oam {
         type threshold-event-enum;
         description
           "The type of threshold event";
+        reference
+          "[802.3] 57.5.3";
       }
       leaf window {
         mandatory true;
@@ -537,96 +555,128 @@ module ethernet-link-oam {
       type uint32;
       description
         "Number of information OAMPDUs transmitted";
+      reference
+        "[802.3], 30.3.6.1.20";
     }
     leaf information-rx {
       mandatory true;
       type uint32;
       description
         "Number of information OAMPDUs received";
+      reference
+        "[802.3], 30.3.6.1.21";
     }
     leaf unique-event-notification-tx {
       mandatory true;
       type uint32;
       description
         "Number of unique event notification OAMPDUs transmitted";
+      reference
+        "[802.3], 30.3.6.1.22";
     }
     leaf unique-event-notification-rx {
       mandatory true;
       type uint32;
       description
         "Number of unique event notification OAMPDUs received";
+      reference
+        "[802.3], 30.3.6.1.24";
     }
     leaf duplicate-event-notification-tx {
       mandatory true;
       type uint32;
       description
         "Number of duplicate event notification OAMPDUs transmitted";
+      reference
+        "[802.3], 30.3.6.1.23";
     }
     leaf duplicate-event-notification-rx {
       mandatory true;
       type uint32;
       description
         "Number of duplicate event notification OAMPDUs received";
+      reference
+        "[802.3], 30.3.6.1.25";
     }
     leaf loopback-control-tx {
       mandatory true;
       type uint32;
       description
         "Number of loopback control OAMPDUs transmitted";
+      reference
+        "[802.3], 30.3.6.1.26";
     }
     leaf loopback-control-rx {
       mandatory true;
       type uint32;
       description
         "Number of loopback control OAMPDUs received";
+      reference
+        "[802.3], 30.3.6.1.27";
     }
     leaf variable-request-tx {
       mandatory true;
       type uint32;
       description
         "Number of variable request OAMPDUs transmitted";
+      reference
+        "[802.3], 30.3.6.1.28";
     }
     leaf variable-request-rx {
       mandatory true;
       type uint32;
       description
         "Number of variable request OAMPDUs received";
+      reference
+        "[802.3], 30.3.6.1.29";
     }
     leaf variable-response-tx {
       mandatory true;
       type uint32;
       description
         "Number of variable response OAMPDUs transmitted";
+      reference
+        "[802.3], 30.3.6.1.30";
     }
     leaf variable-response-rx {
       mandatory true;
       type uint32;
       description
         "Number of variable response OAMPDUs received";
+      reference
+        "[802.3], 30.3.6.1.31";
     }
     leaf org-specific-tx {
       mandatory true;
       type uint32;
       description
         "Number of organization specific OAMPDUs transmitted";
+      reference
+        "[802.3], 30.3.6.1.32";
     }
     leaf org-specific-rx {
       mandatory true;
       type uint32;
       description
         "Number of organization specific OAMPDUs received";
+      reference
+        "[802.3], 30.3.6.1.33";
     }
     leaf unsupported-codes-tx {
       mandatory true;
       type uint32;
       description
         "Number of OAMPDUs with unsupported codes transmitted";
+      reference
+        "[802.3], 30.3.6.1.18";
     }
     leaf unsupported-codes-rx {
       mandatory true;
       type uint32;
       description
         "Number of OAMPDUs with unsupported codes received";
+      reference
+        "[802.3], 30.3.6.1.19";
     }
     leaf frames-lost-due-to-oam {
       mandatory true;
@@ -638,6 +688,8 @@ module ethernet-link-oam {
          dropped due to transmit resource contention.  This counter
          is incremented whenever a frame is dropped by the OAM
          layer.";
+      reference
+        "[802.3], 30.3.6.1.46";
     }
   }
 
@@ -649,13 +701,13 @@ module ethernet-link-oam {
       type mode;
       description "Mode (passive/active)";
       reference
-        "[802.3ah], 30.3.6.1.7";
+        "[802.3], 30.3.6.1.3, 30.3.6.1.7";
     }
     container functions-supported {
       description
         "The Link OAM functions supported by this interface";
       reference
-        "[802.3ah] 30.3.6.1.7";
+        "[802.3] 30.3.6.1.6, 30.3.6.1.7";
       leaf uni-directional-link-fault {
         type boolean;
         description "Unidirectional link fault support";
@@ -677,14 +729,14 @@ module ethernet-link-oam {
       type uint32;
       description "Configuration revision";
       reference
-        "[802.3ah], 30.3.6.1.13";
+        "[802.3], 30.3.6.1.12, 30.3.6.1.13";
     }
     leaf mtu {
       type uint32;
       units "bytes";
       description "The maximum OAMPDU size";
       reference
-        "[802.3ah], 30.3.6.1.9";
+        "[802.3], 30.3.6.1.8, 30.3.6.1.9";
     }
   }
 
@@ -699,11 +751,16 @@ module ethernet-link-oam {
         mandatory true;
         type operational-state;
         description "Operational status";
+        reference	
+          "[RFC-4878] dot3OamOperStatus, [802.3] 30.3.6.1.4,
+           30.3.6.1.10, 30.3.6.1.11";
       }
       leaf loopback-mode {
         mandatory true;
         type loopback-status;
         description "The loopback mode the interface is in";
+        reference
+          "[802.3], 30.3.61.14";
       }
 
       uses discovery-common;
@@ -715,16 +772,22 @@ module ethernet-link-oam {
       leaf mac-address {
         type yang:mac-address;
         description "Remote MAC address";
+        reference
+          "[802.3], 30.3.6.1.5";
       }
       leaf vendor-oui {
         type vendor-oui;
         description "Remote vendor OUI";
+        reference
+          "[802.3], 30.3.6.1.16";
       }
       leaf vendor-info {
         type uint32;
         description
           "Remote vendor info. The semantics of this value are
            proprietary and specific to the vendor.";
+        reference
+          "[802.3], 30.3.6.1.17";
       }
 
       uses discovery-common;
@@ -853,6 +916,8 @@ module ethernet-link-oam {
     description
       "Start/stop remote loopback on the specified interface.";
     if-feature remote-loopback;
+    reference
+      "[802.3] 57.1.2:b";
     input {
       leaf interface {
         mandatory true;

--- a/experimental/ieee/802.3/ethernet-link-oam.yang
+++ b/experimental/ieee/802.3/ethernet-link-oam.yang
@@ -470,8 +470,10 @@ module ethernet-link-oam {
       description
         "Nodes specific to threshold (link monitoring) events";
       if-feature link-monitoring;
-      when
-        "../event-type = 'threshold-event-type'";
+      when "../event-type = 'threshold-event-type'" {
+        description
+          "These nodes only apply to threshold event types";
+      }
 
       leaf threshold-event-type {
         mandatory true;
@@ -892,7 +894,10 @@ module ethernet-link-oam {
     if-feature link-monitoring;
     uses event-details {
       refine event-type {
-        must ". = 'threshold-event-type'";
+        must ". = 'threshold-event-type'" {
+          description
+            "This leaf will always be set to 'threshold-event-type'";
+        }
       }
     }
   }
@@ -903,7 +908,10 @@ module ethernet-link-oam {
        crossing event is detected.";
     uses event-details {
       refine event-type {
-        must ". != 'threshold-event-type'";
+        must ". != 'threshold-event-type'" {
+          description
+            "This leaf will never be set to 'threshold-event-type'";
+        }
       }
     }
   }

--- a/experimental/ieee/802.3/ethernet-link-oam.yang
+++ b/experimental/ieee/802.3/ethernet-link-oam.yang
@@ -1,0 +1,910 @@
+module ethernet-link-oam {
+
+  /*** NAMESPACE / PREFIX DEFINITION ***/
+
+  namespace "urn:ieee:params:xml:ns:yang:ethernet-link-oam";
+
+  prefix "link-oam";
+
+  /*** LINKAGE (IMPORTS / INCLUDES) ***/
+  
+  import ietf-yang-types { prefix "yang"; }
+  
+  import ietf-interfaces { prefix "if"; }
+
+  import ethernet { prefix "eth"; }
+
+  /*** META INFORMATION ***/
+
+  organization
+    "Cisco Systems, Inc.
+     Customer Service
+
+     Postal: 170 W Tasman Drive
+     San Jose, CA 95134
+
+     Tel: +1 1800 553-NETS
+     
+     E-mail: cs-yang@cisco.com";
+
+  contact
+    "Richard Furness - rfurness@cisco.com";
+
+  description 
+    "This module contains a collection of YANG definitions
+     for managing the Ethernet Link OAM feature defined by IEEE
+     802.3. It provides functionality roughly equivalent to that of
+     the DOT3-OAM-MIB defined in RFC 4878.
+
+     This YANG module augments the 'ethernet' module.";
+
+  revision "2015-10-29" {
+    description
+      "Initial version";
+    reference
+      "IEEE 802.3 2012";
+  }
+
+  /*
+   * Features
+   */
+  feature uni-directional-link-fault {
+    description
+      "This feature means the device supports Uni Directional Link
+       Fault detection.";
+    reference	
+      "[802.3] 57.1.2:a";
+  }
+  feature remote-loopback {
+    description
+      "This feature means the device supports remote loopback";
+    reference	
+      "[802.3] 57.1.2:b";
+  }
+  feature link-monitoring {
+    description
+      "This feature means the device supports Link Monitoring.";
+    reference	
+      "[802.3] 57.1.2:c:1";
+  }
+  feature remote-mib-retrieval {
+    description
+      "This feature means the device supports remote MIB retrieval.";
+    reference	
+      "[802.3] 57.1.2:c:2";
+  }
+
+  /*
+   * Types / identities
+   */
+  typedef threshold-event-enum {
+    description
+      "Enumeration of the valid threshold event types";
+    reference	
+        "[802.3] 57.5.3";
+    type enumeration {
+      enum symbol-period-event {
+        value 1;
+        description "Errored symbol period event";
+      }
+      enum frame-period-event {
+        value 2;
+        description "Errored frame period event";
+      }
+      enum frame-event {
+        value 3;
+        description "Errored frame event";
+      }
+      enum frame-seconds-event {
+        value 4;
+        description "Errored frame seconds event";
+      }
+    }
+  }
+
+  identity event-type {
+    description
+      "Base identity for all Link OAM event types.";
+  }
+  identity threshold-event-type {
+    base event-type;
+    description
+      "Event type for a Link Monitoring threshold event.";
+  }
+  identity link-fault-event {
+    /*
+     * Requires Yang 1.1
+     */
+    //if-feature uni-directional-link-fault;
+    base event-type;
+    description
+      "Event type for a uni-directional link fault event.";
+    reference	
+        "[802.3] 57.2.10.1";
+  }
+  identity dying-gasp-event {
+    base event-type;
+    description
+      "Event type for a dying gasp event.";
+    reference	
+        "[802.3] 57.2.10.1";
+  }
+  identity critical-event {
+    base event-type;
+    description
+      "Event type for a critical event.";
+    reference	
+        "[802.3] 57.2.10.1";
+  }
+
+  typedef mode {
+    description
+      "Enumeration of the valid modes in which Link OAM may run";
+    reference	
+        "[802.3] 57.2.9";
+    type enumeration {
+      enum passive {
+        value 0;
+        description "Ethernet Link OAM Passive mode";
+      }
+      enum active {
+        value 1;
+        description "Ethernet Link OAM Active mode";
+      }
+    }
+  }
+
+  typedef event-location {
+    description
+      "The location of the event that caused a log entry";
+    type enumeration {
+      enum event-location-local {
+        value 1;
+        description "A local event";
+      }
+      enum event-location-remote {
+        value 2;
+        description "A remote event";
+      }
+    }
+  }
+
+  typedef loopback-status {
+    description
+      "The loopback mode of an OAM interface";
+    reference	
+        "[802.3] 57.2.11";
+    type enumeration {
+      enum none {
+        value 1;
+        description "Loopback is not being performed";
+      }
+      enum initiating {
+        value 2;
+        description "Initiating master loopback";
+      }
+      enum master-loopback {
+        value 3;
+        description "In master loopback mode";
+      }
+      enum terminating {
+        value 4;
+        description "Terminating master loopback mode";
+      }
+      enum local-loopback {
+        value 5;
+        description "In slave loopback mode";
+      }
+      enum unknown {
+        value 6;
+        description "Parser and multiplexer combination unexpected";
+      }
+    }
+  }
+  typedef operational-state {
+    description
+      "Operational state of an interface";
+    reference	
+        "[RFC-4878] dot3OamOperStatus, [802.3] 57.3.2.1";
+    type enumeration {
+      enum disabled {
+        value 1;
+        description
+          "802.3 OAM is disabled";
+      }
+      enum link-fault {
+        value 2;
+        description
+          "802.3 OAM has encountered a link fault";
+      }
+      enum passive-wait {
+        value 3;
+        description
+          "Passive OAM entity waiting to see if peer is
+           OAM capable";
+      }
+      enum active-send-local {
+        value 4;
+        description
+          "Active OAM entity trying to determine if peer
+           is OAM capable";
+      }
+      enum send-local-and-remote {
+        value 5;
+        description
+          "OAM discovered peer but still to accept or
+          reject peer config";
+      }
+      enum send-local-and-remote-ok {
+        value 6;
+        description
+          "OAM peering is allowed by local device";
+      }
+      enum peering-locally-rejected {
+        value 7;
+        description
+          "OAM peering rejected by local device";
+      }
+      enum peering-remotely-rejected {
+        value 8;
+        description
+          "OAM peering rejected by remote device";
+      }
+      enum operational {
+        value 9;
+        description
+          "802.3 OAM is operational";
+      }
+      enum operational-half-duplex {
+        value 10;
+        description
+          "802.3 OAM is operating in half-duplex mode";
+      }
+    }
+  }
+
+  typedef vendor-oui {
+    type yang:hex-string {
+      length 3;
+    }
+    description "24-bit Organizationally Unique Identifier";
+    reference
+      "IEEE 802-2001 [802-2001], Clause 9";
+  }
+
+  /*
+   * Configuration
+   */
+  
+  /*
+   * Define per-interface configuration as a grouping so that
+   * augmenting models can reuse it (e.g. for templating support)
+   */
+  grouping intf-config {
+    description
+      "Per-interface Link OAM configuration nodes";
+    leaf mode {
+      type mode;
+      default active;
+      description
+        "The mode (active/passive) in which Link OAM should run";
+    }
+    leaf mib-retrieval {
+      type boolean;
+      if-feature remote-mib-retrieval;
+      default false;
+      description
+        "Enable or disable support for responding to MIB retrieval
+         requests from the peer device";
+    }
+    leaf remote-loopback {
+      type boolean;
+      if-feature remote-loopback;
+      default false;
+      description
+        "Enable or disable support for acting as a remote loopback
+         slave device";
+    }
+    leaf udlf {
+      type boolean;
+      if-feature uni-directional-link-fault;
+      default false;
+      description
+        "Enable or disable uni-directional link-fault detection";
+    }
+
+    container link-monitor {
+      description
+        "Configure link monitor parameters";
+      reference	
+        "[802.3] 57.1.2:c";
+      if-feature link-monitoring;
+
+      leaf monitoring {
+        type boolean;
+        default true;
+        description "Enable or disable monitoring";
+      }
+
+      list event-type {
+        description
+          "A list containing at most one entry for each of the
+           threshold event types. If there is no entry for a
+           particular event type, the default values are used for
+           both window size and threshold.";
+        key threshold-type;
+        leaf threshold-type {
+          type threshold-event-enum;
+          description
+            "The type of threshold event for which this list entry is
+             specifying the configuration.";
+        }
+
+        leaf window {
+          type uint64;
+          description
+            "The size of the window to use when monitoring for this
+             threshold event. The units, default and upper and lower
+             bounds depend on the threshold type as follows:
+
+             Symbol Period:
+               Units: number of symbols
+               Default: number of symbols in one second for the
+                underlying physical layer
+               Min: number of symbols in one second for the
+                underlying physical layer
+               Max: number of symbols in one minute for the
+                underlying physical layer
+             Frame:
+               Units: deciseconds
+               Default: 1 second
+               Min: 1 second
+               Max: 1 minute
+             Frame Period:
+               Units: number of frames
+               Default: number of minFrameSize frames in one second
+                for the underlying physical layer
+               Min: number of minFrameSize frames in one second for
+                the underlying physical layer
+               Max: number of minFrameSize frames in one minute for
+                the underlying physical layer
+             Frame Seconds:
+               Units: deciseconds
+               Default: 60 seconds
+               Min: 10 seconds
+               Max: 900 seconds
+             ";
+        }
+        
+        leaf threshold {
+          type uint64 {
+            range "1..max";
+          }
+          description
+            "The threshold value to use when determining whether to
+             generate an event given the number of errors that
+             occurred in a given window. The units, default and upper
+             and lower bounds are depend on the threshold type as
+             follows:
+
+             Symbol Period:
+               Units: number of errored symbols
+               Default: 1
+               Min: 1
+               Max: unspecified
+             Frame:
+               Units: number of errored frames
+               Default: 1
+               Min: 1
+               Max: unspecified
+             Frame Period:
+               Units: number of errored frames
+               Default: 1
+               Min: 1
+               Max: unspecified
+             Frame Seconds:
+               Units: number of errored frame-seconds
+               Default: 1
+               Min: 1
+               Max: unspecified
+             ";
+        }
+      }
+    }
+  }
+
+  augment "/if:interfaces/if:interface/eth:ethernet" {
+    description
+      "Augments ethernet interface configuration model with nodes
+       specific to Ethernet Link OAM";
+
+    container link-oam {
+      presence "Enables Ethernet Link OAM on the interface";
+
+      description "Ethernet Link OAM Interface Configuration";
+
+      uses intf-config;
+    }
+  }
+
+  /*
+   * Operational
+   */
+
+  grouping event-details {
+    description
+      "Nodes describing an event, used in the event log and in
+       notifications";
+    reference
+      "[RFC-4878] Dot3OamEventLogEntry";
+    leaf oui {
+      mandatory true;
+      type vendor-oui;
+      description
+        "Organizationally Unique Identifier for the device that
+         generated the event";
+    }
+    leaf timestamp {
+      mandatory true;
+      type uint64;
+      units "milliseconds";
+      description
+        "Timestamp in milliseconds since unix epoch for when the
+         event occurred";
+    }
+    leaf location {
+      mandatory true;
+      type event-location;
+      description
+        "Where the event occurred (local or remote)";
+    }
+    leaf event-type {
+      mandatory true;
+      type identityref {
+        base event-type;
+      }
+      description
+        "Type of event that occurred";
+    }
+    container threshold {
+      description
+        "Nodes specific to threshold (link monitoring) events";
+      if-feature link-monitoring;
+      when
+        "../event-type = 'threshold-event-type'";
+
+      leaf threshold-event-type {
+        mandatory true;
+        type threshold-event-enum;
+        description
+          "The type of threshold event";
+      }
+      leaf window {
+        mandatory true;
+        type uint64;
+        description
+          "Size of the window in which the event was generated. Units
+           are dependent on the threshold event type.";
+      }
+      leaf threshold {
+        mandatory true;
+        type uint64;
+        description
+          "Size of the threshold that was breached during the window.
+           Units are dependent on the threshold event type.";
+      }
+      leaf value {
+        mandatory true;
+        type uint64;
+        description
+          "Breaching value. Units are dependent on the threshold
+           event type, and match that of the threshold.";
+      }
+    }
+    leaf running-total {
+      mandatory true;
+      type uint64;
+      description
+        "The running total number of errors seen since OAM was
+         enabled on the interface. For threshold events, this is the
+         total number of times that particular type of error (e.g.
+         symbol error) has occurred, which may be greater than the
+         number of threshold-crossing event notifications of that
+         type generated during that time (which is conveyed by the
+         event-total leaf).";
+    }
+    leaf event-total {
+      mandatory true;
+      type uint32;
+      description
+        "Total number of times this event has occurred since OAM was
+         enabled on the interface. For threshold events this is the
+         number of events generated of this type (as opposed to the
+         total number of errors of that type, which may be greater,
+         and is conveyed by the running-total leaf.";
+    }
+  }
+
+  grouping statistics-common {
+    description
+      "Collection of Link OAM event/packet counters";
+    reference
+      "[RFC-4878] Dot3OamStatsEntry";
+    leaf information-tx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of information OAMPDUs transmitted";
+    }
+    leaf information-rx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of information OAMPDUs received";
+    }
+    leaf unique-event-notification-tx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of unique event notification OAMPDUs transmitted";
+    }
+    leaf unique-event-notification-rx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of unique event notification OAMPDUs received";
+    }
+    leaf duplicate-event-notification-tx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of duplicate event notification OAMPDUs transmitted";
+    }
+    leaf duplicate-event-notification-rx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of duplicate event notification OAMPDUs received";
+    }
+    leaf loopback-control-tx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of loopback control OAMPDUs transmitted";
+    }
+    leaf loopback-control-rx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of loopback control OAMPDUs received";
+    }
+    leaf variable-request-tx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of variable request OAMPDUs transmitted";
+    }
+    leaf variable-request-rx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of variable request OAMPDUs received";
+    }
+    leaf variable-response-tx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of variable response OAMPDUs transmitted";
+    }
+    leaf variable-response-rx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of variable response OAMPDUs received";
+    }
+    leaf org-specific-tx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of organization specific OAMPDUs transmitted";
+    }
+    leaf org-specific-rx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of organization specific OAMPDUs received";
+    }
+    leaf unsupported-codes-tx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of OAMPDUs with unsupported codes transmitted";
+    }
+    leaf unsupported-codes-rx {
+      mandatory true;
+      type uint32;
+      description
+        "Number of OAMPDUs with unsupported codes received";
+    }
+    leaf frames-lost-due-to-oam {
+      mandatory true;
+      type uint32;
+      description
+        "A count of the number of frames that were dropped by the OAM
+         multiplexer.  Since the OAM multiplexer has multiple inputs
+         and a single output, there may be cases where frames are
+         dropped due to transmit resource contention.  This counter
+         is incremented whenever a frame is dropped by the OAM
+         layer.";
+    }
+  }
+
+  grouping discovery-common {
+    description
+      "Nodes describing the state of the discovery process common to
+      both ends of a link (either local or remote)";
+    leaf mode {
+      type mode;
+      description "Mode (passive/active)";
+      reference
+        "[802.3ah], 30.3.6.1.7";
+    }
+    container functions-supported {
+      description
+        "The Link OAM functions supported by this interface";
+      reference
+        "[802.3ah] 30.3.6.1.7";
+      leaf uni-directional-link-fault {
+        type boolean;
+        description "Unidirectional link fault support";
+      }
+      leaf loopback {
+        type boolean;
+        description "Loopback support";
+      }
+      leaf link-monitoring {
+        type boolean;
+        description "Link monitoring support";
+      }
+      leaf mib-retrieval {
+        type boolean;
+        description "MIB variable retrieval support";
+      }
+    }
+    leaf revision {
+      type uint32;
+      description "Configuration revision";
+      reference
+        "[802.3ah], 30.3.6.1.13";
+    }
+    leaf mtu {
+      type uint32;
+      units "bytes";
+      description "The maximum OAMPDU size";
+      reference
+        "[802.3ah], 30.3.6.1.9";
+    }
+  }
+
+  grouping discovery-info {
+    description "Information relating to the discovery process";
+
+    container local {
+      description
+        "Properties of the local device";
+
+      leaf operational-status {
+        mandatory true;
+        type operational-state;
+        description "Operational status";
+      }
+      leaf loopback-mode {
+        mandatory true;
+        type loopback-status;
+        description "The loopback mode the interface is in";
+      }
+
+      uses discovery-common;
+    }
+    container remote {
+      description
+        "Properties of the remote (peer) device";
+
+      leaf mac-address {
+        type yang:mac-address;
+        description "Remote MAC address";
+      }
+      leaf vendor-oui {
+        type vendor-oui;
+        description "Remote vendor OUI";
+      }
+      leaf vendor-info {
+        type uint32;
+        description
+          "Remote vendor info. The semantics of this value are
+           proprietary and specific to the vendor.";
+      }
+
+      uses discovery-common;
+    }
+  }
+
+  augment "/if:interfaces-state/if:interface/eth:ethernet" {
+    description
+      "Augments ethernet interface operational state model with nodes
+       specific to Ethernet Link OAM";
+
+    container link-oam {
+      description
+        "Interface operational state for Ethernet Link OAM";
+      presence
+        "Implies Link OAM is configured on the interface";
+
+      leaf rx-fault {
+        if-feature uni-directional-link-fault;
+        mandatory true;
+        type boolean;
+        description
+          "Has a uni-directional link-fault been detected by the
+           local device?";
+      }
+
+      container discovery-info {
+        description "Information relating to the discovery process";
+
+        uses discovery-info;
+      }
+
+      container event-log {
+        description
+          "List of Ethernet Link OAM event log entries on the
+           interface";
+
+        list event-log-entry {
+          key "index";
+          description
+            "Ethernet Link OAM event log entry";
+          leaf index {
+            type uint32;
+            description "Index of this event in the event log";
+          }
+          uses event-details;
+        }
+      }
+
+      container statistics {
+        description "Statistics for an 802.3 OAM interface";
+        
+        uses statistics-common;
+
+        leaf local-error-symbol-period-log-entries {
+          mandatory true;
+          type uint32;
+          description
+            "Number of local error symbol period log entries";
+        }
+        leaf local-error-frame-log-entries {
+          mandatory true;
+          type uint32;
+          description
+            "Number of local error frame log entries";
+        }
+        leaf local-error-frame-period-log-entries {
+          mandatory true;
+          type uint32;
+          description
+            "Number of local error frame period log entries";
+        }
+        leaf local-error-frame-second-log-entries {
+          mandatory true;
+          type uint32;
+          description
+            "Number of local error frame second log entries";
+        }
+        leaf remote-error-symbol-period-log-entries {
+          mandatory true;
+          type uint32;
+          description
+            "Number of remote error symbol period log entries";
+        }
+        leaf remote-error-frame-log-entries {
+          mandatory true;
+          type uint32;
+          description
+            "Number of remote error frame log entries";
+        }
+        leaf remote-error-frame-period-log-entries {
+          mandatory true;
+          type uint32;
+          description
+            "Number of remote error frame period log entries";
+        }
+        leaf remote-error-frame-second-log-entries {
+          mandatory true;
+          type uint32;
+          description
+            "Number of remote error frame second log entries";
+        }
+      }
+    }
+  }
+
+  /*
+   * RPCs
+   */
+
+  rpc reset-stats {
+    description
+      "Reset Ethernet Link OAM statistics on a specific (or all)
+       interface(s)";
+    input {
+      leaf interface {
+        type if:interface-ref;
+        description
+          "The interface to reset stats for. If not specified, stats
+           are reset for all interfaces in the system.";
+      }
+    }
+  }
+
+  rpc remote-loopback {
+    description
+      "Start/stop remote loopback on the specified interface.";
+    if-feature remote-loopback;
+    input {
+      leaf interface {
+        mandatory true;
+        type if:interface-ref;
+        description
+          "The interface to start loopback on.";
+      }
+      leaf enable {
+        mandatory true;
+        type boolean;
+        description
+          "Whether to enable or disable remote loopback.";
+      }
+    }
+    output {
+      leaf success {
+        mandatory true;
+        type boolean;
+        description
+          "True if the operation was successful, False otherwise.";
+      }
+      leaf error-message {
+        type string;
+        description
+          "If the operation failed, optionally used to provide extra
+           details.";
+      }
+    }
+  }
+
+  /*
+   * Notifications
+   */
+
+  notification threshold-event {
+    description
+      "This notification is sent when a local or remote threshold
+       crossing event is detected.";
+    if-feature link-monitoring;
+    uses event-details {
+      refine event-type {
+        must ". = 'threshold-event-type'";
+      }
+    }
+  }
+
+  notification non-threshold-event {
+    description
+      "This notification is sent when a local or remote non-threshold
+       crossing event is detected.";
+    uses event-details {
+      refine event-type {
+        must ". != 'threshold-event-type'";
+      }
+    }
+  }
+}

--- a/vendor/cisco/common/cisco-link-oam.yang
+++ b/vendor/cisco/common/cisco-link-oam.yang
@@ -117,7 +117,10 @@ module cisco-link-oam {
       leaf dying-gasp {
         type action-enum;
         default log;
-        must ". != 'efd'";
+        must ". != 'efd'" {
+          description
+            "EFD is not a valid action for dying-gasp handling";
+        }
         description
           "Action to perform when a dying gasp is received";
       }
@@ -137,14 +140,21 @@ module cisco-link-oam {
       leaf session-up {
         type action-enum;
         default log;
-        must ". != 'efd' and . != 'error-disable'";
+        must ". != 'efd' and . != 'error-disable'" {
+          description
+            "EFD and error-disable are not valid actions for
+             session-up handling";
+        }
         description
           "Action to perform when a session comes up";
       }
       leaf critical-event {
         type action-enum;
         default log;
-        must ". != 'efd'";
+        must ". != 'efd'" {
+          description
+            "EFD is not a valid action for critical-event handling";
+        }
         description
           "Action to perform when a critical event is received from
            the peer";
@@ -153,7 +163,11 @@ module cisco-link-oam {
         type action-enum;
         if-feature link-oam:remote-loopback;
         default log;
-        must ". != 'efd' and . != 'error-disable'";
+        must ". != 'efd' and . != 'error-disable'" {
+          description
+            "EFD and error-disable are not valid actions for
+             remote-loopback handling";
+        }
         description
           "Action to perform when the device enters loopback mode
            as requested by the peer";
@@ -168,7 +182,10 @@ module cisco-link-oam {
         if-feature link-oam:link-monitoring;
         default no-action;
         type action-enum;
-        must ". != 'efd'";
+        must ". != 'efd'" {
+          description
+            "EFD is not a valid action for high-threshold handling";
+        }
         description
           "Action to perform when a link monitoring event (either
            local or remote) crosses the configured high threshold.
@@ -256,11 +273,12 @@ module cisco-link-oam {
          event type. The units, and upper and lower bounds are the
          same as for 'threshold' in the base model.
 
-         If not configured, no high threshold action will be taken.
-
-         The high threshold must be greater than (or equal to) the
-         regular threshold.";
-      must ". >= ../threshold";
+         If not configured, no high threshold action will be taken.";
+      must ". >= ../threshold" {
+        description
+          "The high threshold must be greater than (or equal to) the
+           regular threshold.";
+      }
     }
 
     container cisco {
@@ -367,11 +385,13 @@ module cisco-link-oam {
            If the parent 'cisco' container is present, this leaf
            overrides the 'threshold' leaf in the standard model.
 
-           If not configured, no high threshold action will be taken.
-
-           The high threshold must be greater than (or equal to) the
-           regular threshold.";
-        must ". >= ../threshold";
+           If not configured, no high threshold action will be
+           taken.";
+        must ". >= ../threshold" {
+          description
+            "The high threshold must be greater than (or equal to)
+             the regular threshold.";
+        }
       }
     }
   }

--- a/vendor/cisco/common/cisco-link-oam.yang
+++ b/vendor/cisco/common/cisco-link-oam.yang
@@ -1,0 +1,766 @@
+module cisco-link-oam {
+
+  /*** NAMESPACE / PREFIX DEFINITION ***/
+
+  namespace "urn:cisco:params:xml:ns:yang:cisco-link-oam";
+
+  prefix "cisco-link-oam";
+
+  /*** LINKAGE (IMPORTS / INCLUDES) ***/
+  
+  import ietf-interfaces { prefix "if"; }
+
+  import ethernet { prefix "eth"; }
+
+  import ethernet-link-oam { prefix "link-oam"; }
+
+  import Cisco-IOS-XR-types { prefix "xr"; }
+
+  /*** META INFORMATION ***/
+
+  organization
+    "Cisco Systems, Inc.
+     Customer Service
+
+     Postal: 170 W Tasman Drive
+     San Jose, CA 95134
+
+     Tel: +1 1800 553-NETS
+     
+     E-mail: cs-yang@cisco.com";
+
+  contact
+    "Richard Furness - rfurness@cisco.com";
+
+  description 
+    "This module contains a collection of YANG definitions
+     for managing the IEEE 802.3 Ethernet Link OAM feature on Cisco
+     devices.
+
+     This YANG module augments the 'ethernet-link-oam' module with
+     various features specific to Cisco devices such as:
+     - Configuration profiles
+     - Link monitoring high thresholds and corresponding actions
+     - Configuration to specify the support required of the peer
+     - Configurable hello interval and connection timeout
+     - Mis-wiring detection
+
+     Copyright (c) 2015 by Cisco Systems, Inc.
+     All rights reserved.";
+
+  revision "2015-10-29" {
+    description
+      "Initial version";
+    reference
+      "IEEE 802.3 2012";
+  }
+
+  typedef hello-interval-enum {
+    type enumeration {
+      enum 1s {
+        value 0;
+        description "1 s OAM hello interval";
+      }
+      enum 100ms {
+        value 1;
+        description "100 ms OAM hello interval";
+      }
+    }
+    description "Ethernet Link OAM interface hello interval enum";
+  }
+  typedef require-mode-enum {
+    type enumeration {
+      enum passive {
+        value 0;
+        description "Ethernet Link OAM Passive mode";
+      }
+      enum active {
+        value 1;
+        description "Ethernet Link OAM Active mode";
+      }
+      enum either {
+        value 2;
+        description "Ethernet Link OAM mode not required";
+      }
+    }
+    description "Possible modes required of the peer";
+  }
+
+  typedef action-enum {
+    type enumeration {
+      enum no-action {
+        value 1;
+        description "Disabled (do nothing)";
+      }
+      enum error-disable {
+        value 2;
+        description "Error-Disable the interface";
+      }
+      enum log {
+        value 3;
+        description "Log the event and do nothing else";
+      }
+      enum efd {
+        value 4;
+        description "EFD the interface";
+      }
+    }
+    description "Actions supported by an OAM interface";
+  }
+
+  grouping cisco-intf-config {
+    description
+      "Cisco-specific Link OAM configuration items";
+
+    container action {
+      description "Configure action parameters";
+      leaf dying-gasp {
+        type action-enum;
+        default log;
+        must ". != 'efd'";
+        description
+          "Action to perform when a dying gasp is received";
+      }
+      leaf link-fault {
+        type action-enum;
+        default log;
+        description
+          "Action to perform when a uni-directional link fault
+           notification is received from the peer";
+      }
+      leaf capabilities-conflict {
+        type action-enum;
+        default log;
+        description
+          "Action to perform when a capabilities conflict occurs";
+      }
+      leaf session-up {
+        type action-enum;
+        default log;
+        must ". != 'efd' and . != 'error-disable'";
+        description
+          "Action to perform when a session comes up";
+      }
+      leaf critical-event {
+        type action-enum;
+        default log;
+        must ". != 'efd'";
+        description
+          "Action to perform when a critical event is received from
+           the peer";
+      }
+      leaf remote-loopback {
+        type action-enum;
+        if-feature link-oam:remote-loopback;
+        default log;
+        must ". != 'efd' and . != 'error-disable'";
+        description
+          "Action to perform when the device enters loopback mode
+           as requested by the peer";
+      }
+      leaf wiring-conflict {
+        type action-enum;
+        default error-disable;
+        description
+          "Action to perform when a wiring conflict is detected";
+      }
+      leaf high-threshold {
+        if-feature link-oam:link-monitoring;
+        default no-action;
+        type action-enum;
+        must ". != 'efd'";
+        description
+          "Action to perform when a link monitoring event (either
+           local or remote) crosses the configured high threshold.
+           By default no action is performed.";
+      }
+      leaf discovery-timeout {
+        type action-enum;
+        default log;
+        description
+          "Action to perform when discovery timeout occurs";
+      }
+      leaf session-down {
+        type action-enum;
+        default log;
+        description
+          "Action to perform when a session goes down";
+      }
+    }
+
+    container require-remote {
+      description "Configure remote requirement parameters";
+      leaf mode {
+        type require-mode-enum;
+        default either;
+        description
+          "The Link OAM required of the peer (if any)";
+      }
+      leaf mib-retrieval {
+        type boolean;
+        if-feature link-oam:remote-mib-retrieval;
+        default false;
+        description
+          "If True, do not bring up a session unless the peer
+           supports MIB retrieval";
+      }
+      leaf remote-loopback {
+        type boolean;
+        if-feature link-oam:remote-loopback;
+        default false;
+        description
+          "If True, do not bring up a session unless the peer
+           supports remote loopback";
+      }
+      leaf link-monitoring {
+        type boolean;
+        if-feature link-oam:link-monitoring;
+        default false;
+        description
+          "If True, do not bring up a session unless the peer
+           supports link monitoring";
+      }
+    }
+    leaf timeout {
+      type uint32 {
+        range "2..30";
+      }
+      default 5;
+      description
+        "Connection timeout period in number of lost heartbeats";
+    }
+    leaf hello-interval {
+      type hello-interval-enum;
+      default 1s;
+      description "Possible Ethernet Link OAM hello intervals";
+    }
+  }
+
+  /*
+   * Augmentation to support Cisco units and high-threshold
+   * configuration
+   */
+  grouping link-monitoring-config {
+    description
+      "Link monitoring configuration shared between interface,
+       profile and running configuration";
+
+    leaf threshold-high {
+      if-feature link-oam:link-monitoring;
+      type uint64 {
+        range "1..max";
+      }
+      description
+        "The threshold value to use when determining whether to
+         take the configured action for this particular theshold
+         event type. The units, and upper and lower bounds are the
+         same as for 'threshold' in the base model.
+
+         If not configured, no high threshold action will be taken.
+
+         The high threshold must be greater than (or equal to) the
+         regular threshold.";
+      must ". >= ../threshold";
+    }
+
+    container cisco {
+      description
+        "A set of leaves for configuring Link Monitoring using 'Cisco
+         units'.";
+      presence
+        "If present (which must be the case if any of the three
+         leaves is set for a particular event type) then the values
+         of both 'window' and 'threshold' (from the standard model)
+         are ignored, and are overriden by the 'window-cisco' and
+         'threshold-cisco' leaves defined here.
+         In such cases, even if a particular leaf (say
+         'window-cisco') is not set, this distinction is relevant as
+         the default value is as defined by 'window-cisco' rather
+         than the standard 'window'.";
+
+      leaf window {
+        type uint64;
+        units milliseconds;
+        description
+          "An alternative means to configure the size of the window
+           to use when monitoring for this threshold event. The units
+           are milliseconds, differing from those in the standard
+           model in order to better support interfaces of varying
+           speeds.
+
+           If the parent 'cisco' container is present, this leaf
+           overrides the 'window' leaf in the standard model.
+
+           The default and upper and lower bounds depend on the
+           threshold type as follows:
+
+           Symbol Period:
+             Default: 1 second
+             Min: 1 second
+             Max: 1 minute
+           Frame:
+             Default: 1 second
+             Min: 1 second
+             Max: 1 minute
+           Frame Period:
+             Def: 1 second
+             Min: 1 second
+             Max: 1 minute
+           Frame Seconds:
+             Default: 60 seconds
+             Min: 10 seconds
+             Max: 900 seconds
+           ";
+      }
+
+      leaf threshold {
+        type uint64 {
+          range "1..12000000";
+        }
+        description
+          "An alternative means to configure the threshold value to
+           use when determining whether to generate an event given
+           the number of errors that occurred in a given window. The
+           units differ from those in the standard model in order
+           to better support interfaces of varying speeds.
+
+           If the parent 'cisco' container is present, this leaf
+           overrides the 'threshold' leaf in the standard model.
+
+           The units, default and upper and lower bounds are depend
+           on the threshold type as follows:
+
+           Symbol Period:
+             Units: errors per million symbols
+             Default: 1
+             Min: 1
+             Max: 1000000
+           Frame:
+             Units: number of errored frames
+             Default: 1
+             Min: 1
+             Max: 12000000
+           Frame Period:
+             Units: errors per million frames
+             Default: 1
+             Min: 1
+             Max: 1000000
+           Frame Seconds:
+             Units: number of errored frame-seconds
+             Default: 1
+             Min: 1
+             Max: 900
+           ";
+      }
+
+      leaf threshold-high {
+        if-feature link-oam:link-monitoring;
+        type uint64 {
+          range "1..12000000";
+        }
+        description
+          "The threshold value to use when determining whether to
+           take the configured action for this particular theshold
+           event type. The units, and upper and lower bounds are the
+           same as for the Cisco-specific 'threshold' above.
+
+           If the parent 'cisco' container is present, this leaf
+           overrides the 'threshold' leaf in the standard model.
+
+           If not configured, no high threshold action will be taken.
+
+           The high threshold must be greater than (or equal to) the
+           regular threshold.";
+        must ". >= ../threshold";
+      }
+    }
+  }
+  augment "/if:interfaces/if:interface/eth:ethernet" +
+          "/link-oam:link-oam/link-oam:link-monitor" +
+          "/link-oam:event-type" {
+    description
+      "Augmentation to support Cisco units and high-threshold
+       configuration";
+    uses link-monitoring-config;
+  }
+
+  /*
+   * Augmentation to support other Cisco-specific per-interface
+   * configuration
+   */
+
+  augment "/if:interfaces/if:interface/eth:ethernet" +
+          "/link-oam:link-oam" {
+    description
+      "This augment extends the per-interface Ethernet Link OAM
+       configuration data model with items specific to Cisco
+       devices";
+
+    leaf profile-name {
+      type leafref {
+        path "/ethernet-link-oam/profiles/profile/name";
+      }
+      description "Set the profile to use on the interface";
+    }
+
+    uses cisco-intf-config;
+  }
+
+  /*
+   * New nodes to support Cisco-specific global Link OAM config
+   */
+
+  container ethernet-link-oam {
+    description "Ethernet Link OAM global configuration";
+
+    container profiles {
+      description "List of Ethernet Link OAM configuration profiles";
+
+      list profile {
+        key "name";
+        description "List of Link OAM configuration profiles";
+
+        leaf name {
+          type string {
+            length "1..32";
+          }
+          description "Name of the profile";
+        }
+
+        /*
+         * Reuse the per-interface configuration groupings (standard
+         * and Cisco-specific).
+         */
+        uses link-oam:intf-config {
+          augment "link-monitor/event-type" {
+            description
+              "Augmentation to support Cisco units and high-threshold
+               configuration";
+            uses link-monitoring-config;
+          }
+        }
+
+        uses cisco-intf-config;
+      }
+    }
+  }
+
+  /*
+   * Augmentations to support Cisco-specific per-interface
+   * operational data
+   */
+
+  augment "/if:interfaces-state/if:interface/eth:ethernet" +
+          "/link-oam:link-oam/link-oam:event-log" +
+          "/link-oam:event-log-entry" {
+    description
+      "Augmentation to add Cisco-specific items to the event log";
+    leaf local-high-threshold {
+      type uint64;
+      description
+        "Size of the local high threshold (If applicable). For remote
+         threshold events this is scaled for comparison with the
+         Breaching Value. This is to account for different local and
+         remote window sizes.";
+    }
+    leaf action-taken {
+      type action-enum;
+      description "Local action taken (If applicable)";
+    }
+  }
+
+  augment "/if:interfaces-state/if:interface/eth:ethernet" +
+          "/link-oam:link-oam/link-oam:discovery-info" {
+    description
+      "Augments per-interface discovery information with Cisco-
+       specific items";
+    leaf miswired {
+      type boolean;
+      description "Has the interface been mis-wired?";
+    }
+  }
+
+  augment "/if:interfaces-state/if:interface/eth:ethernet" +
+          "/link-oam:link-oam/link-oam:statistics" {
+    description
+      "Augments per-interface statistics with Cisco-specific items";
+    leaf fixed-frames-rx {
+      type uint32;
+      description
+        "Number of RX frames 'fixed' by Link OAM. This counts the
+         number of received packets that could still be processed
+         despite being in some way invalid (e.g. having
+         unexpected TLVs present).";
+    }
+  }
+
+  augment "/if:interfaces-state/if:interface/eth:ethernet" +
+          "/link-oam:link-oam" {
+    description
+      "This augment extends the per-interface Ethernet Link OAM
+       operational data model with items specific to Cisco devices";
+
+    container efd-triggers {
+      description
+        "Triggers currently causing the interface to be
+        brought down using EFD";
+      leaf link-fault-received {
+        type empty;
+        description "Link-fault messages being received";
+      }
+      leaf discovery-timed-out {
+        type empty;
+        description "The discovery process has timed out";
+      }
+      leaf capabilities-conflict {
+        type empty;
+        description "A capabilities conflict has been detected";
+      }
+      leaf wiring-conflict {
+        type empty;
+        description "A wiring conflict has been detected";
+      }
+      leaf session-down {
+        type empty;
+        description "The 802.3 OAM session is down";
+      }
+    }
+
+    leaf local-mwd-key {
+      type uint32;
+      description "The local mis-wiring-detection key";
+    }
+    leaf remote-mwd-key {
+      type uint32;
+      description "The remote mis-wiring-detection key";
+    }
+
+    container running-config {
+      description
+        "The configuration currently running on an interface, based
+         on both per-interface and profile configuration (if
+         present).";
+      /*
+       * Reuse the per-interface configuration groupings (standard
+       * and Cisco-specific).
+       */
+      uses link-oam:intf-config {
+        augment "link-monitor/event-type" {
+          description
+            "Augmentation to support Cisco units and high-threshold
+             configuration";
+          uses link-monitoring-config;
+        }
+      }
+
+      uses cisco-intf-config;
+    }
+  }
+
+  /*
+   * New nodes to support Cisco-specific global Link OAM state data
+   */
+
+  container ethernet-link-oam-state {
+    description "Ethernet Link OAM global operational state";
+    config false;
+
+    container nodes {
+      description "Node table for node-specific operational data";
+
+      list node {
+        key "node-name";
+        description "Node-specific data for a particular node";
+        leaf node-name {
+          type xr:Node-id;
+          description "Node";
+        }
+        container summary {
+          description
+            "Ethernet Link OAM Summary information for the entire
+             node";
+          leaf interfaces {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces with 802.3 OAM configured";
+          }
+          leaf port-down {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in 'Port Down' state";
+          }
+          leaf passive-wait {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in 'Passive Wait' state";
+          }
+          leaf active-send {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in 'Active Send' state";
+          }
+          leaf evaluating {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in 'Evaluating' state";
+          }
+          leaf local-accept {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in 'Local Accept' state";
+          }
+          leaf local-reject {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in 'Local Reject' state";
+          }
+          leaf remote-reject {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in 'Remote Reject' state";
+          }
+          leaf operational {
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in 'Operational' state";
+          }
+          leaf loopback-mode {
+            if-feature link-oam:remote-loopback;
+            type uint32;
+            mandatory true;
+            description
+              "The number of interfaces in loopback mode";
+          }
+          leaf miswired-connections {
+            type uint32;
+            mandatory true;
+            description
+              "The number of miswired connections";
+          }
+          leaf events {
+            type uint64;
+            mandatory true;
+            description
+              "The number of events recorded (including threshold
+               events)";
+          }
+          leaf local-events {
+            type uint64;
+            mandatory true;
+            description "The number of local events recorded";
+          }
+          leaf local-symbol-period {
+            if-feature link-oam:link-monitoring;
+            type uint64;
+            mandatory true;
+            description
+              "The number of local symbol period events recorded";
+          }
+          leaf local-frame {
+            if-feature link-oam:link-monitoring;
+            type uint64;
+            mandatory true;
+            description
+              "The mumber of local frame error events recorded";
+          }
+          leaf local-frame-period {
+            if-feature link-oam:link-monitoring;
+            type uint64;
+            mandatory true;
+            description
+              "The number of local frame period events recorded";
+          }
+          leaf local-frame-seconds {
+            if-feature link-oam:link-monitoring;
+            type uint64;
+            mandatory true;
+            description
+              "The number of local frame second events recoded";
+          }
+          leaf remote-events {
+            type uint64;
+            mandatory true;
+            description
+              "The number of remote events recorded";
+          }
+          leaf remote-symbol-period {
+            if-feature link-oam:link-monitoring;
+            type uint64;
+            mandatory true;
+            description
+              "The number of remote symbol period events recorded";
+          }
+          leaf remote-frame {
+            if-feature link-oam:link-monitoring;
+            type uint64;
+            mandatory true;
+            description
+              "The mumber of remote frame error events recorded";
+          }
+          leaf remote-frame-period {
+            if-feature link-oam:link-monitoring;
+            type uint64;
+            mandatory true;
+            description
+              "The number of remote frame period events recorded";
+          }
+          leaf remote-frame-seconds {
+            if-feature link-oam:link-monitoring;
+            type uint64;
+            mandatory true;
+            description
+              "The number of remote frame second events recoded";
+          }
+        }
+      }
+    }
+  }
+
+  /*
+   * RPCs for fetching Link OAM related MIB variables from the peer
+   */
+
+  rpc get-remote-stats {
+    if-feature link-oam:remote-mib-retrieval;
+    description
+      "Retrieve Link OAM statistics from the peer for the specified
+       interface.";
+    input {
+      leaf interface {
+        type if:interface-ref;
+        mandatory true;
+        description
+          "The interface to query statistics for.";
+      }
+    }
+    output {
+      uses link-oam:statistics-common;
+    }
+  }
+  rpc get-remote-discovery-info {
+    if-feature link-oam:remote-mib-retrieval;
+    description
+      "Retrieve Link OAM discovery information from the peer for the
+       specified interface.";
+    input {
+      leaf interface {
+        type if:interface-ref;
+        mandatory true;
+        description
+          "The interface to query discovery information for.";
+      }
+    }
+    output {
+      uses link-oam:discovery-info;
+    }
+  }
+}


### PR DESCRIPTION
This pull request is to add two Link OAM modules:
- experimental/ieee/802.3/ethernet-link-oam.yang: Initial draft of a Yang model for 802.3 Link OAM. This is intended to be used as a basis for the 802.3 Yang standardization effort within IETF/IEEE.

- vendor/cisco/common/cisco-link-oam.yang: Initial draft of a Cisco-specific extension to the standard model above, that adds features specific to Cisco devices.

"pyang --ietf" output: (I believe these warnings are acceptable)

$ pyang experimental/ieee/802.3/ethernet-link-oam.yang --ietf
experimental/ieee/802.3/ethernet-link-oam.yang:5: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ethernet-link-oam"

$ pyang vendor/cisco/common/cisco-link-oam.yang --ietf
vendor/cisco/common/cisco-link-oam.yang:1: warning: IETF rule (RFC 6087: 4.9): too many top-level data nodes: ethernet-link-oam, ethernet-link-oam-state
vendor/cisco/common/cisco-link-oam.yang:5: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:cisco-link-oam"