### PR TITLE
Update 802.1 YANG draft modules

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1ax.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1ax.yang
@@ -1,6 +1,6 @@
 module ieee802-dot1ax {
 
-  namespace "urn:ieee:params:xml:ns:yang:ieee802-dot1ax";
+  namespace "urn:ieee:std:802.1AX:yang:ieee802-dot1ax";
   prefix "dot1ax";
 
   import ieee802-types { prefix "ieee";}

--- a/standard/ieee/802.1/draft/ieee802-dot1q-bridge.tree
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-bridge.tree
@@ -1,0 +1,299 @@
+module: ieee802-dot1q-bridge
+   +--rw bridges
+   |  +--rw bridge* [name]
+   |     +--rw name           dot1qtypes:name-type
+   |     +--rw address        ieee:mac-address
+   |     +--rw bridge-type    identityref
+   |     +--rw component* [name]
+   |        +--rw name                     string
+   |        +--rw id?                      uint32
+   |        +--rw type                     identityref
+   |        +--rw address?                 ieee:mac-address
+   |        +--rw traffic-class-enabled?   boolean
+   |        +--rw mmrp-enabled-status?     boolean
+   |        +--rw filtering-database
+   |        |  +--rw aging-time?                  uint32
+   |        |  +--rw filtering-entries* [database-id vids address]
+   |        |  |  +--rw database-id    uint16
+   |        |  |  +--rw address        ieee:mac-address
+   |        |  |  +--rw vids           dot1qtypes:vid-range
+   |        |  |  +--rw entry-type?    enumeration
+   |        |  |  +--rw port-map* [port-number]
+   |        |  |     +--rw port-number                          if:interface-ref
+   |        |  |     +--rw (map-type)?
+   |        |  |        +--:(static-filtering-entries)
+   |        |  |        |  +--rw static-filtering-entries
+   |        |  |        |     +--rw control-element?         enumeration
+   |        |  |        |     +--rw connection-identifier?   port-number-type
+   |        |  |        +--:(static-vlan-registration-entries)
+   |        |  |        |  +--rw static-vlan-registration-entries
+   |        |  |        |     +--rw registrar-admin-control?   enumeration
+   |        |  |        |     +--rw vlan-transmitted?          enumeration
+   |        |  |        +--:(mac-address-registration-entries)
+   |        |  |        |  +--rw mac-address-registration-entries
+   |        |  |        |     +--rw control-element?   enumeration
+   |        |  |        +--:(dynamic-vlan-registration-entries)
+   |        |  |        |  +--rw dynamic-vlan-registration-entries
+   |        |  |        |     +--rw control-element?   enumeration
+   |        |  |        +--:(dynamic-reservation-entries)
+   |        |  |        |  +--rw dynamic-reservation-entries
+   |        |  |        |     +--rw control-element?   enumeration
+   |        |  |        +--:(dynamic-filtering-entries)
+   |        |  |           +--rw dynamic-filtering-entries
+   |        |  |              +--rw control-element?   enumeration
+   |        |  +--rw vlan-registration-entries* [database-id vids]
+   |        |     +--rw database-id    uint32
+   |        |     +--rw vids           dot1qtypes:vid-range
+   |        |     +--rw entry-type?    enumeration
+   |        |     +--rw port-map* [port-number]
+   |        |        +--rw port-number                          if:interface-ref
+   |        |        +--rw (map-type)?
+   |        |           +--:(static-filtering-entries)
+   |        |           |  +--rw static-filtering-entries
+   |        |           |     +--rw control-element?         enumeration
+   |        |           |     +--rw connection-identifier?   port-number-type
+   |        |           +--:(static-vlan-registration-entries)
+   |        |           |  +--rw static-vlan-registration-entries
+   |        |           |     +--rw registrar-admin-control?   enumeration
+   |        |           |     +--rw vlan-transmitted?          enumeration
+   |        |           +--:(mac-address-registration-entries)
+   |        |           |  +--rw mac-address-registration-entries
+   |        |           |     +--rw control-element?   enumeration
+   |        |           +--:(dynamic-vlan-registration-entries)
+   |        |           |  +--rw dynamic-vlan-registration-entries
+   |        |           |     +--rw control-element?   enumeration
+   |        |           +--:(dynamic-reservation-entries)
+   |        |           |  +--rw dynamic-reservation-entries
+   |        |           |     +--rw control-element?   enumeration
+   |        |           +--:(dynamic-filtering-entries)
+   |        |              +--rw dynamic-filtering-entries
+   |        |                 +--rw control-element?   enumeration
+   |        +--rw permanent-database
+   |        |  +--rw filtering-entries* [database-id vids address]
+   |        |     +--rw database-id    uint16
+   |        |     +--rw address        ieee:mac-address
+   |        |     +--rw vids           dot1qtypes:vid-range
+   |        |     +--rw port-map* [port-number]
+   |        |        +--rw port-number                          if:interface-ref
+   |        |        +--rw (map-type)?
+   |        |           +--:(static-filtering-entries)
+   |        |           |  +--rw static-filtering-entries
+   |        |           |     +--rw control-element?         enumeration
+   |        |           |     +--rw connection-identifier?   port-number-type
+   |        |           +--:(static-vlan-registration-entries)
+   |        |           |  +--rw static-vlan-registration-entries
+   |        |           |     +--rw registrar-admin-control?   enumeration
+   |        |           |     +--rw vlan-transmitted?          enumeration
+   |        |           +--:(mac-address-registration-entries)
+   |        |           |  +--rw mac-address-registration-entries
+   |        |           |     +--rw control-element?   enumeration
+   |        |           +--:(dynamic-vlan-registration-entries)
+   |        |           |  +--rw dynamic-vlan-registration-entries
+   |        |           |     +--rw control-element?   enumeration
+   |        |           +--:(dynamic-reservation-entries)
+   |        |           |  +--rw dynamic-reservation-entries
+   |        |           |     +--rw control-element?   enumeration
+   |        |           +--:(dynamic-filtering-entries)
+   |        |              +--rw dynamic-filtering-entries
+   |        |                 +--rw control-element?   enumeration
+   |        +--rw bridge-vlan
+   |           +--rw vlan-id* [vid]
+   |           |  +--rw vid     dot1qtypes:vlan-index
+   |           |  +--rw name?   dot1qtypes:name-type
+   |           +--rw protocol-group-database {port-and-protocol-based-vlan}?
+   |           |  +--rw frame-format-type?   dot1qtypes:protocol-template-format
+   |           |  +--rw (frame-format)?
+   |           |  |  +--:(ethernet-rfc1042-snap8021H)
+   |           |  |  |  +--rw ether-type?          string
+   |           |  |  +--:(snap-other)
+   |           |  |  |  +--rw protocol-id?         string
+   |           |  |  +--:(llc-other)
+   |           |  |     +--rw dsap-ssap-pairs
+   |           |  |        +--rw llc-address?   string
+   |           |  +--rw protocol-group-id?   uint32
+   |           +--rw vid-to-fid
+   |              +--rw vid?   dot1qtypes:vlan-index
+   |              +--rw fid?   uint32
+   +--ro bridges-state
+      +--ro bridge* [name]
+         +--ro name          dot1qtypes:name-type
+         +--ro ports?        dot1qtypes:port-number-type
+         +--ro up-time?      yang:counter32
+         +--ro components?   uint32
+         +--ro component* [name]
+            +--ro name                  string
+            +--ro ports?                dot1qtypes:port-number-type
+            +--ro bridge-port*          if:interface-ref
+            +--ro capabilities
+            |  +--ro extended-filtering?             boolean
+            |  +--ro traffic-classes?                boolean
+            |  +--ro static-entry-individual-port?   boolean
+            |  +--ro ivl-capable?                    boolean
+            |  +--ro svl-capable?                    boolean
+            |  +--ro hybrid-capable?                 boolean
+            |  +--ro configurable-pvid-tagging?      boolean
+            |  +--ro local-vlan-capable?             boolean
+            +--ro filtering-database
+            |  +--ro size?                                uint16
+            |  +--ro static-entries?                      uint16
+            |  +--ro dynamic-entries?                     yang:gauge32
+            |  +--ro static-vlan-registration-entries?    uint16
+            |  +--ro dynamic-vlan-registration-entries?   yang:gauge32
+            |  +--ro mac-address-registration-entries?    yang:gauge32 {extended-filtering-services}?
+            |  +--ro filtering-entries* [database-id vids address]
+            |     +--ro database-id    uint32
+            |     +--ro address        ieee:mac-address
+            |     +--ro vids           dot1qtypes:vid-range
+            |     +--ro status?        enumeration
+            +--ro permanent-database
+            |  +--ro size?                               yang:gauge32
+            |  +--ro static-entries?                     yang:gauge32
+            |  +--ro static-vlan-registration-entries?   yang:gauge32
+            +--ro bridge-vlan
+               +--ro version?                 uint16
+               +--ro max-vids?                uint16
+               +--ro override-default-pvid?   boolean
+               +--ro protocol-template?       dot1qtypes:protocol-template-format {port-and-protocol-based-vlan}?
+               +--ro max-msti?                uint16
+               +--ro vlan-id* [vid]
+               |  +--ro vid               dot1qtypes:vlan-index
+               |  +--ro untagged-ports*   if:interface-ref
+               |  +--ro egress-ports*     if:interface-ref
+               +--ro vid-to-fid-allocation* [vids]
+               |  +--ro vids               dot1qtypes:vid-range
+               |  +--ro fid?               uint32
+               |  +--ro allocation-type?   enumeration
+               +--ro fid-to-vid-allocation* [fid]
+                  +--ro fid     uint32
+                  +--ro vids* [vid]
+                     +--ro vid                dot1qtypes:vlan-index
+                     +--ro allocation-type?   enumeration
+augment /if:interfaces/if:interface:
+   +--rw bridge-port
+      +--rw component-name?                      dot1qtypes:component-ref
+      +--rw service-interface?                   if:interface-ref
+      +--rw pvid?                                dot1qtypes:vlan-index
+      +--rw default-priority?                    dot1qtypes:priority-type
+      +--rw priority-regeneration
+      |  +--rw priority0?   priority-type
+      |  +--rw priority1?   priority-type
+      |  +--rw priority2?   priority-type
+      |  +--rw priority3?   priority-type
+      |  +--rw priority4?   priority-type
+      |  +--rw priority5?   priority-type
+      |  +--rw priority6?   priority-type
+      |  +--rw priority7?   priority-type
+      +--rw pcp-selection?                       dot1qtypes:pcp-selection-type
+      +--rw pcp-decoding-table
+      |  +--rw selection-type?   dot1qtypes:pcp-selection-type
+      |  +--rw decoding-table
+      |     +--rw pcp0
+      |     |  +--rw priority?        priority-type
+      |     |  +--rw drop-eligible?   boolean
+      |     +--rw pcp1
+      |     |  +--rw priority?        priority-type
+      |     |  +--rw drop-eligible?   boolean
+      |     +--rw pcp2
+      |     |  +--rw priority?        priority-type
+      |     |  +--rw drop-eligible?   boolean
+      |     +--rw pcp3
+      |     |  +--rw priority?        priority-type
+      |     |  +--rw drop-eligible?   boolean
+      |     +--rw pcp4
+      |     |  +--rw priority?        priority-type
+      |     |  +--rw drop-eligible?   boolean
+      |     +--rw pcp5
+      |     |  +--rw priority?        priority-type
+      |     |  +--rw drop-eligible?   boolean
+      |     +--rw pcp6
+      |     |  +--rw priority?        priority-type
+      |     |  +--rw drop-eligible?   boolean
+      |     +--rw pcp7
+      |        +--rw priority?        priority-type
+      |        +--rw drop-eligible?   boolean
+      +--rw pcp-encoding-table
+      |  +--rw selection-type?   dot1qtypes:pcp-selection-type
+      |  +--rw encoding-table
+      |     +--rw priority0
+      |     |  +--rw pcp-dei-false?   priority-type
+      |     |  +--rw pcp-dei-true?    priority-type
+      |     +--rw priority1
+      |     |  +--rw pcp-dei-false?   priority-type
+      |     |  +--rw pcp-dei-true?    priority-type
+      |     +--rw priority2
+      |     |  +--rw pcp-dei-false?   priority-type
+      |     |  +--rw pcp-dei-true?    priority-type
+      |     +--rw priority3
+      |     |  +--rw pcp-dei-false?   priority-type
+      |     |  +--rw pcp-dei-true?    priority-type
+      |     +--rw priority4
+      |     |  +--rw pcp-dei-false?   priority-type
+      |     |  +--rw pcp-dei-true?    priority-type
+      |     +--rw priority5
+      |     |  +--rw pcp-dei-false?   priority-type
+      |     |  +--rw pcp-dei-true?    priority-type
+      |     +--rw priority6
+      |     |  +--rw pcp-dei-false?   priority-type
+      |     |  +--rw pcp-dei-true?    priority-type
+      |     +--rw priority7
+      |        +--rw pcp-dei-false?   priority-type
+      |        +--rw pcp-dei-true?    priority-type
+      +--rw use-dei?                             boolean
+      +--rw drop-encoding?                       boolean
+      +--rw service-access-priority-selection?   enumeration
+      +--rw service-access-priority
+      |  +--rw priority0?   priority-type
+      |  +--rw priority1?   priority-type
+      |  +--rw priority2?   priority-type
+      |  +--rw priority3?   priority-type
+      |  +--rw priority4?   priority-type
+      |  +--rw priority5?   priority-type
+      |  +--rw priority6?   priority-type
+      |  +--rw priority7?   priority-type
+      +--rw traffic-class
+      |  +--rw tc-entries* [priority]
+      |     +--rw priority        priority-type
+      |     +--rw available-TC* [traffic-class]
+      |        +--rw traffic-class    traffic-class-type
+      |        +--rw num-tc?          priority-type
+      +--rw acceptable-frame?                    enumeration
+      +--rw enable-ingress-filtering?            boolean
+      +--rw restricted-vlan-registration?        boolean
+      +--rw vid-translation-table?               boolean
+      +--rw egress-vid-translation-table?        boolean
+      +--rw protocol-group-id?                   uint16 {port-and-protocol-based-vlan}?
+      +--rw protocol-group-database-contents {port-and-protocol-based-vlan}?
+      |  +--rw template?   dot1qtypes:protocol-template-format
+      |  +--rw group-id?   uint16
+      +--rw admin-point-to-point?                uint16
+      +--rw vid-translations* [local-vid]
+      |  +--rw local-vid    ieee:vlanid
+      |  +--rw relay-vid?   ieee:vlanid
+      +--rw egress-vid-translations* [relay-vid]
+         +--rw relay-vid    ieee:vlanid
+         +--rw local-vid?   ieee:vlanid
+augment /if:interfaces-state/if:interface:
+   +--ro bridge-port-state
+      +--ro protocol-based-vlan-classification?   boolean {port-and-protocol-based-vlan}?
+      +--ro max-vid-set-entries?                  uint16 {port-and-protocol-based-vlan}?
+      +--ro port-number?                          dot1qtypes:port-number-type
+      +--ro port-type?                            identityref
+      +--ro address?                              ieee:mac-address
+      +--ro capabilities?                         uint16
+      +--ro type-capabilties?                     uint16
+      +--ro external?                             boolean
+      +--ro oper-point-to-point?                  boolean
+      +--ro bridge-port-statistics
+         +--ro delay-exceeded-discards?          yang:counter64
+         +--ro mtu-exceeded-discards?            yang:counter64
+         +--ro frame-rx?                         yang:counter64
+         +--ro octets-rx?                        yang:counter64
+         +--ro frame-tx?                         yang:counter64
+         +--ro octets-tx?                        yang:counter64
+         +--ro discard-inbound?                  yang:counter64
+         +--ro forward-outbound?                 yang:counter64
+         +--ro discard-lack-of-buffers?          yang:counter64
+         +--ro discard-transit-delay-exceeded?   yang:counter64
+         +--ro discard-on-error?                 yang:counter64
+         +--ro discard-on-ingress-filtering?     yang:counter64 {ingress-filtering}?
+         +--ro discard-ttl-expired?              yang:counter64 {flow-filtering}?

--- a/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
@@ -1,6 +1,6 @@
 module ieee802-dot1q-bridge {
 
-  namespace "urn:ieee:params:xml:ns:yang:ieee802-dot1q-bridge";
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-bridge";
   prefix "dot1q";
 
   import ieee802-types { prefix "ieee"; }
@@ -221,6 +221,18 @@ module ieee802-dot1q-bridge {
   }
 
   /*
+   * Generic bridge Interface
+   */
+  identity bridgeInterface {
+    description
+      "Generic interface property that represents any interface that
+      can be associated with an IEEE 802.1Q compliant Bridge
+      component. Any new Interface types would derive from this
+      identity to automatically pick up Bridge related configuration
+      or operational data.";
+  }
+
+  /*
    * IEEE 802.1Q Bridge features.
    */
 
@@ -284,6 +296,17 @@ module ieee802-dot1q-bridge {
       flow.";
     reference
       "IEEE 802.1Q-2014 Clause 44.2";
+  }
+  feature simple-bridge-port {
+    description
+      "A simple bridge port allows underlying (MAC) layers to share
+      the same Interface as the Bridge Port.";
+  }
+  feature flexible-bridge-port {
+    description
+      "A flexible bridge port supports an Interface that is a Bridge
+      Port to be a separate Interface from the underlying (MAC)
+      layer.";
   }
 
   container bridges {
@@ -424,7 +447,7 @@ module ieee802-dot1q-bridge {
           }
 
           list filtering-entries {
-            key "database-id vid address";
+            key "database-id vids address";
             description
               "Information for the entries associated with the
               Permanent Database.";
@@ -444,8 +467,8 @@ module ieee802-dot1q-bridge {
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
-            leaf vid {
-              type ieee:vlanid;
+            leaf vids {
+              type dot1qtypes:vid-range;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
@@ -472,7 +495,7 @@ module ieee802-dot1q-bridge {
           }
 
           list vlan-registration-entries {
-            key "database-id vid";
+            key "database-id vids";
             description
               "The VLAN Registration Entries models the operations
               that can be performed on a single VLAN Registration
@@ -488,8 +511,8 @@ module ieee802-dot1q-bridge {
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
-            leaf vid {
-              type ieee:vlanid;
+            leaf vids {
+              type dot1qtypes:vid-range;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
@@ -522,7 +545,7 @@ module ieee802-dot1q-bridge {
             that can be performed on, or affect, the Permanent
             Database. There is a single Permanent Database per FDB.";
           list filtering-entries {
-            key "database-id vid address";
+            key "database-id vids address";
             description
               "Information for the entries associated with the
               Permanent Database.";
@@ -542,8 +565,8 @@ module ieee802-dot1q-bridge {
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
-            leaf vid {
-              type ieee:vlanid;
+            leaf vids {
+              type dot1qtypes:vid-range;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
@@ -574,7 +597,7 @@ module ieee802-dot1q-bridge {
             reference
               "IEEE 802.1Q-2014 Clause 12.10.2";
             leaf vid {
-              type ieee:vlanid;
+              type dot1qtypes:vlan-index;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
@@ -615,7 +638,8 @@ module ieee802-dot1q-bridge {
                 the frame type, the octet string will have one of
                 the following values:
                   - For ethernet, rfc1042 and snap8021H, this is the
-                    16-bit (2-octet) IEEE 802.3 Type Field.
+                    16-bit (2-octet) IEEE 802 Clause 9.3 EtherType
+                    field.
                   - For snapOther, this is the 40-bit (5-octet) PID.
                   - For llcOther, this is the 2-octet IEEE 802.2
                     Link Service Access Point (LSAP) pair: first
@@ -633,10 +657,10 @@ module ieee802-dot1q-bridge {
                     length "2";
                   }
                   description
-                    "Format containing the 16-bit IEEE 802.3
+                    "Format containing the 16-bit IEEE 802
                     EtherType field.";
                   reference
-                    "IEEE 802.1Q-2014 Clause 12.10.1.7.1";
+                    "IEEE 802-2014 Clause 9.3";
                 }
               }
               case snap-other {
@@ -684,48 +708,19 @@ module ieee802-dot1q-bridge {
                 "IEEE 802.1Q-2014 Clause 6.12.2";
             }
           }
-          /*
-          list vid-to-fid-allocation {
-            key "vids";
-            description
-              "The VID to FID allocations managed object models
-              operations that modify, or inquire about VID to FID
-              allocations.";
-            leaf vids {
-              type dot1qtypes:vid-range;
-              description
-                "Range of VLAN identifiers.";
-              reference
-                "IEEE 802.1Q-2014 Clause 12.10.3";
-            }
-          }
-          list fid-to-vid-allocation {
-            key "fid";
-            description
-              "The FID to VID allocations managed object models
-              operations that modify, or inquire about FID to VID
-              allocations.";
-            leaf fid {
-              type uint16;
-              description
-                "The Filtering Database used by a set of VIDs.";
-              reference
-                "IEEE 802.1Q-2014 Clause 12.10.3";
-            }
-          }
-          */
+
           container vid-to-fid {
             description
               "Fixed allocation of a VID to an FID";
             leaf vid {
-              type ieee:vlanid;
+              type dot1qtypes:vlan-index;
               description
                 "The VLAN identifier.";
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
             leaf fid {
-              type uint16;
+              type uint32;
               description
                 "The Filtering Database used by this VLAN";
               reference
@@ -937,7 +932,7 @@ module ieee802-dot1q-bridge {
           }
 
           list filtering-entries {
-            key "database-id vid address";
+            key "database-id vids address";
             description
               "A table containing filtering information for
               Unicast/Multicast/Broadcast MAC addresses for each
@@ -973,8 +968,8 @@ module ieee802-dot1q-bridge {
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
-            leaf vid {
-              type ieee:vlanid;
+            leaf vids {
+              type dot1qtypes:vid-range;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
@@ -1114,7 +1109,7 @@ module ieee802-dot1q-bridge {
             reference
               "IEEE 802.1Q-2014 Clause 12.10.2";
             leaf vid {
-              type ieee:vlanid;
+              type dot1qtypes:vlan-index;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
@@ -1152,7 +1147,7 @@ module ieee802-dot1q-bridge {
                 "IEEE 802.1Q-2014 Clause 12.10.3";
             }
             leaf fid {
-              type uint16;
+              type uint32;
               description
                 "The Filtering Database used by a set of VIDs.";
               reference
@@ -1186,7 +1181,7 @@ module ieee802-dot1q-bridge {
               operations that modify, or inquire about FID to VID
               allocations.";
             leaf fid {
-              type uint16;
+              type uint32;
               description
                 "The Filtering Database used by a set of VIDs.";
               reference
@@ -1197,7 +1192,7 @@ module ieee802-dot1q-bridge {
               description
                 "The list of VLAN identifiers.";
               leaf vid {
-                type ieee:vlanid;
+                type dot1qtypes:vlan-index;
                 description
                   "The VLAN identifier to which this entry applies.";
                 reference
@@ -1231,9 +1226,13 @@ module ieee802-dot1q-bridge {
   }
 
   augment "/if:interfaces/if:interface" {
-    when "/if:type = 'ianaif:bridge'" {
+    when "/if:type = 'ianaif:bridge' or
+          /if:type = 'ianaif:ethernetCsmacd' or
+          /if:type = 'ianaif:ieee8023adLag' or
+          /if:type = 'ianaif:ilan' or
+          /if:type = 'ianaif:pip'" {
       description
-        "Applies when a Bridge interface";
+        "Applies when a Bridge interface.";
     }
     description
       "Augment the interface model with the Bridge Port";
@@ -1256,7 +1255,7 @@ module ieee802-dot1q-bridge {
           description
             "Applies to non TPMR Bridges";
         }
-        type ieee:vlanid;
+        type dot1qtypes:vlan-index;
         default "1";
         description
           "The primary (default) VID assigned to a specific Bridge
@@ -1622,7 +1621,11 @@ module ieee802-dot1q-bridge {
   }
 
   augment "/if:interfaces-state/if:interface" {
-    when "/if:type = 'ianaif:bridge'" {
+    when "/if:type = 'ianaif:bridge' or
+          /if:type = 'ianaif:ethernetCsmacd' or
+          /if:type = 'ianaif:ieee8023adLag' or
+          /if:type = 'ianaif:ilan' or
+          /if:type = 'ianaif:pip'" {
       description
         "Applies when a Bridge interface.";
     }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
@@ -1,6 +1,6 @@
 module ieee802-dot1q-pb {
 
-  namespace "urn:ieee:params:xml:ns:yang:ieee802-dot1q-pb";
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-pb";
   prefix "dot1q-pb";
 
   import ieee802-dot1q-bridge { prefix dot1q; }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.yang
@@ -1,6 +1,6 @@
 module ieee802-dot1q-tpmr {
 
-  namespace "urn:ieee:params:xml:ns:yang:ieee802-dot1q-tpmr";
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-tpmr";
   prefix "dot1q-tpmr";
 
   import ieee802-dot1q-bridge { prefix "dot1q"; }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
@@ -1,6 +1,6 @@
 module ieee802-dot1q-types {
 
-  namespace "urn:ieee:params:xml:ns:yang:ieee802-dot1q-types";
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-types";
   prefix "dot1q-types";
 
   import ietf-interfaces { prefix "if"; }
@@ -75,25 +75,29 @@ module ieee802-dot1q-types {
    *    for VLAN tag matching.
    */
 
-  identity dot1q-tag-vlan-type {
+  identity dot1q-vlan-type {
     description
       "Base identity from which all 802.1Q VLAN tag types are
       derived from.";
   }
 
   identity c-vlan {
-    base dot1q-tag-vlan-type;
+    base dot1q-vlan-type;
     description
-      "An 802.1Q Customer-VLAN tag, normally using the 0x8100
+      "An 802.1Q Customer VLAN, normally using the 0x8100
        Ethertype";
+    reference
+      "IEEE 802.1Q-2014, Clause 5.5";
   }
 
   identity s-vlan {
-    base dot1q-tag-vlan-type;
+    base dot1q-vlan-type;
     description
-      "An 802.1Q Service-VLAN tag, using the 0x88a8 Ethertype
+      "An 802.1Q Service VLAN, using the 0x88a8 Ethertype
        originally introduced in 802.1ad, and incorporated into
        802.1Q (2011)";
+    reference
+      "IEEE 802.1Q-2014, Clause 5.6";
   }
 
   /*
@@ -169,6 +173,22 @@ module ieee802-dot1q-types {
       ascending order, between 1 and 4094";
   }
 
+  typedef vlan-index {
+    type uint32 {
+      range "1..4094 | 4096..4294967295";
+    }
+    description
+      "A value used to index per-VLAN tables. Values of 0 and 4095
+      are not permitted. The range of valid VLAN indices. If the
+      value is greater than 4095, then it represents a VLAN with
+      scope local to the particular agent, i.e., one without a
+      global VLAN-ID assigned to it. Such VLANs are outside the
+      scope of IEEE 802.1Q, but it is convenient to be able to
+      manage them in the same way using this YANG module.";
+    reference
+      "IEEE Std 802.1Q-2014: Virtual Bridged Local Area Networks.";
+  }
+
   typedef pcp-selection-type {
     type enumeration {
       enum 8P0D {
@@ -228,17 +248,29 @@ module ieee802-dot1q-types {
     description
       "The Ethernet Type (or Length) value.";
     reference
-      "IEEE 802.3-2012 Clause 3.2.6";
+      "IEEE 802-2014 Clause 9.2";
   }
 
   typedef dot1q-tag-type {
     type identityref {
-      base "dot1q-tag-vlan-type";
+      base "dot1q-vlan-type";
     }
     description
       "Identifies a specific 802.1Q tag type";
     reference
       "IEEE 802.1Q (2014)";
+  }
+
+  typedef traffic-class-type {
+    type uint8 {
+      range "0..7";
+    }
+    description
+      "This is the numerical value associated with a traffic
+      class in a Bridge. Larger values are associated with
+      higher priority traffic classes.";
+    reference
+      "IEEE Std 802.1Q-2014, Clause 3.239";
   }
 
   /*
@@ -247,19 +279,17 @@ module ieee802-dot1q-types {
 
   grouping dot1q-tag-classifier {
     description
-      "A grouping which represents an 802.1Q VLAN tag, matching
-      both the tag Ethertype and a single VLAN Id.  The PCP and DEI
-      fields in the 802.1Q tag are ignored for tag matching
-      purposes.";
+      "A grouping which represents an 802.1Q VLAN, matching both
+      the Ethertype and a single VLAN Id.";
     container dot1q-tag {
       description
-        "Identifies an 802.1Q VLAN tag with an explicit
-        tag-type and a single VLAN Id";
+        "Identifies an 802.1Q VLAN with an explicit EtherType and a
+        single VLAN Id";
       leaf tag-type {
         type dot1q-tag-type;
         mandatory true;
         description
-          "VLAN tag type";
+          "VLAN type";
       }
       leaf vlan-id {
         type ieee:vlanid;
@@ -272,19 +302,18 @@ module ieee802-dot1q-types {
 
   grouping dot1q-tag-or-any-classifier {
     description
-      "A grouping which represents an 802.1Q VLAN tag, matching both
-      the tag Ethertype and a single VLAN Id or 'any' to match on
-      any VLAN Id.  The PCP and DEI fields in the 802.1Q tag are
-      ignored for tag matching purposes.";
+      "A grouping which represents an 802.1Q VLAN, matching both
+      the  Ethertype and a single VLAN Id or 'any' to match on
+      any VLAN Id.";
     container dot1q-tag {
       description
-        "Identifies an 802.1Q VLAN tag with an explicit
-        tag-type and a single VLAN Id, or 'any' VLAN Id.";
+        "Identifies an 802.1Q VLAN with an explicit
+        EtherType and a single VLAN Id, or 'any' VLAN Id.";
       leaf tag-type {
         type dot1q-tag-type;
         mandatory true;
         description
-          "VLAN tag type";
+          "VLAN type";
       }
       leaf vlan-id {
         type union {
@@ -293,7 +322,7 @@ module ieee802-dot1q-types {
             enum "any" {
               value 4096;
               description
-                "Matches 'any' VLAN tag in the range 1 to 4094 that
+                "Matches 'any' VLAN in the range 1 to 4094 that
                  is not matched by a more specific VLAN Id match";
             }
           }
@@ -307,18 +336,17 @@ module ieee802-dot1q-types {
 
   grouping dot1q-tag-ranges-classifier {
     description
-      "A grouping which represents an 802.1Q tag that matches a
-      range of VLAN Ids.  The PCP and DEI fields in the 802.1Q tag
-      are ignored for tag matching purposes.";
+      "A grouping which represents an 802.1Q VLAN that matches a
+      range of VLAN Ids.";
     container dot1q-tag {
       description
-        "Identifies an 802.1Q VLAN tag with an explicit
-        tag-type and and a range of VLAN Ids.";
+        "Identifies an 802.1Q VLAN with an explicit
+        EtherType and and a range of VLAN Ids.";
       leaf tag-type {
         type dot1q-tag-type;
         mandatory true;
         description
-          "VLAN tag type";
+          "VLAN type";
       }
       leaf vlan-ids {
         type dot1q-types:vid-range;
@@ -331,20 +359,18 @@ module ieee802-dot1q-types {
 
   grouping dot1q-tag-ranges-or-any-classifier {
     description
-      "A grouping which represents an 802.1Q VLAN tag, matching
-      both the tag Ethertype and a single VLAN Id, ordered list of
-      ranges, or 'any' to match on any VLAN Id.  The PCP and DEI
-      fields in the 802.1Q tag are ignored for tag matching
-      purposes.";
+      "A grouping which represents an 802.1Q VLAN, matching
+      both the Ethertype and a single VLAN Id, ordered list of
+      ranges, or 'any' to match on any VLAN Id.";
     container dot1q-tag {
       description
-        "Identifies an 802.1Q VLAN tag with an explicit tag-type,
+        "Identifies an 802.1Q VLAN with an explicit EtherType,
         an ordered list of VLAN Id ranges, or 'any' VLAN Id.";
       leaf tag-type {
         type dot1q-tag-type;
         mandatory true;
         description
-          "VLAN tag type";
+          "VLAN type";
       }
       leaf vlan-id {
         type union {
@@ -352,7 +378,7 @@ module ieee802-dot1q-types {
           type enumeration {
             enum "any" {
               description
-                "Matches 'any' VLAN tag in the range 1 to 4094.";
+                "Matches 'any' VLAN in the range 1 to 4094.";
             }
           }
         }
@@ -818,9 +844,7 @@ module ieee802-dot1q-types {
         reference
           "IEEE 802.1Q-2014 Clause 8.6.6";
         leaf traffic-class {
-          type uint8 {
-            range "1..8";
-          }
+          type traffic-class-type;
           description
             "The traffic class index associated with a given traffic
             class entry.";

--- a/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.yang
@@ -1,6 +1,6 @@
 module ieee802-dot1q-vlan-bridge {
 
-  namespace "urn:ieee:params:xml:ns:yang:ieee802-dot1q-vlan-bridge";
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-vlan-bridge";
   prefix "dot1q-vlan-bridge";
 
   import ieee802-dot1q-bridge { prefix "dot1q"; }

--- a/standard/ieee/802.1/draft/ieee802-dot1x.tree
+++ b/standard/ieee/802.1/draft/ieee802-dot1x.tree
@@ -56,7 +56,6 @@ augment /if:interfaces/if:interface:
       |  |  +--rw desired?   boolean
       |  +--rw suspend-on-request?   boolean
       |  +--rw suspend-for?          uint8
-      |  +--rw suspend-while?        uint8
       |  +--rw participants* [participant]
       |     +--rw participant    uint32
       |     +--rw cached?        boolean
@@ -131,6 +130,7 @@ augment /if:interfaces-state/if:interface:
       |  |  +--ro protect?          boolean
       |  |  +--ro validate?         boolean
       |  |  +--ro replay-protect?   boolean
+      |  +--ro suspended-while?      uint8
       |  +--ro active?               boolean
       |  +--ro authenticated?        boolean
       |  +--ro secured?              boolean

--- a/standard/ieee/802.1/draft/ieee802-dot1x.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1x.yang
@@ -1,6 +1,6 @@
 module ieee802-dot1x {
 
-  namespace "urn:ieee:params:xml:ns:yang:ieee802-dot1x";
+  namespace "urn:ieee:std:802.1X:yang:ieee802-dot1x";
   prefix "dot1x";
 
   import ieee802-types { prefix "ieee"; }
@@ -916,15 +916,6 @@ module ieee802-dot1x {
           reference
             "IEEE 802.1X-2010 Clause 9.18";
         }
-        leaf suspend-while {
-          type uint8;
-          description
-            "Read by management to determine if a suspension is in
-            progress and (when available) to discover the remaining
-            duration of that suspension";
-          reference
-            "IEEE 802.1X-2010 Clause 9.18";
-        }
 
         list participants {
           key "participant";
@@ -1447,6 +1438,15 @@ module ieee802-dot1x {
             reference
               "IEEE 802.1X-2010 Clause 9.16";
           }
+        }
+        leaf suspended-while {
+          type uint8;
+          description
+            "Read by management to determine if a suspension is in
+            progress and (when available) to discover the remaining
+            duration of that suspension";
+          reference
+            "IEEE 802.1X-2010 Clause 9.18";
         }
         leaf active {
           type boolean;

--- a/standard/ieee/draft/ieee802-types.yang
+++ b/standard/ieee/draft/ieee802-types.yang
@@ -1,6 +1,6 @@
 module ieee802-types {
 
-  namespace "urn:ieee:params:xml:ns:yang:ieee802-types";
+  namespace "urn:ieee:std:802:yang:ieee802-types";
   prefix "ieee";
 
   organization
@@ -92,4 +92,5 @@ module ieee802-types {
     reference
       "IEEE Std 802.1Q-2014: Virtual Bridged Local Area Networks.";
   }
+
 }


### PR DESCRIPTION
Update YANG modules based upon TG ballot comment resolution from IEEE
Interim meeting Nov 2016.

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ ll
total 290
-rw-r--r-- 1 mholness 1049089   371 Oct 16  2015 README.txt
-rw-r--r-- 1 mholness 1049089 16274 Jul 24 16:40 ieee802-dot1-bridge.tree
-rw-r--r-- 1 mholness 1049089 43130 Nov  4 16:41 ieee802-dot1ax.yang
-rw-r--r-- 1 mholness 1049089 16377 Dec 12 15:20 ieee802-dot1q-bridge.tree
-rw-r--r-- 1 mholness 1049089 64035 Dec 12 15:07 ieee802-dot1q-bridge.yang
-rw-r--r-- 1 mholness 1049089  1044 Dec 12 15:21 ieee802-dot1q-pb.tree
-rw-r--r-- 1 mholness 1049089  7549 Nov  4 16:07 ieee802-dot1q-pb.yang
-rw-r--r-- 1 mholness 1049089  1175 Dec 12 15:21 ieee802-dot1q-tpmr.tree
-rw-r--r-- 1 mholness 1049089  7969 Nov  4 16:06 ieee802-dot1q-tpmr.yang
-rw-r--r-- 1 mholness 1049089     0 Dec 12 15:20 ieee802-dot1q-types.tree
-rw-r--r-- 1 mholness 1049089 34709 Dec 12 14:28 ieee802-dot1q-types.yang
-rw-r--r-- 1 mholness 1049089    96 Dec 12 15:21 ieee802-dot1q-vlan-bridge.tree
-rw-r--r-- 1 mholness 1049089  2202 Nov  4 16:07 ieee802-dot1q-vlan-bridge.yang
-rw-r--r-- 1 mholness 1049089  9558 Dec 12 15:20 ieee802-dot1x.tree
-rw-r--r-- 1 mholness 1049089 73428 Nov  8 15:50 ieee802-dot1x.yang

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1x.yang
ieee802-dot1x.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1x"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-types.yang
ieee802-dot1q-types.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-types"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-bridge.yang
ieee802-dot1q-bridge.yang:1: warning: IETF rule (RFC 6087: 4.9): too many top-level data nodes: bridges, bridges-state
ieee802-dot1q-bridge.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-bridge"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-tpmr.yang
ieee802-dot1q-tpmr.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-tpmr"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-vlan-bridge.yang
ieee802-dot1q-vlan-bridge.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-vlan-bridge"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-pb.yang
ieee802-dot1q-pb.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-pb"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$
