### PR TITLE
Fix to use ietf_dir

### DIFF
--- a/standard/ietf/check.sh
+++ b/standard/ietf/check.sh
@@ -11,10 +11,11 @@ to_check="RFC"
 pyang_flags="--verbose"
 
 checkDir () {
-    echo Checking yang files in $1
+    local dir="$ietf_dir/$1"
+    echo Checking yang files in $dir
     exit_status=""
     cwd=`pwd`
-    cd $1
+    cd $dir
     printf "\n"
     for f in *.yang; do
         printf "pyang $pyang_flags $f\n"


### PR DESCRIPTION
Script wasn't using ietf_dir and so was failing. However, this
wasn't detected.

Script output:

% standard/ietf/check.sh
Checking modules with pyang command:

    pyang --verbose MODULE

Checking yang files in standard/ietf/RFC
/Users/william/Applications/yang/standard/ietf/RFC

pyang --verbose iana-crypt-hash@2014-08-06.yang
pyang --verbose iana-if-type.yang
pyang --verbose ietf-complex-types@2011-03-15.yang
pyang --verbose ietf-inet-types.yang
pyang --verbose ietf-inet-types@2010-09-24.yang
pyang --verbose ietf-inet-types@2013-07-15.yang
pyang --verbose ietf-interfaces@2014-05-08.yang
pyang --verbose ietf-ip@2014-06-16.yang
pyang --verbose ietf-ipfix-psamp@2012-09-05.yang
pyang --verbose ietf-netconf-acm@2012-02-22.yang
pyang --verbose ietf-netconf-monitoring@2010-10-04.yang
pyang --verbose ietf-netconf-notifications.yang
pyang --verbose ietf-netconf-partial-lock.yang
pyang --verbose ietf-netconf-time@2016-01-26.yang
pyang --verbose ietf-netconf-with-defaults.yang
pyang --verbose ietf-netconf@2011-06-01.yang
pyang --verbose ietf-snmp-common.yang
pyang --verbose ietf-snmp-community.yang
pyang --verbose ietf-snmp-engine.yang
pyang --verbose ietf-snmp-notification.yang
pyang --verbose ietf-snmp-proxy.yang
pyang --verbose ietf-snmp-ssh.yang
pyang --verbose ietf-snmp-target.yang
pyang --verbose ietf-snmp-tls.yang
pyang --verbose ietf-snmp-tsm.yang
pyang --verbose ietf-snmp-usm.yang
pyang --verbose ietf-snmp-vacm.yang
pyang --verbose ietf-snmp.yang
pyang --verbose ietf-system@2014-08-06.yang
pyang --verbose ietf-template@2010-05-18.yang
pyang --verbose ietf-x509-cert-to-name.yang
pyang --verbose ietf-yang-library@2016-06-21.yang
pyang --verbose ietf-yang-smiv2@2012-06-22.yang
pyang --verbose ietf-yang-types.yang
pyang --verbose ietf-yang-types@2010-09-24.yang
pyang --verbose ietf-yang-types@2013-07-15.yang