### PR TITLE
Fix compile error due to missing reference

### DIFF
--- a/experimental/ieee/802.3/ethernet.yang
+++ b/experimental/ieee/802.3/ethernet.yang
@@ -66,10 +66,6 @@ module ethernet {
   }
 
   typedef flow-control-settings {
-    description
-      "Enumerates the possible flow control settings that can be
-       used in explicit configuration, or when reporting the
-       operational state";
     type enumeration {
       enum "disabled" {
         description 
@@ -100,6 +96,10 @@ module ethernet {
           ingress are processed to reduce the egress traffic rate.";
       }
     }
+    description
+      "Enumerates the possible flow control settings that can be
+       used in explicit configuration, or when reporting the
+       operational state";
   }
 
   augment "/if:interfaces/if:interface" {
@@ -319,8 +319,6 @@ module ethernet {
         description "Contains auto-negotiation status";
         
         leaf status {
-          description
-            "The status of the auto-negotiation protocol";
           type enumeration {
             enum "successful" {
               description
@@ -336,11 +334,12 @@ module ethernet {
                  protocol cannot run (e.g. if no medium is present)";
             }
           }
+          description
+            "The status of the auto-negotiation protocol";
         } 
       }
 
       leaf duplex {
-        description "Operational duplex setting of the interface";
         type enumeration {
           enum "full" {
             description "Full duplex";
@@ -349,18 +348,19 @@ module ethernet {
             description "Half duplex";
           }
         } 
+        description "Operational duplex setting of the interface";
       }
       
       leaf speed {
-        description "Operational speed setting of the interface";
-        units "Mb/s";
         type uint64;
+        units "Mb/s";
+        description "Operational speed setting of the interface";
       }
       
       leaf flow-control {
+        type flow-control-settings;
         description
           "Operation flow-control setting on the interface"; 
-        type flow-control-settings;
       }
     }
   }

--- a/standard/ieee/draft/ieee-types.yang
+++ b/standard/ieee/draft/ieee-types.yang
@@ -20,6 +20,8 @@ module ieee-types {
   revision 2015-09-10 {
 	  description
 		  "Initial revision.";
+      reference
+          "IEEE 802";
   }
 
   /*


### PR DESCRIPTION
Added in reference statement to fix compile error when using pyang 1.6 with --lint option.

Change approved by Marc Holness over email.

Clean pyang output:
sjc-ads-5101:rgwilton-yang$ pyang -v
pyang 1.6
sjc-ads-5101:rgwilton-yang$ pyang --lint standard/ieee/draft/ieee-types.yang 
sjc-ads-5101:rgwilton-yang$ 

Also similar fixes for ethernet.yang:
sjc-ads-5101:rgwilton-yang$ pyang --lint experimental/ieee/802.3/ethernet.yang 
experimental/ieee/802.3/ethernet.yang:1: warning: RFC 6087: 4.1: no module name prefix used
sjc-ads-5101:rgwilton-yang$ 

Note - this warning will be resolved once the IEEE 802.3 publishes a proper draft model (which we are working on).  At the moment, I'm just getting rid of the compile warnings for Benoit.