### PR TITLE
Add experimental module for IEEE Std 802.1Qbv-2015.

### DIFF
--- a/experimental/ieee/802.1/ieee802-dot1q-sched.yang
+++ b/experimental/ieee/802.1/ieee802-dot1q-sched.yang
@@ -1,0 +1,454 @@
+module ieee802-dot1q-sched {
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-sched";
+  prefix "sched";
+
+  import ietf-yang-types { prefix yang; }
+  import ietf-interfaces { prefix "if"; }
+  import ieee802-dot1q-bridge { prefix "dot1q"; }
+
+  organization
+    "National Instruments";
+
+  contact
+    "Web URL: http://ni.com 
+    Rodney Cummings 
+    Rodney.Cummings@ni.com";
+
+  description
+    "This module provides for management of IEEE Std 802.1Q Bridges
+    that support Scheduled Traffic Enhancements. 
+    
+    This experimental YANG module is an individual contribution, and
+    does not represent a formally sanctioned YANG module of IEEE.
+    Therefore, this YANG module will change in incompatible ways
+    from its current revision to the formally published YANG
+    module for IEEE Std 802.1Qbv-2015.";
+
+  revision 2016-11-11 {
+    description
+      "Module for IEEE Std 802.1Qbv-2015, Enhancements for Scheduled Traffic";
+    reference
+      "IEEE Std 802.1Qbv-2015";
+  }
+
+  /*
+  * IEEE 802.1Qbv-2015 operation name identities.
+  */
+  identity type-of-operation {
+    description
+      "Represents the operation type (name).";
+  }
+  identity set-gate-states {
+    base type-of-operation;
+    description
+      "Operation to set the gate states.";
+  }
+  
+  feature scheduled-traffic {
+    description
+      "Each Port supports the Enhancements for Scheduled Traffic.";
+    reference
+      "IEEE Std 802.1Qbv-2015";
+  }
+  
+  typedef traffic-class {
+    type uint8 {
+      range "0..7";
+    }
+    description
+      "This is the numerical value associated with a traffic
+      class in a Bridge. Larger values are associated with
+      higher priority traffic classes.
+      
+      TODO: The typedef is likely to be included in an update
+      to the draft ieee802-dot1q-types as part of the
+      IEEE P802.1Qcp project.";
+    reference
+      "IEEE Std 802.1Q-2014: 3.239";
+  }
+
+  grouping ptp-timestamp {
+    description
+      "This grouping specifies a PTP timestamp, 
+      represented as a 48-bit unsigned integer number of seconds 
+      and a 32-bit unsigned integer number of nanoseconds.";
+    reference
+      "IEEE Std 802.1AS-2011: 6.3.3.4";
+    leaf seconds {
+      type uint64;
+      description
+        "This is the integer portion of the timestamp in units of seconds.
+        The upper 16 bits are always zero.";
+    }
+    leaf fractional-seconds {
+      type uint64;
+      description
+        "This is the fractional portion of the timestamp 
+        in units of nanoseconds. This value is always 
+        less than 10^9.";
+    }
+  }
+
+  grouping gate-control-entry {
+    description
+      "This grouping specifies a GateControlEntry, an
+      entry in the gate control list for scheduled traffic.";
+    reference
+      "IEEE Std 802.1Qbv-2015: 12.29.1.2.1";
+    leaf operation-name {
+      type identityref {
+        base type-of-operation;
+      }
+      mandatory true;
+      description
+        "The name (type) of the operation for this entry.";
+    }
+    container sgs-params {
+      when "sched:operation-name = 'set-gate-states'" {
+        description
+          "Applies to the SetGateStates operation.";
+      }
+      description
+        "Contains parameters for the SetGateStates operation.";
+      reference
+        "IEEE Std 802.1Qbv-2015: 8.6.8.4, 12.29.1.2.1";
+      
+      leaf gate-states-value {
+        type uint8;
+        description
+          "gateStatesValue is the gate states for this entry for the Port.
+          The gates are immediately set to the states in gateStatesValue 
+          when this entry execiutes.
+          The bits of the octet represent the gate states for the
+          corresponding traffic classes; the most-significant bit 
+          corresponds to traffic class 7, the least-significant bit 
+          to traffic class 0. A bit value of 0 indicates closed; a
+          bit value of 1 indicates open.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.4, 12.29.1.2.2";
+      }
+      leaf time-interval-value {
+        type uint32;
+        description
+          "timeIntervalValue is a 32-bit unsigned integer, 
+          representing a number of nanoseconds.
+          After timeIntervalValue nanoseconds have
+          elapsed since the completion of the previous entry in the
+          gate control list, control passes to the next entry.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.4, 12.29.1.2.3";
+      }
+    }
+  }
+
+  augment "/if:interfaces/if:interface/dot1q:bridge-port" {
+    if-feature scheduled-traffic;
+    description
+      "Augment the dot1q bridge-port with Scheduled Traffic configuration.";
+    
+    list max-sdu-table {
+      key "traffic-class";
+      description
+        "A table (list) containing a set of max SDU
+        parameters, one for each traffic class.
+        All writable objects in this table must be
+        persistent over power up restart/reboot.";   
+      reference
+        "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9, 12.29.1";
+      leaf traffic-class {
+        type traffic-class;
+        description
+          "Traffic class";
+      }     
+      leaf queue-max-sdu {
+        type uint32;
+        default "0";
+        description
+          "The value of the queueMaxSDU parameter for the traffic class.
+          A value of 0 is interpreted as the max SDU size supported by
+          the underlying MAC. The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9, 12.29.1.1.1";
+      }        
+      leaf transmission-overrun {
+        type yang:counter64;
+        default "0";
+        description
+          "A counter of transmission overrun events, where
+          a PDU is still being transmitted by a MAC at the
+          time when the transmission gate for the queue closed.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9, 12.29.1.1.2";
+      }
+    }
+      
+    container gate-parameters {
+      description
+        "A table (list) that contains the per-port 
+        managable parameters for traffic scheduling.
+        For a given Port, an entry in the table exists.
+        All writable objects in this table must be
+        persistent over power up restart/reboot.";
+      reference
+        "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9, 12.29.1";
+      
+      leaf gate-enabled {
+        type boolean;
+        description
+          "The GateEnabled parameter determines whether traffic scheduling
+          is active (true) or inactive (false).
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.2, 8.6.9.4.14, 12.29.1";
+      }
+      leaf admin-gate-states {
+        type uint8;
+        description
+          "AdminGateStates is the administrative value of the 
+          initial gate states for the Port.
+          The bits of the octet represent the gate states for the
+          corresponding traffic classes; the most-significant bit 
+          corresponds to traffic class 7, the least-significant bit 
+          to traffic class 0. A bit value of 0 indicates closed; a
+          bit value of 1 indicates open.
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.5, 12.29.1";
+      }
+      leaf oper-gate-states {
+        type uint8;
+        description
+          "OperGateStates is the operational value of the 
+          current gate states for the Port.
+          The bits of the octet represent the gate states for the
+          corresponding traffic classes; the most-significant bit 
+          corresponds to traffic class 7, the least-significant bit 
+          to traffic class 0. A bit value of 0 indicates closed; a
+          bit value of 1 indicates open.
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.22, 12.29.1";
+      }
+      leaf admin-control-list-length {
+        type uint32;
+        description
+          "AdminControlListLength is the number of entries in the
+          AdminControlList.
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.6, 12.29.1.2";
+      }
+      leaf oper-control-list-length {
+        type uint32;
+        description
+          "OperControlListLength is the number of entries in the
+          OperControlList.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.23, 12.29.1.2";
+      }
+      list admin-control-list {
+        key "index";
+        description
+          "AdminControlList is the administrative value of the 
+          gate control list for the Port.
+          
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9.4.2, 12.29.1.2";
+        
+        leaf index {
+          type uint32;
+          description
+            "This index is provided in order to provide a unique 
+            key per list entry.
+            
+            The value of index for each entry shall be unique
+            (but not neccesarily contiguous).";
+        }
+          
+        uses gate-control-entry;
+      }
+      list oper-control-list {
+        key "index";
+        description
+          "OperControlList is the operational value of the 
+          gate control list for the Port.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9.4.19, 12.29.1.2";
+        
+        leaf index {
+          type uint32;
+          description
+            "This index is provided in order to provide a unique 
+            key per list entry.
+            
+            The value of index for each entry shall be unique
+            (but not neccesarily contiguous).";
+        }
+          
+        uses gate-control-entry;
+      }     
+      container admin-cycle-time {
+        description
+          "AdminCycleTime specifies the administrative value 
+          of the gating cycle time for the Port.
+          
+          AdminCycleTime is a rational number of seconds,
+          defined by an integer numerator and an integer
+          denominator.
+          
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9.4.3, 12.29.1";
+        leaf numerator {
+          type uint32;
+          description "AdminCycleTime’s numerator.";
+        }
+        leaf denominator {
+          type uint32;
+          description "AdminCycleTime’s denominator.";
+        }
+      }
+      container oper-cycle-time {
+        description
+          "OperCycleTime specifies the operational value 
+          of the gating cycle time for the Port.
+          
+          OperCycleTime is a rational number of seconds,
+          defined by an integer numerator and an integer
+          denominator.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9.4.20, 12.29.1";
+        leaf numerator {
+          type uint32;
+          description "OperCycleTime’s numerator.";
+        }
+        leaf denominator {
+          type uint32;
+          description "OperCycleTime’s denominator.";
+        }
+      }
+      leaf admin-cycle-time-extension {
+        type uint32;
+        description
+          "An unsigned integer number of nanoseconds, 
+          defining the maximum amount of time by which the gating cycle 
+          for the Port is permitted to be extended when a new cycle 
+          configuration is being installed. This is the
+          administrative value.
+          
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.4, 12.29.1";
+      }
+      leaf oper-cycle-time-extension {
+        type uint32;
+        description
+          "An unsigned integer number of nanoseconds, 
+          defining the maximum amount of time by which the gating cycle 
+          for the Port is permitted to be extended when a new cycle 
+          configuration is being installed. This is the
+          operational value.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.21, 12.29.1";
+      }
+      container admin-base-time {
+        description
+          "The administrative value of the base time at which 
+          gating cycles begin, expressed as an IEEE 1588 precision time 
+          protocol (PTP) timescale.
+          
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.1, 12.29.1";
+        uses ptp-timestamp;
+      }
+      container oper-base-time {
+        description
+          "The operational value of the base time at which 
+          gating cycles begin, expressed as an IEEE 1588 precision time 
+          protocol (PTP) timescale.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.18, 12.29.1";
+        uses ptp-timestamp;
+      }
+      leaf config-change {
+        type boolean;
+        description
+          "The ConfigChange parameter signals the start of a
+          configuration change when it is set to TRUE, indicating
+          that the administrative parmaeters for the Port are ready 
+          to be copied into their corresponding operational parameters.
+          This should only be done when the various administrative 
+          parameters are all set to appropriate values.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.7, 12.29.1";
+      }
+      container config-change-time {
+        description
+          "The time at which the next config change is scheduled to occur.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.9, 12.29.1";
+        uses ptp-timestamp;
+      }
+      leaf tick-granularity {
+        type uint32;
+        description
+          "The granularity of the cycle time clock, represented as an
+          unsigned number of tenths of nanoseconds.
+          
+          The value must be retained across
+          reinitializations of the management system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 12.29.1";
+      }
+      container current-time {
+        description
+          "The current time as maintained by the local system.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.10, 12.29.1";
+        uses ptp-timestamp;
+      }
+      leaf config-pending {
+        type boolean;
+        description
+          "The value of the ConfigPending state machine variable.
+          The value is TRUE if a configuration change is in progress
+          but has not yet completed.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.8, 12.29.1";
+      }
+      leaf config-change-error {
+        type yang:counter64;
+        description
+          "A counter of the number of times that a re-configuration
+          of the traffic schedule has been requested with the old
+          schedule still running and the requested base time was
+          in the past.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.3.1, 12.29.1";
+      }
+      leaf support-list-max {
+        type uint32;
+        description
+          "The maximum value supported by this Port for the
+          AdminControlListLength and OperControlListLength
+          parameters. It is available for use by schedule 
+          computation software to determine the port’s control list
+          capacity prior to computation.";
+        reference
+          "IEEE Std 802.1Qbv-2015: 8.6.9.4.21, 12.29.1.5";
+      }
+    }    
+  }
+}
+


### PR DESCRIPTION
This branch contains one new module in experimental/ieee/802.1 for experimental development with IEEE Std 802.1Qbv-2015. The module augments the draft modules of P802.1Qcp (editor Marc Holness). The following pyang validation with the appropriate IETF and IEEE802 modules:
   pyang --strict --lint --canonical ieee802-dot1q-sched.yang
returns empty output (no warnings/errors). 

The following pyang validation:
   pyang --strict --lint --canonical --ietf ieee802-dot1q-sched.yang
returns
ieee802-dot1q-sched.yang:1: warning: RFC 6087: 4.1: the module name should start with one of the strings "ietf-" or "iana-"
ieee802-dot1q-sched.yang:2: warning: RFC 6087: 4.8: namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-sched"

as expected, since ieee prefixes are not yet recognized by pyang.