### PR TITLE
Adding Juniper directory

### DIFF
--- a/vendor/juniper/README
+++ b/vendor/juniper/README
@@ -1,0 +1,1 @@
+Please refer to https://github.com/Juniper/yang


### PR DESCRIPTION
Adding juniper under vendor directory. The README file points to the Juniper's official yang placeholder.