### PR TITLE
reorder key leaves, minor cleanup

### DIFF
--- a/experimental/ietf/ACL-MODEL/ietf-access-control-list.yang
+++ b/experimental/ietf/ACL-MODEL/ietf-access-control-list.yang
@@ -52,7 +52,7 @@ module ietf-access-control-list {
   }
   identity ipv4-acl {
     base acl:acl-base;
-    description 
+    description
        "ACL that primarily matches on fields from the IPv4 header
        (e.g. IPv4 destination address) and layer 4 headers (e.g. TCP
        destination port).  An acl of type ipv4-acl does not contain 
@@ -76,7 +76,7 @@ module ietf-access-control-list {
   }
   typedef acl-type {
     type identityref {
-      base acl-base;
+      base acl:acl-base;
     }
     description
       "This type is used to refer to an Access Control List
@@ -105,6 +105,20 @@ module ietf-access-control-list {
         different vendors, this
         model accommodates customizing Access Control Lists for
         each kind and for each vendor.";
+      leaf acl-name {
+        type string;
+        description
+          "The name of access-list. A device MAY restrict the length 
+    	  and value of this name, possibly space and special 
+    	  characters are not allowed.";
+      }
+      leaf acl-type {
+        type acl-type;
+        description
+	    "Type of access control list. Indicates the primary intended
+	    type of match criteria (e.g. ethernet, IPv4, IPv6, mixed, etc)
+	    used in the list instance.";
+      }
       container acl-oper-data {
         config false;
         description
@@ -119,6 +133,12 @@ module ietf-access-control-list {
           ordered-by user;
           description
             "List of access list entries(ACE)";
+          leaf rule-name {
+            type string;
+            description
+              "A unique name identifying this Access List 
+              Entry(ACE).";
+          }
           container matches {
             description
               "Definitions for match criteria for this Access List 
@@ -130,7 +150,7 @@ module ietf-access-control-list {
                       description "IP Access List Entry.";
                 choice ace-ip-version {
                   description
-                    "IP version used in this Acess List Entry.";
+                    "IP version used in this Access List Entry.";
                   case ace-ipv4 {
                     uses packet-fields:acl-ipv4-header-fields;
                   }
@@ -182,27 +202,7 @@ module ietf-access-control-list {
                 "Number of matches for this Access List Entry";
             }
           }
-          leaf rule-name {
-            type string;
-            description
-              "A unique name identifying this Access List 
-              Entry(ACE).";
-          }
         }
-      }
-      leaf acl-name {
-        type string;
-        description
-          "The name of access-list. A device MAY restrict the length 
-    	  and value of this name, possibly space and special 
-    	  characters are not allowed.";
-      }
-      leaf acl-type {
-        type acl-type;
-        description
-	    "Type of access control list. Indicates the primary intended
-	    type of match criteria (e.g. ethernet, IPv4, IPv6, mixed, etc)
-	    used in the list instance.";
       }
     }
   }


### PR DESCRIPTION
This change reorders key leaves to the top to fulfill implementations where strict ordering is required.

```
$ pyang -p ../../../standard/ietf/RFC --strict --ietf ietf-access-control-list.yang ietf-packet-fields.yang -f tree
module: ietf-access-control-list
   +--rw access-lists
      +--rw acl* [acl-type acl-name]
         +--rw acl-name               string
         +--rw acl-type               acl-type
         +--ro acl-oper-data
         +--rw access-list-entries
            +--rw ace* [rule-name]
               +--rw rule-name        string
               +--rw matches
               |  +--rw (ace-type)?
               |  |  +--:(ace-ip)
               |  |  |  +--rw (ace-ip-version)?
               |  |  |  |  +--:(ace-ipv4)
               |  |  |  |  |  +--rw destination-ipv4-network?       inet:ipv4-prefix
               |  |  |  |  |  +--rw source-ipv4-network?            inet:ipv4-prefix
               |  |  |  |  +--:(ace-ipv6)
               |  |  |  |     +--rw destination-ipv6-network?       inet:ipv6-prefix
               |  |  |  |     +--rw source-ipv6-network?            inet:ipv6-prefix
               |  |  |  |     +--rw flow-label?                     inet:ipv6-flow-label
               |  |  |  +--rw dscp?                           inet:dscp
               |  |  |  +--rw protocol?                       uint8
               |  |  |  +--rw source-port-range!
               |  |  |  |  +--rw lower-port    inet:port-number
               |  |  |  |  +--rw upper-port?   inet:port-number
               |  |  |  +--rw destination-port-range!
               |  |  |     +--rw lower-port    inet:port-number
               |  |  |     +--rw upper-port?   inet:port-number
               |  |  +--:(ace-eth)
               |  |     +--rw destination-mac-address?        yang:mac-address
               |  |     +--rw destination-mac-address-mask?   yang:mac-address
               |  |     +--rw source-mac-address?             yang:mac-address
               |  |     +--rw source-mac-address-mask?        yang:mac-address
               |  +--rw input-interface?                string
               +--rw actions
               |  +--rw (packet-handling)?
               |     +--:(deny)
               |     |  +--rw deny?     empty
               |     +--:(permit)
               |        +--rw permit?   empty
               +--ro ace-oper-data
                  +--ro match-counter?   yang:counter64
```