### PR TITLE
Changes to IEEE 802.1 YANG modules

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1ax.tree
+++ b/standard/ieee/802.1/draft/ieee802-dot1ax.tree
@@ -1,0 +1,84 @@
+module: ieee802-dot1ax
+   +--rw lag-system
+      +--rw aggregating-system* [agg-system]
+         +--rw agg-system         string
+         +--rw system-id?         ieee:mac-address
+         +--rw system-priority?   uint32
+augment /if:interfaces/if:interface:
+   +--rw aggregator
+      +--rw name?                        string
+      +--rw agg-system-name?             string
+      +--rw admin-state?                 enumeration
+      +--rw link-up-down-notification?   enumeration
+      +--rw collector-max-delay?         int16
+      +--rw aggregator-lacp
+         +--rw actor-admin-key?   int16
+augment /if:interfaces-state/if:interface:
+   +--ro aggregator
+      +--ro id?                         uint32
+      +--ro description?                string
+      +--ro aggregate-or-individual?    boolean
+      +--ro collector-max-delay?        int16
+      +--ro oper-state?                 enumeration
+      +--ro time-of-last-oper-change?   yang:counter32
+      +--ro data-rate?                  uint64
+      +--ro aggregator-lacp
+      |  +--ro actor-oper-key?            int16
+      |  +--ro agg-mac-address?           ieee:mac-address
+      |  +--ro partner-system-id?         ieee:mac-address
+      |  +--ro partner-system-priority?   uint16
+      |  +--ro partner-oper-key?          int16
+      +--ro statistics
+         +--ro octets-tx?                 yang:counter64
+         +--ro octets-rx?                 yang:counter64
+         +--ro frames-tx?                 yang:counter64
+         +--ro frames-rx?                 yang:counter64
+         +--ro multicast-frames-tx?       yang:counter64
+         +--ro multicast-frames-rx?       yang:counter64
+         +--ro broadcast-frames-tx?       yang:counter64
+         +--ro broadcast-frames-rx?       yang:counter64
+         +--ro frames-discarded-on-tx?    yang:counter64
+         +--ro frames-discarded-on-rx?    yang:counter64
+         +--ro frames-with-tx-errors?     yang:counter64
+         +--ro frames-with-rx-errors?     yang:counter64
+         +--ro unknown-protocol-frames?   yang:counter64
+augment /if:interfaces/if:interface:
+   +--rw aggregation-port
+      +--rw aggregation-port-lacp
+         +--rw actor-system-priority?           int16
+         +--rw actor-admin-key?                 int16
+         +--rw partner-admin-system-priority?   int16
+         +--rw partner-admin-system-id?         ieee:mac-address
+         +--rw partner-admin-key?               int16
+         +--rw actor-port-priority?             int16
+         +--rw partner-admin-port?              int16
+         +--rw partner-admin-port-priority?     int16
+         +--rw actor-admin-state?               bits
+         +--rw partner-admin-state?             bits
+augment /if:interfaces-state/if:interface:
+   +--ro aggregation-port
+      +--ro id?                        int16
+      +--ro aggregate-or-individual?   boolean
+      +--ro aggregation-port-lacp
+         +--ro actor-system-id?                ieee:mac-address
+         +--ro actor-oper-key?                 int16
+         +--ro partner-oper-system-priority?   int16
+         +--ro partner-oper-system-id?         ieee:mac-address
+         +--ro partner-oper-key?               int16
+         +--ro selected-agg-id?                int16
+         +--ro attached-agg-id?                int16
+         +--ro actor-port?                     int16
+         +--ro partner-oper-port?              int16
+         +--ro partner-oper-port-priority?     int16
+         +--ro actor-oper-state?               bits
+         +--ro partner-oper-state?             bits
+         +--ro aggregation-port-stats
+            +--ro stats-id?                 int16
+            +--ro lacp-pdu-rx?              yang:counter64
+            +--ro marker-pdu-rx?            yang:counter64
+            +--ro marker-response-pdu-rx?   yang:counter64
+            +--ro unknown-rx?               yang:counter64
+            +--ro illegal-rx?               yang:counter64
+            +--ro lacp-pdu-tx?              yang:counter64
+            +--ro marker-pdu-tx?            yang:counter64
+            +--ro marker-response-pdu-tx?   yang:counter64

--- a/standard/ieee/802.1/draft/ieee802-dot1ax.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1ax.yang
@@ -84,9 +84,9 @@ module ieee802-dot1ax {
   //  Aggregator Nodes
   //
   augment "/if:interfaces/if:interface" {
-    when "/if:type = 'ianaif:ieee8023adLag' or
-          /if:type = 'ianaif:ethernetCsmacd' or
-          /if:type = 'ianaif:bridge'" {
+    when "if:type = 'ianaif:ieee8023adLag' or
+          if:type = 'ianaif:ethernetCsmacd' or 
+          if:type = 'ianaif:bridge'" {
       description
         "Applies to Ethernet interfaces or Bridge Ports.";
       }
@@ -184,9 +184,9 @@ module ieee802-dot1ax {
   } // augment if:interface
 
   augment "/if:interfaces-state/if:interface" {
-    when "/if:type = 'ianaif:ieee8023adLag' or
-          /if:type = 'ianaif:ethernetCsmacd' or
-          /if:type = 'ianaif:bridge'" {
+    when "if:type = 'ianaif:ieee8023adLag' or
+          if:type = 'ianaif:ethernetCsmacd' or
+          if:type = 'ianaif:bridge'" {
       description
         "Applies to Ethernet interfaces or Bridge Ports.";
     }
@@ -526,8 +526,8 @@ module ieee802-dot1ax {
   //  Aggregation Port Nodes
   //---------------------------------------------------
   augment "/if:interfaces/if:interface" {
-    when "/if:type = 'ianaif:ethernetCsmacd' or
-          /if:type = 'ianaif:bridge'" {
+    when "if:type = 'ianaif:ethernetCsmacd' or
+          if:type = 'ianaif:bridge'" {
       description
         "Applies to Ethernet interfaces or Bridge Ports.";
       }
@@ -754,8 +754,8 @@ module ieee802-dot1ax {
   } // augment interfaces
 
   augment "/if:interfaces-state/if:interface" {
-    when "/if:type = 'ianaif:ethernetCsmacd' or
-          /if:type = 'ianaif:bridge'" {
+    when "if:type = 'ianaif:ethernetCsmacd' or
+          if:type = 'ianaif:bridge'" {
       description
         "Applies to Ethernet interfaces or Bridge Ports.";
     }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-bridge.tree
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-bridge.tree
@@ -12,14 +12,14 @@ module: ieee802-dot1q-bridge
    |        +--rw traffic-class-enabled?   boolean
    |        +--rw mmrp-enabled-status?     boolean
    |        +--rw filtering-database
-   |        |  +--rw aging-time?                  uint32
-   |        |  +--rw filtering-entries* [database-id vids address]
-   |        |  |  +--rw database-id    uint16
+   |        |  +--rw aging-time?                uint32
+   |        |  +--rw filtering-entry* [database-id vids address]
+   |        |  |  +--rw database-id    uint32
    |        |  |  +--rw address        ieee:mac-address
-   |        |  |  +--rw vids           dot1qtypes:vid-range
+   |        |  |  +--rw vids           dot1qtypes:vid-range-type
    |        |  |  +--rw entry-type?    enumeration
-   |        |  |  +--rw port-map* [port-number]
-   |        |  |     +--rw port-number                          if:interface-ref
+   |        |  |  +--rw port-map* [port-ref]
+   |        |  |     +--rw port-ref                             if:interface-ref
    |        |  |     +--rw (map-type)?
    |        |  |        +--:(static-filtering-entries)
    |        |  |        |  +--rw static-filtering-entries
@@ -41,12 +41,12 @@ module: ieee802-dot1q-bridge
    |        |  |        +--:(dynamic-filtering-entries)
    |        |  |           +--rw dynamic-filtering-entries
    |        |  |              +--rw control-element?   enumeration
-   |        |  +--rw vlan-registration-entries* [database-id vids]
+   |        |  +--rw vlan-registration-entry* [database-id vids]
    |        |     +--rw database-id    uint32
-   |        |     +--rw vids           dot1qtypes:vid-range
+   |        |     +--rw vids           dot1qtypes:vid-range-type
    |        |     +--rw entry-type?    enumeration
-   |        |     +--rw port-map* [port-number]
-   |        |        +--rw port-number                          if:interface-ref
+   |        |     +--rw port-map* [port-ref]
+   |        |        +--rw port-ref                             if:interface-ref
    |        |        +--rw (map-type)?
    |        |           +--:(static-filtering-entries)
    |        |           |  +--rw static-filtering-entries
@@ -69,12 +69,12 @@ module: ieee802-dot1q-bridge
    |        |              +--rw dynamic-filtering-entries
    |        |                 +--rw control-element?   enumeration
    |        +--rw permanent-database
-   |        |  +--rw filtering-entries* [database-id vids address]
-   |        |     +--rw database-id    uint16
+   |        |  +--rw filtering-entry* [database-id vids address]
+   |        |     +--rw database-id    uint32
    |        |     +--rw address        ieee:mac-address
-   |        |     +--rw vids           dot1qtypes:vid-range
-   |        |     +--rw port-map* [port-number]
-   |        |        +--rw port-number                          if:interface-ref
+   |        |     +--rw vids           dot1qtypes:vid-range-type
+   |        |     +--rw port-map* [port-ref]
+   |        |        +--rw port-ref                             if:interface-ref
    |        |        +--rw (map-type)?
    |        |           +--:(static-filtering-entries)
    |        |           |  +--rw static-filtering-entries
@@ -97,32 +97,34 @@ module: ieee802-dot1q-bridge
    |        |              +--rw dynamic-filtering-entries
    |        |                 +--rw control-element?   enumeration
    |        +--rw bridge-vlan
-   |           +--rw vlan-id* [vid]
-   |           |  +--rw vid     dot1qtypes:vlan-index
+   |           +--rw vlan* [vid]
+   |           |  +--rw vid     dot1qtypes:vlan-index-type
    |           |  +--rw name?   dot1qtypes:name-type
-   |           +--rw protocol-group-database {port-and-protocol-based-vlan}?
-   |           |  +--rw frame-format-type?   dot1qtypes:protocol-template-format
+   |           +--rw protocol-group-database* [db-index] {port-and-protocol-based-vlan}?
+   |           |  +--rw db-index             uint16
+   |           |  +--rw frame-format-type?   dot1qtypes:protocol-frame-format-type
    |           |  +--rw (frame-format)?
    |           |  |  +--:(ethernet-rfc1042-snap8021H)
-   |           |  |  |  +--rw ether-type?          string
+   |           |  |  |  +--rw ether-type?          dot1qtypes:ether-type
    |           |  |  +--:(snap-other)
    |           |  |  |  +--rw protocol-id?         string
    |           |  |  +--:(llc-other)
    |           |  |     +--rw dsap-ssap-pairs
    |           |  |        +--rw llc-address?   string
-   |           |  +--rw protocol-group-id?   uint32
+   |           |  +--rw group-id?            uint32
    |           +--rw vid-to-fid
-   |              +--rw vid?   dot1qtypes:vlan-index
+   |              +--rw vid*   dot1qtypes:vlan-index-type
    |              +--rw fid?   uint32
    +--ro bridges-state
       +--ro bridge* [name]
-         +--ro name          dot1qtypes:name-type
-         +--ro ports?        dot1qtypes:port-number-type
-         +--ro up-time?      yang:counter32
-         +--ro components?   uint32
+         +--ro name           dot1qtypes:name-type
+         +--ro bridge-type?   identityref
+         +--ro ports?         uint16
+         +--ro up-time?       yang:zero-based-counter32
+         +--ro components?    uint32
          +--ro component* [name]
             +--ro name                  string
-            +--ro ports?                dot1qtypes:port-number-type
+            +--ro ports?                uint16
             +--ro bridge-port*          if:interface-ref
             +--ro capabilities
             |  +--ro extended-filtering?             boolean
@@ -134,17 +136,22 @@ module: ieee802-dot1q-bridge
             |  +--ro configurable-pvid-tagging?      boolean
             |  +--ro local-vlan-capable?             boolean
             +--ro filtering-database
-            |  +--ro size?                                uint16
-            |  +--ro static-entries?                      uint16
+            |  +--ro size?                                yang:gauge32
+            |  +--ro static-entries?                      yang:gauge32
             |  +--ro dynamic-entries?                     yang:gauge32
-            |  +--ro static-vlan-registration-entries?    uint16
+            |  +--ro static-vlan-registration-entries?    yang:gauge32
             |  +--ro dynamic-vlan-registration-entries?   yang:gauge32
             |  +--ro mac-address-registration-entries?    yang:gauge32 {extended-filtering-services}?
-            |  +--ro filtering-entries* [database-id vids address]
+            |  +--ro filtering-entry* [database-id vids address]
+            |  |  +--ro database-id    uint32
+            |  |  +--ro address        ieee:mac-address
+            |  |  +--ro vids           dot1qtypes:vid-range-type
+            |  |  +--ro entry-type?    enumeration
+            |  |  +--ro status?        enumeration
+            |  +--ro vlan-registration-entry* [database-id vids]
             |     +--ro database-id    uint32
-            |     +--ro address        ieee:mac-address
-            |     +--ro vids           dot1qtypes:vid-range
-            |     +--ro status?        enumeration
+            |     +--ro vids           dot1qtypes:vid-range-type
+            |     +--ro entry-type?    enumeration
             +--ro permanent-database
             |  +--ro size?                               yang:gauge32
             |  +--ro static-entries?                     yang:gauge32
@@ -153,27 +160,26 @@ module: ieee802-dot1q-bridge
                +--ro version?                 uint16
                +--ro max-vids?                uint16
                +--ro override-default-pvid?   boolean
-               +--ro protocol-template?       dot1qtypes:protocol-template-format {port-and-protocol-based-vlan}?
+               +--ro protocol-template?       dot1qtypes:protocol-frame-format-type {port-and-protocol-based-vlan}?
                +--ro max-msti?                uint16
-               +--ro vlan-id* [vid]
-               |  +--ro vid               dot1qtypes:vlan-index
+               +--ro vlan* [vid]
+               |  +--ro vid               dot1qtypes:vlan-index-type
                |  +--ro untagged-ports*   if:interface-ref
                |  +--ro egress-ports*     if:interface-ref
                +--ro vid-to-fid-allocation* [vids]
-               |  +--ro vids               dot1qtypes:vid-range
+               |  +--ro vids               dot1qtypes:vid-range-type
                |  +--ro fid?               uint32
                |  +--ro allocation-type?   enumeration
                +--ro fid-to-vid-allocation* [fid]
-                  +--ro fid     uint32
-                  +--ro vids* [vid]
-                     +--ro vid                dot1qtypes:vlan-index
-                     +--ro allocation-type?   enumeration
+                  +--ro fid                uint32
+                  +--ro allocation-type?   enumeration
+                  +--ro vid*               dot1qtypes:vlan-index-type
 augment /if:interfaces/if:interface:
    +--rw bridge-port
-      +--rw component-name?                      dot1qtypes:component-ref
-      +--rw service-interface?                   if:interface-ref
-      +--rw pvid?                                dot1qtypes:vlan-index
-      +--rw default-priority?                    dot1qtypes:priority-type
+      +--rw component-name?                        string
+      +--rw port-type?                             identityref
+      +--rw pvid?                                  dot1qtypes:vlan-index-type
+      +--rw default-priority?                      dot1qtypes:priority-type
       +--rw priority-regeneration
       |  +--rw priority0?   priority-type
       |  +--rw priority1?   priority-type
@@ -183,64 +189,24 @@ augment /if:interfaces/if:interface:
       |  +--rw priority5?   priority-type
       |  +--rw priority6?   priority-type
       |  +--rw priority7?   priority-type
-      +--rw pcp-selection?                       dot1qtypes:pcp-selection-type
+      +--rw pcp-selection?                         dot1qtypes:pcp-selection-type
       +--rw pcp-decoding-table
-      |  +--rw selection-type?   dot1qtypes:pcp-selection-type
-      |  +--rw decoding-table
-      |     +--rw pcp0
-      |     |  +--rw priority?        priority-type
-      |     |  +--rw drop-eligible?   boolean
-      |     +--rw pcp1
-      |     |  +--rw priority?        priority-type
-      |     |  +--rw drop-eligible?   boolean
-      |     +--rw pcp2
-      |     |  +--rw priority?        priority-type
-      |     |  +--rw drop-eligible?   boolean
-      |     +--rw pcp3
-      |     |  +--rw priority?        priority-type
-      |     |  +--rw drop-eligible?   boolean
-      |     +--rw pcp4
-      |     |  +--rw priority?        priority-type
-      |     |  +--rw drop-eligible?   boolean
-      |     +--rw pcp5
-      |     |  +--rw priority?        priority-type
-      |     |  +--rw drop-eligible?   boolean
-      |     +--rw pcp6
-      |     |  +--rw priority?        priority-type
-      |     |  +--rw drop-eligible?   boolean
-      |     +--rw pcp7
-      |        +--rw priority?        priority-type
-      |        +--rw drop-eligible?   boolean
+      |  +--rw pcp-decoding-map* [pcp]
+      |     +--rw pcp             pcp-selection-type
+      |     +--rw priority-map* [priority-code-point]
+      |        +--rw priority-code-point    priority-type
+      |        +--rw priority?              priority-type
+      |        +--rw drop-eligible?         boolean
       +--rw pcp-encoding-table
-      |  +--rw selection-type?   dot1qtypes:pcp-selection-type
-      |  +--rw encoding-table
-      |     +--rw priority0
-      |     |  +--rw pcp-dei-false?   priority-type
-      |     |  +--rw pcp-dei-true?    priority-type
-      |     +--rw priority1
-      |     |  +--rw pcp-dei-false?   priority-type
-      |     |  +--rw pcp-dei-true?    priority-type
-      |     +--rw priority2
-      |     |  +--rw pcp-dei-false?   priority-type
-      |     |  +--rw pcp-dei-true?    priority-type
-      |     +--rw priority3
-      |     |  +--rw pcp-dei-false?   priority-type
-      |     |  +--rw pcp-dei-true?    priority-type
-      |     +--rw priority4
-      |     |  +--rw pcp-dei-false?   priority-type
-      |     |  +--rw pcp-dei-true?    priority-type
-      |     +--rw priority5
-      |     |  +--rw pcp-dei-false?   priority-type
-      |     |  +--rw pcp-dei-true?    priority-type
-      |     +--rw priority6
-      |     |  +--rw pcp-dei-false?   priority-type
-      |     |  +--rw pcp-dei-true?    priority-type
-      |     +--rw priority7
-      |        +--rw pcp-dei-false?   priority-type
-      |        +--rw pcp-dei-true?    priority-type
-      +--rw use-dei?                             boolean
-      +--rw drop-encoding?                       boolean
-      +--rw service-access-priority-selection?   enumeration
+      |  +--rw pcp-encoding-map* [pcp]
+      |     +--rw pcp             pcp-selection-type
+      |     +--rw priority-map* [priority dei]
+      |        +--rw priority               priority-type
+      |        +--rw dei                    boolean
+      |        +--rw priority-code-point?   priority-type
+      +--rw use-dei?                               boolean
+      +--rw drop-encoding?                         boolean
+      +--rw service-access-priority-selection?     boolean
       +--rw service-access-priority
       |  +--rw priority0?   priority-type
       |  +--rw priority1?   priority-type
@@ -251,21 +217,20 @@ augment /if:interfaces/if:interface:
       |  +--rw priority6?   priority-type
       |  +--rw priority7?   priority-type
       +--rw traffic-class
-      |  +--rw tc-entries* [priority]
-      |     +--rw priority        priority-type
-      |     +--rw available-TC* [traffic-class]
-      |        +--rw traffic-class    traffic-class-type
-      |        +--rw num-tc?          priority-type
-      +--rw acceptable-frame?                    enumeration
-      +--rw enable-ingress-filtering?            boolean
-      +--rw restricted-vlan-registration?        boolean
-      +--rw vid-translation-table?               boolean
-      +--rw egress-vid-translation-table?        boolean
-      +--rw protocol-group-id?                   uint16 {port-and-protocol-based-vlan}?
-      +--rw protocol-group-database-contents {port-and-protocol-based-vlan}?
-      |  +--rw template?   dot1qtypes:protocol-template-format
-      |  +--rw group-id?   uint16
-      +--rw admin-point-to-point?                uint16
+      |  +--rw traffic-class-map* [priority]
+      |     +--rw priority                   priority-type
+      |     +--rw available-traffic-class* [num-traffic-class]
+      |        +--rw num-traffic-class    uint8
+      |        +--rw traffic-class?       traffic-class-type
+      +--rw acceptable-frame?                      enumeration
+      +--rw enable-ingress-filtering?              boolean
+      +--rw restricted-vlan-registration?          boolean
+      +--rw enable-vid-translation-table?          boolean
+      +--rw enable-egress-vid-translation-table?   boolean
+      +--rw protocol-group-vid-set* [group-id] {port-and-protocol-based-vlan}?
+      |  +--rw group-id    uint32
+      |  +--rw vid*        ieee:vlanid
+      +--rw admin-point-to-point?                  enumeration
       +--rw vid-translations* [local-vid]
       |  +--rw local-vid    ieee:vlanid
       |  +--rw relay-vid?   ieee:vlanid
@@ -273,17 +238,18 @@ augment /if:interfaces/if:interface:
          +--rw relay-vid    ieee:vlanid
          +--rw local-vid?   ieee:vlanid
 augment /if:interfaces-state/if:interface:
-   +--ro bridge-port-state
+   +--ro bridge-port
+      +--ro component-name?                       string
       +--ro protocol-based-vlan-classification?   boolean {port-and-protocol-based-vlan}?
       +--ro max-vid-set-entries?                  uint16 {port-and-protocol-based-vlan}?
       +--ro port-number?                          dot1qtypes:port-number-type
       +--ro port-type?                            identityref
       +--ro address?                              ieee:mac-address
-      +--ro capabilities?                         uint16
-      +--ro type-capabilties?                     uint16
+      +--ro capabilities?                         bits
+      +--ro type-capabilties?                     bits
       +--ro external?                             boolean
       +--ro oper-point-to-point?                  boolean
-      +--ro bridge-port-statistics
+      +--ro statistics
          +--ro delay-exceeded-discards?          yang:counter64
          +--ro mtu-exceeded-discards?            yang:counter64
          +--ro frame-rx?                         yang:counter64
@@ -296,4 +262,3 @@ augment /if:interfaces-state/if:interface:
          +--ro discard-transit-delay-exceeded?   yang:counter64
          +--ro discard-on-error?                 yang:counter64
          +--ro discard-on-ingress-filtering?     yang:counter64 {ingress-filtering}?
-         +--ro discard-ttl-expired?              yang:counter64 {flow-filtering}?

--- a/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
@@ -106,8 +106,8 @@ module ieee802-dot1q-bridge {
   }
 
   /*
-     * IEEE 802.1Q Bridge Component identities.
-     */
+   * IEEE 802.1Q Bridge Component identities.
+   */
   identity type-of-component {
     description
       "Represents the type of Component.";
@@ -145,7 +145,7 @@ module ieee802-dot1q-bridge {
 
   /*
    * IEEE 802.1Q Bridge Port Type identities.
-     */
+   */
   identity type-of-port {
     description
       "Represents the type of Bridge port.";
@@ -161,20 +161,24 @@ module ieee802-dot1q-bridge {
     description
       "Indicates the port can be an S-TAG aware port of a Provider
       Bridge or Backbone Edge Bridge used for connections within a
-      PBN or PBBN.";
+      PBN (Provider Bridged Network) or PBBN (Provider Backbone
+    	Bridged Network).";
   }
   identity customer-network-port {
     base type-of-port;
     description
       "Indicates the port can be an S-TAG aware port of a Provider
       Bridge or Backbone Edge Bridge used for connections to the
-      exterior of a PBN or PBBN.";
+      exterior of a PBN (Provider Bridged Network) or PBBN (Provider
+    	Backbone Bridged Network).";
   }
   identity customer-edge-port {
     base type-of-port;
     description
       "Indicates the port can be a C-TAG aware port of a Provider
-      Bridge used for connections to the exterior of a PBN or PBBN.";
+      Bridge used for connections to the exterior of a PBN
+    	(Provider Bridged Network) or PBBN (Provider Backbone Bridged
+    	Network).";
   }
   identity customer-backbone-port {
     base type-of-port;
@@ -421,14 +425,14 @@ module ieee802-dot1q-bridge {
         }
 
         container filtering-database {
-          when "dot1q:bridge-type != 'TPMR-bridge'" {
+          when "../../bridge-type != 'two-port-mac-relay-bridge'" {
             description
               "Applies to non TPMR Bridges.";
           }
           description
             "Contains filtering information used by the Forwarding
             Process in deciding through which Ports of the Bridge
-            frames shoudl be forwarded.";
+            frames should be forwarded.";
           reference
             "IEEE 802.1Q-2014 Clause 12.7";
           leaf aging-time {
@@ -439,20 +443,18 @@ module ieee802-dot1q-bridge {
             default 300;
             description
               "The timeout period in seconds for aging out
-              dynamically-learned forwarding information. The value
-              of this object MUST be retained across
-              reinitializations of the managment system.";
+              dynamically-learned forwarding information.";
             reference
               "IEEE 802.1Q-2014 Clause 12.7, 8.8.3";
           }
 
-          list filtering-entries {
+          list filtering-entry {
             key "database-id vids address";
             description
               "Information for the entries associated with the
               Permanent Database.";
             leaf database-id {
-              type uint16;
+              type uint32;
               description
                 "The identity of this Filtering Database.";
               reference
@@ -468,9 +470,10 @@ module ieee802-dot1q-bridge {
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
             leaf vids {
-              type dot1qtypes:vid-range;
+              type dot1qtypes:vid-range-type;
               description
-                "The VLAN identifier to which this entry applies.";
+                "The set of VLAN identifiers to which this entry
+              	applies.";
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
@@ -480,10 +483,6 @@ module ieee802-dot1q-bridge {
                   description
                     "Static entry type";
                 }
-                enum dynamic {
-                  description
-                    "Dynamic/learnt entry type";
-                }
               }
               description
                 "The type of filtering entry. Whether static or
@@ -491,10 +490,10 @@ module ieee802-dot1q-bridge {
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
-            uses dot1qtypes:port-map;
+            uses dot1qtypes:port-map-grouping;
           }
 
-          list vlan-registration-entries {
+          list vlan-registration-entry {
             key "database-id vids";
             description
               "The VLAN Registration Entries models the operations
@@ -512,9 +511,10 @@ module ieee802-dot1q-bridge {
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
             leaf vids {
-              type dot1qtypes:vid-range;
+              type dot1qtypes:vid-range-type;
               description
-                "The VLAN identifier to which this entry applies.";
+              	"The set of VLAN identifiers to which this entry
+              	applies.";
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
@@ -524,10 +524,6 @@ module ieee802-dot1q-bridge {
                   description
                     "Static entry type";
                 }
-                enum dynamic {
-                  description
-                    "Dynamic/learnt entry type";
-                }
               }
               description
                 "The type of filtering entry. Whether static or
@@ -535,7 +531,7 @@ module ieee802-dot1q-bridge {
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
-            uses dot1qtypes:port-map;
+            uses dot1qtypes:port-map-grouping;
           }
         }
 
@@ -544,13 +540,13 @@ module ieee802-dot1q-bridge {
             "The Permanent Database container models the operations
             that can be performed on, or affect, the Permanent
             Database. There is a single Permanent Database per FDB.";
-          list filtering-entries {
+          list filtering-entry {
             key "database-id vids address";
             description
               "Information for the entries associated with the
               Permanent Database.";
             leaf database-id {
-              type uint16;
+              type uint32;
               description
                 "The identity of this Filtering Database.";
               reference
@@ -566,18 +562,19 @@ module ieee802-dot1q-bridge {
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
             leaf vids {
-              type dot1qtypes:vid-range;
+              type dot1qtypes:vid-range-type;
               description
-                "The VLAN identifier to which this entry applies.";
+              	"The set of VLAN identifiers to which this entry
+              	applies.";
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
-            uses dot1qtypes:port-map;
+            uses dot1qtypes:port-map-grouping;
           }
         }
 
         container bridge-vlan {
-          when "dot1q:bridge-type != 'TPMR-bridge'" {
+        	when "../../bridge-type != 'two-port-mac-relay-bridge'" {
             description
               "Applies to non TPMR Bridges.";
           }
@@ -589,7 +586,7 @@ module ieee802-dot1q-bridge {
             Bridge.";
           reference
             "IEEE 802.1Q-2014 Clause 12.10";
-          list vlan-id {
+          list vlan {
             key "vid";
             description
               "List of VLAN related configuration nodes associated
@@ -597,7 +594,7 @@ module ieee802-dot1q-bridge {
             reference
               "IEEE 802.1Q-2014 Clause 12.10.2";
             leaf vid {
-              type dot1qtypes:vlan-index;
+              type dot1qtypes:vlan-index-type;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
@@ -612,19 +609,21 @@ module ieee802-dot1q-bridge {
                 "IEEE 802.1Q-2014 Clause 12.10.2";
             }
           }
-
-          container protocol-group-database {
-            if-feature port-and-protocol-based-vlan;
-            description
-              "A table that contains mappings from Protocol
-              Templates to Protocol Group Identifiers used for
-              Port-and-Protocol-based VLAN Classification. Entries
-              in this table must be persistent over power up
-              restart/reboot";
-            reference
-              "IEEE 802.1Q-2014 Clause 12.10.1.7";
-            leaf frame-format-type {
-              type dot1qtypes:protocol-template-format;
+          
+          list protocol-group-database {
+          	if-feature port-and-protocol-based-vlan;
+          	key "db-index";
+          	description
+          		"List of the protocol group database entries.";
+          	reference
+          		"IEEE 802.1Q-2014 Clause 12.10.1.7, 6.12.3";
+          	leaf db-index {
+          		type uint16;
+          		description
+          			"The protocol group database index.";
+          	}
+          	leaf frame-format-type {
+              type dot1qtypes:protocol-frame-format-type;
               description
                 "The data-link encapsulation format or the
                 detagged_frame_type in a Protocol Template";
@@ -649,13 +648,18 @@ module ieee802-dot1q-bridge {
               reference
                 "IEEE 802.1Q-2014 Clause 12.10.1.7";
               case ethernet-rfc1042-snap8021H {
+              	when "frame-format-type = 'Ethernet' or
+              		    frame-format-type = 'rfc1042' or
+              		    frame-format-type = 'snap8021H'" {
+              		description
+              			"Applies to Ethernet, RFC 1042, SNAP 8021H
+              			frame formats.";
+              	}
                 description
                   "Identifier used if Ethenet, RFC1042, or SNAP
                   8021H.";
                 leaf ether-type {
-                  type string {
-                    length "2";
-                  }
+                	type dot1qtypes:ether-type;
                   description
                     "Format containing the 16-bit IEEE 802
                     EtherType field.";
@@ -664,11 +668,15 @@ module ieee802-dot1q-bridge {
                 }
               }
               case snap-other {
+              	when "frame-format-type = 'snapOther'" {
+		          		description
+		          			"Applies to Snap Other frame formats.";
+		          	}
                 description
                   "Identifier used if SNAP other.";
                 leaf protocol-id {
                   type string {
-                    length "5";
+                    pattern '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){4}';
                   }
                   description
                     "Format containing the 40-bit protocol identifier
@@ -678,6 +686,10 @@ module ieee802-dot1q-bridge {
                 }
               }
               case llc-other {
+              	when "frame-format-type = 'llcOther'" {
+		          		description
+		          			"Applies to LLC Other frame formats ";
+		          	}
                 description
                   "Identifier used if LLC other.";
                 container dsap-ssap-pairs {
@@ -687,7 +699,7 @@ module ieee802-dot1q-bridge {
                     LLC_Other.";
                   leaf llc-address {
                     type string {
-                      length "2";
+                      pattern '[0-9a-fA-F]{4}';
                     }
                     description
                       "A pair of ISO/IEC 8802-2 DSAP and SSAP
@@ -699,23 +711,24 @@ module ieee802-dot1q-bridge {
                 }
               }
             }
-            leaf protocol-group-id {
+            leaf group-id {
               type uint32;
               description
                 "Designates a group of protocols in the Protocol
                 Group Database.";
               reference
                 "IEEE 802.1Q-2014 Clause 6.12.2";
-            }
+            }    		
           }
 
           container vid-to-fid {
             description
               "Fixed allocation of a VID to an FID";
-            leaf vid {
-              type dot1qtypes:vlan-index;
+            leaf-list vid {
+              type dot1qtypes:vlan-index-type;
               description
-                "The VLAN identifier.";
+                "A list of VLAN identifier associated with a given
+              	database identifier (i.e., FID).";
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
@@ -739,9 +752,8 @@ module ieee802-dot1q-bridge {
     list bridge {
       key name;
       description
-        "Provides configuration data in support of the Bridge
-        Configuration resources. There is a single bridge data node
-        per Bridge.";
+        "Provides operational and state data in support of the Bridge
+        resources. There is a single bridge data node per Bridge.";
       leaf name {
         type dot1qtypes:name-type;
         description
@@ -750,15 +762,24 @@ module ieee802-dot1q-bridge {
         reference
           "IEEE 802.1Q-2014 Clause 12.4";
       }
+      leaf bridge-type {
+          type identityref {
+            base type-of-bridge;
+          }
+          description
+            "The type of Bridge.";
+        }
       leaf ports {
-        type dot1qtypes:port-number-type;
+      	type uint16 {
+          range "1..4095";
+        }
         description
           "The number of Bridge Ports (MAC Entities)";
         reference
           "IEEE 802.1Q-2014 Clause 12.4";
       }
       leaf up-time {
-        type yang:counter32;
+        type yang:zero-based-counter32;
         units seconds;
         description
           "The count in seconds of the time elapsed since the Bridge
@@ -769,7 +790,7 @@ module ieee802-dot1q-bridge {
       leaf components {
         type uint32;
         description
-          "The number of components assocaited with the Bridge.";
+          "The number of components associated with the Bridge.";
       }
       list component {
         key "name";
@@ -790,7 +811,9 @@ module ieee802-dot1q-bridge {
             "The name of the Component.";
         }
         leaf ports {
-          type dot1qtypes:port-number-type;
+        	type uint16 {
+            range "1..4095";
+          }
           description
             "The number of Bridge Ports associated with the Bridge
             Component.";
@@ -810,6 +833,7 @@ module ieee802-dot1q-bridge {
             "IEEE 802.1Q-2014 Clause 12.4.1.5.2, 12.10.1.1.3 b)";
           leaf extended-filtering {
             type boolean;
+            default "false";
             description
               "Can perform filtering on individual multicast
               addresses controlled by MMRP.";
@@ -818,6 +842,7 @@ module ieee802-dot1q-bridge {
           }
           leaf traffic-classes {
             type boolean;
+            default "false";
             description
               "Can map priority to multiple traffic classes.";
             reference
@@ -825,6 +850,7 @@ module ieee802-dot1q-bridge {
           }
           leaf static-entry-individual-port {
             type boolean;
+            default "false";
             description
               "Static entries per port.";
             reference
@@ -832,6 +858,7 @@ module ieee802-dot1q-bridge {
           }
           leaf ivl-capable {
             type boolean;
+            default "true";
             description
               "Independent VLAN Learning (IVL).";
             reference
@@ -839,6 +866,7 @@ module ieee802-dot1q-bridge {
           }
           leaf svl-capable {
             type boolean;
+            default "false";
             description
               "Shared VLAN Learning (SVL).";
             reference
@@ -846,6 +874,7 @@ module ieee802-dot1q-bridge {
           }
           leaf hybrid-capable {
             type boolean;
+            default "false";
             description
               "Both IVL and SVL simultaneously.";
             reference
@@ -853,15 +882,17 @@ module ieee802-dot1q-bridge {
           }
           leaf configurable-pvid-tagging {
             type boolean;
+            default "false";
             description
               "Whether the implementation supports the ability to
-              override the defautl PVID setting and its egress status
+              override the default PVID setting and its egress status
               (VLAN-tagged or Untagged) on each port.";
             reference
               "IEEE 802.1Q-2014 Clause 12.4.1.5.2";
           }
           leaf local-vlan-capable {
             type boolean;
+            default "false";
             description
               "Can support multiple local Bridges, outside the scope
               of 802.1Q defined VLANs.";
@@ -871,18 +902,18 @@ module ieee802-dot1q-bridge {
         }
 
         container filtering-database {
-          when "dot1q:bridge-type != 'TPMR-bridge'" {
+        	when "../../bridge-type != 'two-port-mac-relay-bridge'" {
             description
               "Applies to non TPMR Bridges.";
           }
           description
             "Contains filtering information used by the Forwarding
             Process in deciding through which Ports of the Bridge
-            frames shoudl be forwarded.";
+            frames should be forwarded.";
           reference
             "IEEE 802.1Q-2014 Clause 12.7";
           leaf size {
-            type uint16;
+            type yang:gauge32;
             description
               "The maximum number of entries that can be held in the
               FDB.";
@@ -890,7 +921,7 @@ module ieee802-dot1q-bridge {
               "IEEE 802.1Q-2014 Clause 12.7";
           }
           leaf static-entries {
-            type uint16;
+            type yang:gauge32;
             description
               "The number of Static Filtering entries currently in
               the FDB.";
@@ -906,7 +937,7 @@ module ieee802-dot1q-bridge {
               "IEEE 802.1Q-2014 Clause 12.7, 8.8.3";
           }
           leaf static-vlan-registration-entries {
-            type uint16;
+            type yang:gauge32;
             description
               "The number of Static VLAN Registration entries
               currently in the FDB.";
@@ -931,7 +962,7 @@ module ieee802-dot1q-bridge {
               "IEEE 802.1Q-2014 Clause 12.7, 8.8.4";
           }
 
-          list filtering-entries {
+          list filtering-entry {
             key "database-id vids address";
             description
               "A table containing filtering information for
@@ -942,7 +973,7 @@ module ieee802-dot1q-bridge {
               Unicast/Multicast/Broadcast destination MAC addresses
               are allowed to be forwarded. A value of zero (as the
               Port number from which frames with a specific
-              destiantion MAC address are received) is used to
+              destination MAC address are received) is used to
               specify all ports for which there is no specific entry
               in this table for that particular MAC address. Two
               modes of operation are supported. When the receive
@@ -969,9 +1000,23 @@ module ieee802-dot1q-bridge {
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
             leaf vids {
-              type dot1qtypes:vid-range;
+              type dot1qtypes:vid-range-type;
               description
-                "The VLAN identifier to which this entry applies.";
+              	"The set of VLAN identifiers to which this entry
+              	applies.";
+              reference
+                "IEEE 802.1Q-2014 Clause 12.7.7";
+            }
+            leaf entry-type {
+              type enumeration {
+                enum dynamic {
+                  description
+                    "Dynamic/learnt entry type";
+                }
+              }
+              description
+                "The type of filtering entry. Whether static or
+                dynamic.";
               reference
                 "IEEE 802.1Q-2014 Clause 12.7.7";
             }
@@ -981,8 +1026,9 @@ module ieee802-dot1q-bridge {
                   description
                     "None of the following. This may include the case
                     where some other object is being used to
-                    determine if and how frames MAC addressed to the
-                    value of are being forwarded.";
+                    determine if and how frames addressed to the
+                    value of the corresponding instance of 'address'
+                  	are being forwarded.";
                 }
                 enum invalid {
                   description
@@ -1012,41 +1058,80 @@ module ieee802-dot1q-bridge {
                 "The status of this entry.";
             }
           }
+          
+          list vlan-registration-entry {
+            key "database-id vids";
+            description
+              "The VLAN Registration Entries models the operations
+              that can be performed on a single VLAN Registration
+              Entry in the FDB. The set of VLAN Registration Entries
+              within the FDB changes under management control and
+              also as a result of MVRP exchanges";
+            reference
+              "IEEE 802.1Q-2014 Clause 12.7.5";
+            leaf database-id {
+              type uint32;
+              description
+                "The identity of this Filtering Database.";
+              reference
+                "IEEE 802.1Q-2014 Clause 12.7.7";
+            }
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "The VLAN identifier to which this entry applies.";
+              reference
+                "IEEE 802.1Q-2014 Clause 12.7.7";
+            }
+            leaf entry-type {
+              type enumeration {
+                enum dynamic {
+                  description
+                    "Dynamic/learnt entry type";
+                }
+              }
+              description
+                "The type of filtering entry. Whether static or
+                dynamic.";
+              reference
+                "IEEE 802.1Q-2014 Clause 12.7.7";
+            }
+          }
         }
+        
+	      container permanent-database {
+	        description
+	          "The Permanent Database container models the operations
+	          that can be performed on, or affect, the Permanent
+	          Database. There is a single Permanent Database per FDB.";
+	        leaf size {
+	          type yang:gauge32;
+	          description
+	            "The maximum number of entries that can be held in the
+	            FDB.";
+	          reference
+	            "IEEE 802.1Q-2014 Clause 12.7.6";
+	        }
+	        leaf static-entries {
+	          type yang:gauge32;
+	          description
+	            "The number of Static Filtering entries currently in
+	            the FDB.";
+	          reference
+	            "IEEE 802.1Q-2014 Clause 12.7.6";
+	        }
+	        leaf static-vlan-registration-entries {
+	          type yang:gauge32;
+	          description
+	            "The number of Static VLAN Registration entries
+	            currently in the FDB.";
+	          reference
+	            "IEEE 802.1Q-2014 Clause 12.7.6";
+	        }
+	      }
 
-        container permanent-database {
-          description
-            "The Permanent Database container models the operations
-            that can be performed on, or affect, the Permanent
-            Database. There is a single Permanent Database per FDB.";
-          leaf size {
-            type yang:gauge32;
-            description
-              "The maximum number of entries that can be held in the
-              FDB.";
-            reference
-              "IEEE 802.1Q-2014 Clause 12.7.6";
-          }
-          leaf static-entries {
-            type yang:gauge32;
-            description
-              "The number of Static Filtering entries currently in
-              the FDB.";
-            reference
-              "IEEE 802.1Q-2014 Clause 12.7.6";
-          }
-          leaf static-vlan-registration-entries {
-            type yang:gauge32;
-            description
-              "The number of Static VLAN Registration entries
-              currently in the FDB.";
-            reference
-              "IEEE 802.1Q-2014 Clause 12.7.6";
-          }
-        }
-
-        container bridge-vlan {
-          when "dot1q:bridge-type != 'TPMR-bridge'" {
+        container bridge-vlan {        	
+        	when "../../bridge-type != 'two-port-mac-relay-bridge'" {
             description
               "Applies to non TPMR Bridges.";
           }
@@ -1074,6 +1159,7 @@ module ieee802-dot1q-bridge {
           }
           leaf override-default-pvid {
             type boolean;
+            default "false";
             description
               "Indicates if the default PVID can be overridden, and
               its egress status (VLAN-tagged or untagged) on each
@@ -1083,7 +1169,7 @@ module ieee802-dot1q-bridge {
           }
           leaf protocol-template {
             if-feature port-and-protocol-based-vlan;
-            type dot1qtypes:protocol-template-format;
+            type dot1qtypes:protocol-frame-format-type;
             description
               "The data-link encapsulation format or the
               detagged_frame_type in a Protocol Template";
@@ -1096,12 +1182,12 @@ module ieee802-dot1q-bridge {
               "The maximum number of MSTIs supported within an MST
               region (i.e., the number of spanning tree instances
               that can be supported in addition to the CIST), for MST
-              Bridges. Fos SST Bridges, this parameter may be either
+              Bridges. For SST Bridges, this parameter may be either
               omitted or reported as 0.";
             reference
               "IEEE 802.1Q-2014 Clause 12.10.1.7";
           }
-          list vlan-id {
+          list vlan {
             key "vid";
             description
               "List of VLAN related configuration nodes associated
@@ -1109,7 +1195,7 @@ module ieee802-dot1q-bridge {
             reference
               "IEEE 802.1Q-2014 Clause 12.10.2";
             leaf vid {
-              type dot1qtypes:vlan-index;
+              type dot1qtypes:vlan-index-type;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
@@ -1133,14 +1219,14 @@ module ieee802-dot1q-bridge {
                 Clause 12.10.2.1.3";
             }
           }
+          
           list vid-to-fid-allocation {
             key "vids";
             description
-              "The VID to FID allocations managed object models
-              operations that modify, or inquire about VID to FID
-              allocations.";
+              "This list allows inquiries about VID to FID
+            	allocations.";
             leaf vids {
-              type dot1qtypes:vid-range;
+              type dot1qtypes:vid-range-type;
               description
                 "Range of VLAN identifiers.";
               reference
@@ -1187,37 +1273,32 @@ module ieee802-dot1q-bridge {
               reference
                 "IEEE 802.1Q-2014 Clause 12.10.3";
             }
-            list vids {
-              key "vid";
-              description
-                "The list of VLAN identifiers.";
-              leaf vid {
-                type dot1qtypes:vlan-index;
-                description
-                  "The VLAN identifier to which this entry applies.";
-                reference
-                  "IEEE 802.1Q-2014 Clause 12.7.7";
-              }
-              leaf allocation-type {
-                type enumeration {
-                  enum undefined {
-                    description
-                      "No allocation defined.";
-                  }
-                  enum fixed {
-                    description
-                      "A fixed allocation to FID is defined.";
-                  }
-                  enum dynamic {
-                    description
-                      "A dynamic allocation to FID is defined.";
-                  }
+            leaf allocation-type {
+              type enumeration {
+                enum undefined {
+                  description
+                    "No allocation defined.";
                 }
-                description
-                  "The type of allocation used";
-                reference
-                  "IEEE 802.1Q-2014 Clause 12.10.3";
+                enum fixed {
+                  description
+                    "A fixed allocation to FID is defined.";
+                }
+                enum dynamic {
+                  description
+                    "A dynamic allocation to FID is defined.";
+                }
               }
+              description
+                "The type of allocation used";
+              reference
+                "IEEE 802.1Q-2014 Clause 12.10.3";
+            }
+            leaf-list vid {
+              type dot1qtypes:vlan-index-type;
+              description
+                "The VLAN identifier to which this entry applies.";
+              reference
+                "IEEE 802.1Q-2014 Clause 12.7.7";
             }
           }
         }
@@ -1226,11 +1307,11 @@ module ieee802-dot1q-bridge {
   }
 
   augment "/if:interfaces/if:interface" {
-    when "/if:type = 'ianaif:bridge' or
-          /if:type = 'ianaif:ethernetCsmacd' or
-          /if:type = 'ianaif:ieee8023adLag' or
-          /if:type = 'ianaif:ilan' or
-          /if:type = 'ianaif:pip'" {
+    when "if:type = 'ianaif:bridge' or
+          if:type = 'ianaif:ethernetCsmacd' or
+          if:type = 'ianaif:ieee8023adLag' or
+          if:type = 'ianaif:ilan' or
+          if:type = 'ianaif:pip'" {
       description
         "Applies when a Bridge interface.";
     }
@@ -1241,21 +1322,25 @@ module ieee802-dot1q-bridge {
         "Bridge Port is an extension of the IETF Interfaces model
         (RFC7223).";
       leaf component-name {
-        type dot1qtypes:component-ref;
+        type string;
         description
-          "Used to reference configured Component nodes.";
+          "Used to reference configured Component node.";
       }
-      leaf service-interface {
-        type if:interface-ref;
+      leaf port-type {
+        type identityref {
+          base type-of-port;
+        }
         description
-          "The interface reference pointed to by the bridge port.";
+          "The port type. Indicates the capabilities of this port.";
+        reference
+          "IEEE 802.1Q-2014 Clause 12.4.2.1";
       }
       leaf pvid {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+    	  when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
-        type dot1qtypes:vlan-index;
+        type dot1qtypes:vlan-index-type;
         default "1";
         description
           "The primary (default) VID assigned to a specific Bridge
@@ -1273,7 +1358,7 @@ module ieee802-dot1q-bridge {
       }
       container priority-regeneration {
         description
-          "The Priority Regeneration Table parameters associted with
+          "The Priority Regeneration Table parameters associated with
           a specific Bridge Port. A list of Regenerated User
           Priorities for each received priority on each port of a
           Bridge. The regenerated priority value may be used to
@@ -1283,7 +1368,7 @@ module ieee802-dot1q-bridge {
           same as the User Priorities";
         reference
           "IEEE 802.1Q-2014 Clause 12.6.2, 6.9.4";
-        uses dot1qtypes:priority-regeneration-table;
+        uses dot1qtypes:priority-regeneration-table-grouping;
       }
       leaf pcp-selection {
         type dot1qtypes:pcp-selection-type;
@@ -1300,41 +1385,13 @@ module ieee802-dot1q-bridge {
         description
           "The Priority Code Point Decoding Table parameters
           associated with a specific Bridge Port.";
-        leaf selection-type {
-          type dot1qtypes:pcp-selection-type;
-          default "8P0D";
-          description
-            "Priority Code Point selection type";
-          reference
-            "IEEE 802.1Q-2014 Clause 12.6.2, 6.9.3";
-        }
-        container decoding-table {
-          description
-            "Priority Code Point decoding table";
-          reference
-            "IEEE 802.1Q-2014 Clause 12.6.2";
-          uses dot1qtypes:pcpDecodingTable;
-        }
+        uses dot1qtypes:pcp-decoding-table-grouping;
       }
       container pcp-encoding-table {
         description
           "The Priority Code Point Encoding Table parameters
           associated with a specific Bridge Port.";
-        leaf selection-type {
-          type dot1qtypes:pcp-selection-type;
-          default "8P0D";
-          description
-            "Priority Code Point selection type";
-          reference
-            "IEEE 802.1Q-2014 Clause 12.6.2";
-        }
-        container encoding-table {
-          description
-            "Priority Code Point encoding table";
-          reference
-            "IEEE 802.1Q-2014 Clause 12.6.2";
-          uses dot1qtypes:pcp-encoding-table;
-        }
+        uses dot1qtypes:pcp-encoding-table-grouping;
       }
       leaf use-dei {
         type boolean;
@@ -1368,16 +1425,8 @@ module ieee802-dot1q-bridge {
           "IEEE 802.1Q-2014 Clause 12.6.2, 8.6.6";
       }
       leaf service-access-priority-selection {
-        type enumeration {
-          enum enabled {
-            description
-              "Enable service access priority selection.";
-          }
-          enum disabled {
-            description
-              "Disable service access priority selection.";
-          }
-        }
+      	type boolean;
+      	default "false";
         description
           "The Service Access Priority selection. Indication of
           whether the Service Access Priority Selection function is
@@ -1394,11 +1443,10 @@ module ieee802-dot1q-bridge {
           Priority Selection function for a Provider Bridge. The use
           of this table enables a mechanism for a Customer Bridge
           attached to a Provider Bridged Network to request priority
-          handling of frames. All writable objects in this table
-          MUST be persistent over power up restart/reboot";
+          handling of frames.";
         reference
           "IEEE 802.1Q-2014 Clause 12.6.2, 6.13.1";
-        uses dot1qtypes:service-access-priority-table;
+        uses dot1qtypes:service-access-priority-table-grouping;
       }
       container traffic-class {
         description
@@ -1407,10 +1455,10 @@ module ieee802-dot1q-bridge {
           Bridge";
         reference
           "IEEE 802.1Q-2014 Clause 12.6.3, 8.6.6";
-        uses dot1qtypes:traffic-class-table;
+        uses dot1qtypes:traffic-class-table-grouping;
       }
       leaf acceptable-frame {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+        when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
@@ -1436,100 +1484,110 @@ module ieee802-dot1q-bridge {
           "IEEE 802.1Q-2014 Clause 12.10.1.3, 6.9";
       }
       leaf enable-ingress-filtering {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
-          description
-            "Applies to non TPMR Bridges";
+    	when "../component-name != 'd-bride-component'" {
+    		description
+    			"Applies to non TPMR Bridges";
         }
         type boolean;
         default "false";
         description
-          "To configure the Enabled Ingress Filtering parameter(s)
+          "To enable the Ingress Filtering feature
           associated with one or more Ports.";
         reference
           "IEEE 802.1Q-2014 Clause 12.10.1.4, 8.6.2";
       }
       leaf restricted-vlan-registration {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+    	when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
         type boolean;
         default "false";
         description
-          "To configure the Restricted_VLAN_Registration parameter
+          "To enable the Restricted VLAN Registration
           associated with one or more Ports.";
         reference
           "IEEE 802.1Q-2014 Clause 12.10.1.6, 11.2.3.2.3";
       }
-      leaf vid-translation-table {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+      leaf enable-vid-translation-table {
+    	when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
         type boolean;
         default "false";
         description
-          "The VD Translation table associated with a Bridge Port.
-          This is not applicable to Bridge Ports that do no support
-          a VID Translation Table.";
+          "To enable VID Translation table associated with a 
+        	Bridge Port. This is not applicable to Bridge Ports that
+        	do no support a VID Translation Table.";
         reference
           "IEEE 802.1Q-2014 Clause 12.10.1.8, 6.9";
       }
-      leaf egress-vid-translation-table {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+      leaf enable-egress-vid-translation-table {
+    	when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
         type boolean;
         default "false";
         description
-          "The Egress VID Translation table associated with a Bridge
-          Port. This is not applicable to Ports that do not support
-          an Egress VID Translation table.";
+          "To enable Egress VID Translation table associated with
+        	a Bridge Port. This is not applicable to Ports that do 
+        	not support an Egress VID Translation table.";
         reference
           "IEEE 802.1Q-2014 Clause 12.10.1.9, 6.9";
       }
-      leaf protocol-group-id {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
-          description
-            "Applies to non TPMR Bridge";
-        }
-        if-feature port-and-protocol-based-vlan;
-        type uint16;
-        description
-          "Designates a group of protocols in the Protocol Group
-          Database";
-        reference
-          "IEEE 802.1Q-2014 Clause 6.12.2";
-      }
-      container protocol-group-database-contents {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+      list protocol-group-vid-set {
+      	when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
         if-feature port-and-protocol-based-vlan;
+        key "group-id";
         description
-          "A table that contains mappings from Protocol Templates to
-          Protocol Group Identifiers used for Port-and-Protocol-based
-          VLAN Classification. Entries in this table must be
-          persistent over power up restart/reboot.";
-        leaf template {
-          type dot1qtypes:protocol-template-format;
-          description
-            "The protocol template format type";
-          reference
-            "IEEE 802.1Q-2014 Clause 12.10.1.7";
-        }
+        	"The list of VID values associated with the Protocol
+        	Group Identifer for this port.";
+        reference
+        	"IEEE 802.1Q-2014 Clause 12.10.1.1.3";
         leaf group-id {
-          type uint16;
+          type uint32;
           description
             "The protocol group identifier";
           reference
             "IEEE 802.1Q-2014 Clause 12.10.1.7";
         }
+        leaf-list vid {
+        	type ieee:vlanid;
+        	description
+            "The VLAN identifier to which this entry applies.";
+          reference
+            "IEEE 802.1Q-2014 Clause 12.10.2";
+        }
       }
       leaf admin-point-to-point {
-        type uint16;
+      	type enumeration {
+      		enum force-true {
+      			value 1;
+      			description
+      				"Indicates that this port should always be treated
+      				as if it is connected to a point-to-point link.";
+      		}
+      		enum force-false {
+      			value 2;
+      			description
+      				"Indicates that this port should be treated as
+      				having a shared media connection.";
+      		}
+      		enum auto {
+      			value 3;
+      			description 
+      				"Indicates that this port is considered to have a
+      				point-to-point link if it is an Aggregator and all
+      				of its members are aggregatable, or if the MAC entity
+      				is configured for full duplex operation, either
+      				through auto-negotiation or by management means.";
+      		}
+      	}
         description
           "For a port running spanning tree, this object represents
           the administrative point-to-point status of the LAN
@@ -1544,15 +1602,12 @@ module ieee802-dot1q-bridge {
           the MAC entity is configured for full duplex operation,
           either through auto-negotiation or by management means.
           Manipulating this object changes the underlying
-          adminPointToPointMAC. The value of this object MUST be
-          retained across reinitializations of the management
-          system.";
+          adminPointToPointMAC.";
         reference
           "IEEE 802.1Q-2014 Clause 6.8.2, 12.4.2";
       }
       list vid-translations {
-        // Need to re-assess and confirm these definitions.
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+	    when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
@@ -1562,8 +1617,10 @@ module ieee802-dot1q-bridge {
           with a Port. This object is not applicable to Ports that
           do not support a VID Translation Table. The default
           configuration of the table has the value of the Relay VID
-          equal to the value of the Local VID for all Local VID
-          values. If the port supports an Egress VID translation
+          equal to the value of the Local VID. If no local VID is
+        	configured, then it is assumed that the relay VID is
+        	the same value as the local VID.
+        	If the port supports an Egress VID translation
           table, the VID Translation Configuration object configures
           the Local VID to Relay VID mapping on ingress only. If an
           Egress VID translation is not supported, the VID
@@ -1587,8 +1644,7 @@ module ieee802-dot1q-bridge {
         }
       }
       list egress-vid-translations {
-        // Need to re-assess and confirm these definitions.
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+	    when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
@@ -1598,8 +1654,9 @@ module ieee802-dot1q-bridge {
           associated with a Port. This object is not applicable to
           Ports that do not support an Egress VID Translation Table.
           The default configuration of the table has the value of the
-          Local VID equal to the value of the Relay VID for all Relay
-          VID values.";
+          Local VID equal to the value of the Relay VID. If no Relay
+        	VID is configured, then it is assumed that the local VID
+        	is the same value as the relay VID.";
         leaf relay-vid {
           type ieee:vlanid;
           description
@@ -1621,22 +1678,27 @@ module ieee802-dot1q-bridge {
   }
 
   augment "/if:interfaces-state/if:interface" {
-    when "/if:type = 'ianaif:bridge' or
-          /if:type = 'ianaif:ethernetCsmacd' or
-          /if:type = 'ianaif:ieee8023adLag' or
-          /if:type = 'ianaif:ilan' or
-          /if:type = 'ianaif:pip'" {
+    when "if:type = 'ianaif:bridge' or
+          if:type = 'ianaif:ethernetCsmacd' or
+          if:type = 'ianaif:ieee8023adLag' or
+          if:type = 'ianaif:ilan' or
+          if:type = 'ianaif:pip'" {
       description
         "Applies when a Bridge interface.";
     }
     description
       "Augment the interface-state model with the Bridge Port";
-    container bridge-port-state {
+    container bridge-port {
       description
         "Bridge Port nodes are extensions of the IETF Interfaces
         model (RFC7223).";
+      leaf component-name {
+        type string;
+        description
+          "Used to reference configured Component nodes.";
+      }
       leaf protocol-based-vlan-classification {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+	    when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
@@ -1644,13 +1706,13 @@ module ieee802-dot1q-bridge {
         type boolean;
         description
           "A boolean indication indicating if
-          Port-and-Prorotocl-based VLAN classification is supported
+          Port-and-Protocol-based VLAN classification is supported
           on a given Port.";
         reference
           "IEEE 802.1Q-2014 Clause 5.4.1.2";
       }
       leaf max-vid-set-entries {
-        when "dot1q:bridge-type != 'TPMR-bridge'" {
+	    when "../component-name != 'd-bride-component'" {
           description
             "Applies to non TPMR Bridges";
         }
@@ -1687,16 +1749,110 @@ module ieee802-dot1q-bridge {
           "IEEE 802.1Q-2014 Clause 12.4.2, 12.4.2.1.1.3 a)";
       }
       leaf capabilities {
-        type uint16;
+      	type bits {
+      		bit tagging {
+      			position 0;
+      			description
+      				"Supports 802.1Q VLAN taggging of frames and MVRP.";
+      		}
+      		bit configurable-acceptable-frame-type {
+      			position 1;
+      			description
+      				"Allows modified values of acceptable frame types";
+      		}
+      		bit ingress-filtering {
+      			position 2;
+      			description
+      				"Supports the discarding of any frame received on
+      				a Port whose VLAN classificaiton does not include
+      				that Port in its member set.";
+      		}
+      	}
         description
-          "The feature capabilities associated with port";
+          "The feature capabilities associated with port. Indicates
+        	the parts of IEEE 802.1Q that are optional on a per-port
+        	basis, that are implemented by this device, and that are
+        	manageable.";
         reference
           "IEEE 802.1Q-2014 Clause 12.4.2, 12.10.1.1.3 c)";
       }
       leaf type-capabilties {
-        type uint16;
+      	type bits {
+      		bit customer-vlan-port {
+      			position 0;
+      			description
+      				"Indicates the port can be a C-TAG aware port of
+      				an enterprise VLAN aware Bridge";
+      		}
+      		bit provider-network-port {
+      			position 1;
+      			description
+      				"Indicates the port can be an S-TAG aware port of
+      				a Provider Bridge or Backbone Edge Bridge used for
+      				connections within a PBN or PBBN.";
+      		}
+      		bit customer-network-port {
+      			position 2;
+      			description
+      				"Indicates the port can be an S-TAG aware port of a
+      				Provider Bridge or Backbone Edge Bridge used for
+      				connections to the exterior of a PBN or PBBN.";
+      		}
+      		bit customer-edge-port {
+      			position 3;
+      			description
+      				"Indicates the port can be a C-TAG aware port of a 
+      				Provider Bridge used for connections to the exterior
+      				of a PBN or PBBN.";
+      		}
+      		bit customer-backbone-port {
+      			position 4;
+      			description
+      				"Indicates the port can be a I-TAG aware port of a 
+      				Backbone Edge Bridge's B-component.";
+      		}
+      		bit virtual-instance-port {
+      			position 5;
+      			description
+      				"Indicates the port can be a virtual S-TAG aware port
+      				within a Backbone Edge Bridge's I-component which is
+      				responsible for handling S-tagged traffic for a 
+      				specific backbone service instance.";
+      		}
+      		bit d-bridge-port {
+      			position 6;
+      			description
+      				"Indicates the port can be a VLAN-unaware member of 
+      				an 802.1Q Bridge.";
+      		}
+      		bit remote-customer-access-port {
+      			position 7;
+      			description
+      				"Indicates the port can be an S-TAG aware port of a 
+      				Provider Bridge capable of providing Remote Customer
+      				Service Interfaces.";
+      		}
+      		bit station-facing-bridge-port {
+      			position 8;
+      			description
+      				"Indicates the station-facing Bridge Port in a EVB
+      				Bridge.";
+      		}
+      		bit uplink-access-port {
+      			position 9;
+      			description
+      				"Indicates the uplink access port in an EVB Bridge or
+      				EVB station.";
+      		}
+      		bit uplink-relay-port {
+      			position 10;
+      			description
+      				"Indicates the uplink relay port in an EVB station.";
+      		}
+      	}
         description
-          "The type of feature capabilities supported with port.";
+          "The type of feature capabilities supported with port.
+        	Indicates the capabilities of this port.";
         reference
           "IEEE 802.1Q-2014 Clause 12.4.2";
       }
@@ -1715,25 +1871,28 @@ module ieee802-dot1q-bridge {
           "For a port running spanning tree, this object represents
           the operational point-to-point status of the LAN segment
           attached to this port. It indicates whether a port is
-          considered to have a point-to-point connection. If
-          adminPointToPointMAC is set to auto(2), then the value of
-          operPointToPointMAC is determined in accordance with the
-          specific procedures defined for the MAC entity concerned,
-          as defined in IEEE Std 802.1AC. The value is determined
-          dynamically; that is, it is re-evaluated whenever the value
-          of adminPointToPointMAC changes, and whenever the specific
-          procedures defined for the MAC entity evaluate a change in
-          its point-to-point status.";
+          considered to have a point-to-point connection. 
+        	
+        	If admin-point-to-point is set to auto(2), then the value
+        	of oper-point-to-point is determined in accordance with 
+        	the specific procedures defined for the MAC entity 
+        	concerned, as defined in IEEE Std 802.1AC. 
+        	
+        	The value is determined dynamically; that is, it is 
+        	re-evaluated whenever the value of admin-point-to-point
+        	changes, and whenever the specific procedures defined for
+        	the MAC entity evaluate a change in its point-to-point
+        	status.";
         reference
           "IEEE 802.1Q-2014 Clause 12.4.2, IEEE 802.1AC";
       }
-      container bridge-port-statistics {
+      container statistics {
         description
           "Container of operational state node information
           associated with the bridge port.";
-        uses dot1qtypes:bridge-port-statistics;
+        uses dot1qtypes:bridge-port-statistics-grouping;
         leaf discard-on-ingress-filtering {
-          when "dot1q:bridge-type != 'TPMR-bridge'" {
+    	  when "../../component-name != 'd-bride-component'" {
             description
               "Applies to non TPMR Bridges";
           }
@@ -1741,20 +1900,12 @@ module ieee802-dot1q-bridge {
           type yang:counter64;
           description
             "The number of frames that were discarded as a result of
-            Ingress Filtering being enabled.";
-          reference
-            "IEEE 802.1Q-2014 Clause 12.6.1.1.3";
-        }
-        leaf discard-ttl-expired {
-          when "dot1q:bridge-type != 'TPMR-bridge'" {
-            description
-              "Applies to non TPMR Bridges";
-          }
-          if-feature flow-filtering;
-          type yang:counter64;
-          description
-            "The number of frames discarded because they were
-            received with the TTL field expired";
+            Ingress Filtering being enabled.
+          	
+          	Discontinuities in the value of this counter can occur
+            at re-initialization of the management system, and at
+            other times as indicated by the value of
+            'discontinuity-time'.";
           reference
             "IEEE 802.1Q-2014 Clause 12.6.1.1.3";
         }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-pb.tree
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-pb.tree
@@ -1,11 +1,12 @@
 module: ieee802-dot1q-pb
 augment /if:interfaces/if:interface/dot1q:bridge-port:
-   +--rw cvid-registration-table* [cvid]
+   +--rw svid?                            ieee:vlanid
+   +--rw cvid-registration* [cvid]
    |  +--rw cvid            ieee:vlanid
    |  +--rw svid?           ieee:vlanid
    |  +--rw untagged-pep?   boolean
    |  +--rw untagged-cep?   boolean
-   +--rw service-priority-regeneration-table* [svid]
+   +--rw service-priority-regeneration* [svid]
    |  +--rw svid                     ieee:vlanid
    |  +--rw priority-regeneration
    |     +--rw priority0?   priority-type
@@ -16,7 +17,7 @@ augment /if:interfaces/if:interface/dot1q:bridge-port:
    |     +--rw priority5?   priority-type
    |     +--rw priority6?   priority-type
    |     +--rw priority7?   priority-type
-   +--rw rcap-internal-interface-table* [external-svid]
+   +--rw rcap-internal-interface* [external-svid]
       +--rw external-svid              ieee:vlanid
       +--rw internal-port-number?      dot1qtypes:port-number-type
       +--rw internal-svid?             ieee:vlanid

--- a/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
@@ -7,7 +7,7 @@ module ieee802-dot1q-pb {
   import ieee802-dot1q-types { prefix "dot1qtypes"; }
   import ieee802-types { prefix "ieee"; }
   import ietf-interfaces { prefix "if"; }
-  import ietf-system { prefix "system"; }
+  //import ietf-system { prefix "system"; }
 
   organization
     "Institute of Electrical and Electronics Engineers";
@@ -66,14 +66,18 @@ module ieee802-dot1q-pb {
 
   augment "/if:interfaces/if:interface/dot1q:bridge-port" {
     description
-      "Augment the interfac model with 802.1Q Bridge Port
+      "Augment the interface model with 802.1Q Bridge Port
       configuration specific nodes.";
-    list cvid-registration-table {
-      when "/dot1q:bridges/dot1q:bridge/dot1q:component"
-          + "/dot1q:component-type = 'cVlanComponent' and
-          /dot1q:bridges/dot1q:bridge/dot1q:component"
-          + "/dot1q:bridge-port"
-          + "/dot1q:port-type = 'customer-edge-port'" {
+    leaf svid {
+      type ieee:vlanid;
+      description
+        "Service VLAN identifier.";
+      reference
+        "IEEE 802.1Q-2014 Clause 12.13.2.1";
+    }
+    list cvid-registration {
+      when "../dot1q:component-name = 'dot1q:c-vlan-component' and
+            ../dot1q:port-type = 'dot1q:customer-edge-port'" {
         description
           "Applies when the component associated with this interface
           is a CVLAN component and the port-type is a customer edge
@@ -109,6 +113,7 @@ module ieee802-dot1q-pb {
       }
       leaf untagged-pep {
         type boolean;
+        default "true";
         description
           "A boolean indicating frames for this C-VLAN should be
           forwarded untagged through the Provider Edge Port.";
@@ -117,6 +122,7 @@ module ieee802-dot1q-pb {
       }
       leaf untagged-cep {
         type boolean;
+        default "true";
         description
           "A boolean indicating frames for this C-VLAN should be
           forwarded untagged through the Customer Edge Port.";
@@ -125,16 +131,14 @@ module ieee802-dot1q-pb {
       }
     }
 
-    list service-priority-regeneration-table {
-      when "/system:system/dot1q:bridge/dot1q:component"
-      + "/dot1q:component-type = 'cVlanComponent' and
-          /dot1q:bridges/dot1q:bridge/dot1q:component"
-      + "/dot1q:bridge-port/dot1q:port-type = 'customer-edge-port'" {
-        description
-          "Applies when the bridge component assocaited with this
-          interface is a CVLAN component and the bridge port type is
-          a customer edge port.";
-      }
+    list service-priority-regeneration {
+    	when "../dot1q:component-name = 'dot1q:c-vlan-component' and
+      			../dot1q:port-type = 'dot1q:customer-edge-port'" {
+  			description
+    			"Applies when the component associated with this interface
+			    is a CVLAN component and the port-type is a customer edge
+			    port.";
+			}
       key "svid";
       description
         "The Service Priority Regeneration Table, which provides the
@@ -153,21 +157,18 @@ module ieee802-dot1q-pb {
           information.";
         reference
           "IEEE 802.1Q-2014 Clause 12.13.2.6";
-        uses dot1qtypes:priority-regeneration-table;
+        uses dot1qtypes:priority-regeneration-table-grouping;
       }
     }
 
-    list rcap-internal-interface-table {
-      when "/system:system/dot1q:bridge/dot1q:component"
-      + "/dot1q:component-type = 'sVlanComponent' and
-          /dot1q:bridges/dot1q:bridge/dot1q:component"
-      + "/dot1q:bridge-port"
-      + "/dot1q:port-type = 'remote-customer-access-port'" {
-        description
-          "Applies when the Bridge component type associated with
-          this interface is an SVLAN component and the bridge port
-          type is a remote customer access port.";
-      }
+    list rcap-internal-interface {
+    	when "../dot1q:component-name = 'dot1q:s-vlan-component' and
+     			 ../dot1q:port-type = 'dot1q:remote-customer-access-port'" {
+			  description
+			    "Applies when the component associated with this interface
+			    is a CVLAN component and the port-type is a customer edge
+			    port.";
+			}
       key "external-svid";
       description
         "Designating an external port as a RCAP automatically creates
@@ -198,11 +199,11 @@ module ieee802-dot1q-pb {
       }
       leaf internal-interface-type {
         type enumeration {
-          enum port-based-rsci {
+          enum port-based-rcsi {
             description
               "Port-based RCSI";
           }
-          enum c-tagged-rsci {
+          enum c-tagged-rcsi {
             description
               "C-tagged RCSI";
           }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.tree
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.tree
@@ -1,6 +1,4 @@
 module: ieee802-dot1q-tpmr
-augment /dot1q:bridges/dot1q:bridge:
-   +--rw tpmr!
 augment /if:interfaces/if:interface/dot1q:bridge-port:
    +--rw managed-address?          boolean
    +--rw mac-status-propagation
@@ -10,15 +8,15 @@ augment /if:interfaces/if:interface/dot1q:bridge-port:
       +--rw mac-notify?          boolean
       +--rw mac-notify-time?     yang:timeticks
       +--rw mac-recover-time?    yang:timeticks
-augment /if:interfaces-state/if:interface/dot1q:bridge-port-state/dot1q:bridge-port-statistics:
-   +--ro acks-tx?                    yang:counter64
-   +--ro add-notificatons-tx?        yang:counter64
-   +--ro loss-notification-tx?       yang:counter64
-   +--ro loss-confirmation-tx?       yang:counter64
-   +--ro acks-rx?                    yang:counter64
-   +--ro add-notificatons-rx?        yang:counter64
-   +--ro loss-notification-rx?       yang:counter64
-   +--ro loss-confirmation-rx?       yang:counter64
-   +--ro add-events?                 yang:counter64
-   +--ro loss-events?                yang:counter64
-   +--ro mac-status-notifications?   yang:counter64
+augment /if:interfaces-state/if:interface/dot1q:bridge-port/dot1q:statistics:
+   +--ro acks-tx?                    yang:counter32
+   +--ro add-notificatons-tx?        yang:counter32
+   +--ro loss-notification-tx?       yang:counter32
+   +--ro loss-confirmation-tx?       yang:counter32
+   +--ro acks-rx?                    yang:counter32
+   +--ro add-notificatons-rx?        yang:counter32
+   +--ro loss-notification-rx?       yang:counter32
+   +--ro loss-confirmation-rx?       yang:counter32
+   +--ro add-events?                 yang:counter32
+   +--ro loss-events?                yang:counter32
+   +--ro mac-status-notifications?   yang:counter32

--- a/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.yang
@@ -62,29 +62,11 @@ module ieee802-dot1q-tpmr {
       Virtual Bridged Local Area Networks.";
   }
 
-  augment "/dot1q:bridges/dot1q:bridge" {
-    when "/dot1q:components = '1' and
-      /dot1q:bridge-type = 'two-port-mac-relay-bridge'" {
-      description
-        "Applies when there is a single Bridge component of bridge
-        type TPMR.";
-    }
-    description
-      "Augment the dot1q Bridge model with TPMR bridge nodal
-      information.";
-    container tpmr {
-      presence
-        "Two Port MAC Relay Bridge";
-      description
-        "TPMR bridge configuration data.";
-    }
-  }
-
   augment "/if:interfaces/if:interface/dot1q:bridge-port" {
-    when "/dot1q:bridges/dot1q:bridge/dot1q:num-ports = '2'" {
-      description
-        "Applies when the number of bridge ports is 2";
-    }
+  	when "dot1q:port-type = 'd-bridge-port'" {
+  		description
+  			"Applies to TPMR Bridges ports";
+  	}
     description
       "Augment Interface model with TPMR bridge port configuration
       specific nodes.";
@@ -100,7 +82,7 @@ module ieee802-dot1q-tpmr {
         "MAC status propagation configuration node parameters.";
       leaf link-notify {
         type boolean;
-        default "false";
+        default "true";
         description
           "The current value (Boolean) of LinkNotify (23.5.1) being
           used by the MSP state machines.";
@@ -108,7 +90,10 @@ module ieee802-dot1q-tpmr {
           "IEEE 802.1Q-2014 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
       }
       leaf link-notify-wait {
-        type yang:timeticks;
+        type yang:timeticks {
+        	range "2..10";
+        }
+        default 4;
         description
           "The current value, in centiseconds, of LinkNotifyWait
           (23.5.2) being used by the MSP state machines.";
@@ -116,7 +101,10 @@ module ieee802-dot1q-tpmr {
           "IEEE 802.1Q-2014 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
       }
       leaf link-notify-retry {
-        type yang:timeticks;
+        type yang:timeticks {
+        	range "1..10";
+        }
+        default 10;
         description
           "The current value, in centiseconds, of LinkNotifyRetry
           (23.5.3) being used by the MSP state machines.";
@@ -125,7 +113,7 @@ module ieee802-dot1q-tpmr {
       }
       leaf mac-notify {
         type boolean;
-        default "false";
+        default "true";
         description
           "The current value (Boolean) of MACNotify (23.5.4) being
           used by the MSP state machines.";
@@ -133,7 +121,10 @@ module ieee802-dot1q-tpmr {
           "IEEE 802.1Q-2014 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
       }
       leaf mac-notify-time {
-        type yang:timeticks;
+        type yang:timeticks {
+        	range "1..5";
+        }
+        default 2;
         description
           "The current value, in centiseconds, of MACNotifyTime
           (23.5.5) being used by the MSP state machines.";
@@ -141,7 +132,10 @@ module ieee802-dot1q-tpmr {
           "IEEE 802.1Q-2014 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
       }
       leaf mac-recover-time {
-        type yang:timeticks;
+        type yang:timeticks {
+        	range "1..5";
+        }
+        default 1;
         description
           "The current value, in centiseconds, of MACRecoverTime
           (23.5.6) being used by the MSP state machines.";
@@ -152,16 +146,16 @@ module ieee802-dot1q-tpmr {
   }
 
   augment "/if:interfaces-state/if:interface"
-  + "/dot1q:bridge-port-state/dot1q:bridge-port-statistics" {
-    when "/dot1q:bridges/dot1q:bridge/dot1q:num-ports = '2'" {
-      description
-        "Applies when there are 2 Bridge ports.";
-    }
+        + "/dot1q:bridge-port/dot1q:statistics" {
+  	when "../dot1q:port-type = 'd-bridge-port'" {
+  		description
+  			"Applies to TPMR Bridges ports";
+  	}
     description
       "Augment Interface-state model with TPMR bridge port
       operational state specific nodes.";
     leaf acks-tx {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of acks transmitted (23.6.15) by the Ports
         Transmit Process as a consequence of txAck being set.";
@@ -169,7 +163,7 @@ module ieee802-dot1q-tpmr {
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf add-notificatons-tx {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of adds transmitted (23.6.16) by the Ports
         Transmit Process as a consequence of txAdd being set.";
@@ -177,74 +171,119 @@ module ieee802-dot1q-tpmr {
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf loss-notification-tx {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of losses transmitted (23.6.18) by the Ports
-        Transmit Process as a consequence of txLoss being set.";
+        Transmit Process as a consequence of txLoss being set.
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf loss-confirmation-tx {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of loss confirms transmitted (23.6.19) by the
         Ports Transmit Process as a consequence of txLossConfirm
-        being set.";
+        being set.
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf acks-rx {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of acks received (23.6.10) by the Ports Transmit
-        Process.";
+        Process.
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf add-notificatons-rx {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of adds received (23.6.11) by the Ports Receive
-        Process.";
+        Process.
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf loss-notification-rx {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of losses received (23.6.13) by the Ports Receive
-        Process.";
+        Process.
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf loss-confirmation-rx {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of loss confirms received (23.6.14) by the Ports
-        Receive Process.";
+        Receive Process.
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf add-events {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of transitions to STM:ADD directly from STM:DOWN
-        or STM:LOSS (23.8).";
+        or STM:LOSS (23.8).
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf loss-events {
-      type yang:counter64;
+      type yang:counter32;
       description
         "The number of transitions to STM:LOSS directly from STM:UP
-        or STM:ADD (23.8).";
+        or STM:ADD (23.8).
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }
     leaf mac-status-notifications {
-      type yang:counter64;
+      type yang:counter32;
       description
-        "The number of transitions to SNM:MAC_NOTIFICATION (23.9).";
+        "The number of transitions to SNM:MAC_NOTIFICATION (23.9).
+      	
+      	Discontinuities in the value of this counter can occur
+        at re-initialization of the management system, and at
+        other times as indicated by the value of
+        'discontinuity-time'.";
       reference
         "IEEE 802.1Q-2014 Clause 12.19.4.1.3.3";
     }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
@@ -104,13 +104,6 @@ module ieee802-dot1q-types {
    * IEEE 802.1Q Type Definitions.
    */
 
-  typedef component-ref {
-    type string;
-    description
-      "Unique identifier for a particular Bridge component within the
-      system.";
-  }
-
   typedef name-type {
     type string {
       length "0..32";
@@ -148,7 +141,7 @@ module ieee802-dot1q-types {
       different classes of traffic.";
   }
 
-  typedef vid-range {
+  typedef vid-range-type {
     /*
      * Defines the type used to represent ranges of VLAN Ids.
      *
@@ -156,24 +149,24 @@ module ieee802-dot1q-types {
      * but the model is easier to use if this is just represented
      * as a string.
      *
-     * This type is used to match an ordered list of VLAN Ids, or
-     * contiguous ranges of VLAN Ids. Valid VLAN Ids must be in
-     * the range 1 to 4094, and included in the list in non
-     * overlapping ascending order.
-     *
-     * For example, "1, 10-100, 50, 500-1000"
-     *
      */
     type string {
-      pattern "([0-9]{1,4}(-[0-9]{1,4})?(,[0-9]{1,4}" +
-            "(-[0-9]{1,4})?)*)";
+      pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?" +
+              "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
     }
     description
       "A list of VLAN Ids, or non overlapping VLAN ranges, in
-      ascending order, between 1 and 4094";
+      ascending order, between 1 and 4094.
+    	
+    	This type is used to match an ordered list of VLAN Ids, or
+    	contiguous ranges of VLAN Ids. Valid VLAN Ids must be in the 
+    	range 1 to 4094, and included in the list in non overlapping
+    	ascending order.
+    	
+    	For example: 1,10-100,50,500-1000";
   }
 
-  typedef vlan-index {
+  typedef vlan-index-type {
     type uint32 {
       range "1..4094 | 4096..4294967295";
     }
@@ -214,7 +207,7 @@ module ieee802-dot1q-types {
       "IEEE 802.1Q-2014 Clause 12.6.2.5.3, 6.9.3";
   }
 
-  typedef protocol-template-format {
+  typedef protocol-frame-format-type {
     type enumeration {
       enum Ethernet {
         description
@@ -243,10 +236,14 @@ module ieee802-dot1q-types {
       "IEEE 802.1Q-2014 Clause 12.10.1.7.1";
   }
 
-  typedef etherType {
-    type uint16;
+  typedef ether-type {
+    type string {
+      pattern '[0-9a-fA-F]{4}';
+    }
     description
-      "The Ethernet Type (or Length) value.";
+      "The Ethernet Type (or Length) value represented
+      in the canonical order defined by IEEE 802. The canonical
+    	representation uses lowercase characters.";
     reference
       "IEEE 802-2014 Clause 9.2";
   }
@@ -277,7 +274,7 @@ module ieee802-dot1q-types {
    * IEEE 802.1Q Bridge Group definitions.
    */
 
-  grouping dot1q-tag-classifier {
+  grouping dot1q-tag-classifier-grouping {
     description
       "A grouping which represents an 802.1Q VLAN, matching both
       the Ethertype and a single VLAN Id.";
@@ -300,7 +297,7 @@ module ieee802-dot1q-types {
     }
   }
 
-  grouping dot1q-tag-or-any-classifier {
+  grouping dot1q-tag-or-any-classifier-grouping {
     description
       "A grouping which represents an 802.1Q VLAN, matching both
       the  Ethertype and a single VLAN Id or 'any' to match on
@@ -320,7 +317,7 @@ module ieee802-dot1q-types {
           type ieee:vlanid;
           type enumeration {
             enum "any" {
-              value 4096;
+              value 4095;
               description
                 "Matches 'any' VLAN in the range 1 to 4094 that
                  is not matched by a more specific VLAN Id match";
@@ -334,7 +331,7 @@ module ieee802-dot1q-types {
     }
   }
 
-  grouping dot1q-tag-ranges-classifier {
+  grouping dot1q-tag-ranges-classifier-grouping {
     description
       "A grouping which represents an 802.1Q VLAN that matches a
       range of VLAN Ids.";
@@ -349,7 +346,7 @@ module ieee802-dot1q-types {
           "VLAN type";
       }
       leaf vlan-ids {
-        type dot1q-types:vid-range;
+        type vid-range-type;
         mandatory true;
         description
           "VLAN Ids";
@@ -357,7 +354,7 @@ module ieee802-dot1q-types {
     }
   }
 
-  grouping dot1q-tag-ranges-or-any-classifier {
+  grouping dot1q-tag-ranges-or-any-classifier-grouping {
     description
       "A grouping which represents an 802.1Q VLAN, matching
       both the Ethertype and a single VLAN Id, ordered list of
@@ -374,9 +371,10 @@ module ieee802-dot1q-types {
       }
       leaf vlan-id {
         type union {
-          type dot1q-types:vid-range;
+          type vid-range-type;
           type enumeration {
             enum "any" {
+            	value 4095;
               description
                 "Matches 'any' VLAN in the range 1 to 4094.";
             }
@@ -389,13 +387,16 @@ module ieee802-dot1q-types {
     }
   }
 
-  grouping priority-regeneration-table {
+  grouping priority-regeneration-table-grouping {
     description
-      "The priority regeneration table.";
+      "The priority regeneration table provides the ability to map
+    	incoming priority values on a per-Port basis, under management
+    	control.";
     reference
       "IEEE 802.1Q-2014 Clause 6.9.4";
     leaf priority0 {
       type priority-type;
+      default 0;
       description
         "Priority 0";
       reference
@@ -403,6 +404,7 @@ module ieee802-dot1q-types {
     }
     leaf priority1 {
       type priority-type;
+      default 1;
       description
         "Priority 1";
       reference
@@ -410,6 +412,7 @@ module ieee802-dot1q-types {
     }
     leaf priority2 {
       type priority-type;
+      default 2;
       description
         "Priority 2";
       reference
@@ -417,6 +420,7 @@ module ieee802-dot1q-types {
     }
     leaf priority3 {
       type priority-type;
+      default 3;
       description
         "Priority 3";
       reference
@@ -424,6 +428,7 @@ module ieee802-dot1q-types {
     }
     leaf priority4 {
       type priority-type;
+      default 4;
       description
         "Priority 4";
       reference
@@ -431,6 +436,7 @@ module ieee802-dot1q-types {
     }
     leaf priority5 {
       type priority-type;
+      default 5;
       description
         "Priority 5";
       reference
@@ -438,6 +444,7 @@ module ieee802-dot1q-types {
     }
     leaf priority6 {
       type priority-type;
+      default 6;
       description
         "Priority 6";
       reference
@@ -445,6 +452,7 @@ module ieee802-dot1q-types {
     }
     leaf priority7 {
       type priority-type;
+      default 7;
       description
         "Priority 7";
       reference
@@ -452,315 +460,115 @@ module ieee802-dot1q-types {
     }
   }
 
-  grouping pcpDecodingTable {
+  grouping pcp-decoding-table-grouping {
     description
-      "The Priority Code Point decoding table.";
+      "The Priority Code Point decoding table enables the decoding of
+    	the priority and drop-eligible parameters from the PCP.";
     reference
       "IEEE 802.1Q-2014 Clause 6.9.3";
-    container pcp0 {
-      description
-        "Priority code point 0 value";
-      leaf priority {
-        type priority-type;
-        description
-          "Priority associated with pcp";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-      leaf drop-eligible {
-        type boolean;
-        description
-          "Drop eligible value for pcp0";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-    }
-    container pcp1 {
-      description
-        "Priority code point 1 value";
-      leaf priority {
-        type priority-type;
-        description
-          "Priority associated with pcp";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-      leaf drop-eligible {
-        type boolean;
-        description
-          "Drop eligible value for pcp1";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-    }
-    container pcp2 {
-      description
-        "Priority code point 2 value";
-      leaf priority {
-        type priority-type;
-        description
-          "Priority associated with pcp";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-      leaf drop-eligible {
-        type boolean;
-        description
-          "Drop eligible value for pcp2";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-    }
-    container pcp3 {
-      description
-        "Priority code point 3 value";
-      leaf priority {
-        type priority-type;
-        description
-          "Priority associated with pcp";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-      leaf drop-eligible {
-        type boolean;
-        description
-          "Drop eligible value for pcp3";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-    }
-    container pcp4 {
-      description
-        "Priority code point 4 value";
-      leaf priority {
-        type priority-type;
-        description
-          "Priority associated with pcp";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-      leaf drop-eligible {
-        type boolean;
-        description
-          "Drop eligible value for pcp4";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-    }
-    container pcp5 {
-      description
-        "Priority code point 5 value";
-      leaf priority {
-        type priority-type;
-        description
-          "Priority associated with pcp";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-      leaf drop-eligible {
-        type boolean;
-        description
-          "Drop eligible value for pcp5";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-    }
-    container pcp6 {
-      description
-        "Priority code point 6 value";
-      leaf priority {
-        type priority-type;
-        description
-          "Priority associated with pcp";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-      leaf drop-eligible {
-        type boolean;
-        description
-          "Drop eligible value for pcp6";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-    }
-    container pcp7 {
-      description
-        "Priority code point 7 value";
-      leaf priority {
-        type priority-type;
-        description
-          "Priority associated with pcp";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
-      leaf drop-eligible {
-        type boolean;
-        description
-          "Drop eligible value for pcp7";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
-      }
+    list pcp-decoding-map {
+    	key "pcp";
+    	description
+	    	"This map associates the priority code point field found
+				in the VLAN to a priority and drop eligible value based
+				upon the priority code point selection type.";
+    	leaf pcp {
+    		type pcp-selection-type;
+    		description
+    			"The priority code point selection type.";
+    		reference
+    			"IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
+    	}
+    	list priority-map {
+    		key "priority-code-point";
+    		description
+      		"This map associated a priority code point value
+    			to priority and drop eligible parameters.";
+    		leaf priority-code-point {
+    			type priority-type;
+    			description
+    				"Priority associated with the pcp.";
+    			reference
+            "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
+    		}
+    		leaf priority {
+    			type priority-type;
+    			description
+    				"Priority associated with the pcp.";
+    			reference
+            "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
+    		}
+    		leaf drop-eligible {
+          type boolean;
+          description
+            "Drop eligible value for pcp";
+          reference
+            "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
+        } 		
+    	}   	
     }
   }
 
-  grouping pcp-encoding-table {
+  grouping pcp-encoding-table-grouping {
     description
-      "The Priority Code Point encoding table.";
+      "The Priority Code Point encoding table encodes the priority 
+    	and drop-eligible parameters in the PCP field of the VLAN tag.";
     reference
       "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-    container priority0 {
-      description
-        "Priority 0 PCP encoding table entry";
-      leaf pcp-dei-false {
-        type priority-type;
-        description
-          "PCP value for priority 0 when DEI false";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-      leaf pcp-dei-true {
-        type priority-type;
-        description
-          "PCP value for priority 0 when DEI true";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-    }
-    container priority1 {
-      description
-        "Priority 1 PCP encoding table entry";
-      leaf pcp-dei-false {
-        type priority-type;
-        description
-          "PCP value for priority 1 when DEI false";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-      leaf pcp-dei-true {
-        type priority-type;
-        description
-          "PCP value for priority 1 when DEI true";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-    }
-    container priority2 {
-      description
-        "Priority 2 PCP encoding table entry";
-      leaf pcp-dei-false {
-        type priority-type;
-        description
-          "PCP value for priority 2 when DEI false";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-      leaf pcp-dei-true {
-        type priority-type;
-        description
-          "PCP value for priority 2 when DEI true";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-    }
-    container priority3 {
-      description
-        "Priority 3 PCP encoding table entry";
-      leaf pcp-dei-false {
-        type priority-type;
-        description
-          "PCP value for priority 3 when DEI false";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-      leaf pcp-dei-true {
-        type priority-type;
-        description
-          "PCP value for priority 3 when DEI true";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-    }
-    container priority4 {
-      description
-        "Priority 4 PCP encoding table entry";
-      leaf pcp-dei-false {
-        type priority-type;
-        description
-          "PCP value for priority 4 when DEI false";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-      leaf pcp-dei-true {
-        type priority-type;
-        description
-          "PCP value for priority 4 when DEI true";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-    }
-    container priority5 {
-      description
-        "Priority 5 PCP encoding table entry";
-      leaf pcp-dei-false {
-        type priority-type;
-        description
-          "PCP value for priority 5 when DEI false";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-      leaf pcp-dei-true {
-        type priority-type;
-        description
-          "PCP value for priority 5 when DEI true";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-    }
-    container priority6 {
-      description
-        "Priority 6 PCP encoding table entry";
-      leaf pcp-dei-false {
-        type priority-type;
-        description
-          "PCP value for priority 6 when DEI false";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-      leaf pcp-dei-true {
-        type priority-type;
-        description
-          "PCP value for priority 6 when DEI true";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-    }
-    container priority7 {
-      description
-        "Priority 7 PCP encoding table entry";
-      leaf pcp-dei-false {
-        type priority-type;
-        description
-          "PCP value for priority 7 when DEI false";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
-      leaf pcp-dei-true {
-        type priority-type;
-        description
-          "PCP value for priority 7 when DEI true";
-        reference
-          "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
-      }
+    list pcp-encoding-map {
+    	key "pcp";
+    	description
+    		"This map associated the priority and drop-eligible 
+    		parameters to the priority used to encode the PCP of
+    		the VLAN based upon the priority code point selection 
+    		type.";
+    	leaf pcp {
+    		type pcp-selection-type;
+    		description
+    			"The priority code point selection type.";
+    		reference
+    			"IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
+    	}
+    	list priority-map {
+    		key "priority dei";
+    		description
+    			"This map associated the priority and drop-eligible 
+      		parameters to the priority code point field of the VLAN 
+    			tag.";
+    		leaf priority {
+    			type priority-type;
+    			description
+    				"Priority associated with the pcp.";
+    			reference
+            "IEEE 802.1Q-2014 Clause 12.6.2.7, 6.9.3";
+    		}
+    		leaf dei {
+    			type boolean;
+    			description
+    				"The drop eligible value.";
+    			reference
+            "IEEE 802.1Q-2014 Clause 12.6.2, 8.6.6";
+    		}
+    		leaf priority-code-point {
+          type priority-type;
+          description
+            "PCP value for priority when DEI value";
+          reference
+            "IEEE 802.1Q-2014 Clause 12.6.2.9, 6.9.3";
+        }	
+    	}    	
     }
   }
 
-  grouping service-access-priority-table {
+  grouping service-access-priority-table-grouping {
     description
-      "The Service Access Priority Table.";
+      "The Service Access Priority Table associates a received
+    	priority with a serice access priority.";
     reference
       "IEEE 802.1Q-2014 Clause 6.13.1, 12.6.2.17";
     leaf priority0 {
       type priority-type;
+      default 0;
       description
         "Service access priority value for priority 0";
       reference
@@ -768,6 +576,7 @@ module ieee802-dot1q-types {
     }
     leaf priority1 {
       type priority-type;
+      default 1;
       description
         "Service access priority value for priority 1";
       reference
@@ -775,6 +584,7 @@ module ieee802-dot1q-types {
     }
     leaf priority2 {
       type priority-type;
+      default 2;
       description
         "Service access priority value for priority 2";
       reference
@@ -782,6 +592,7 @@ module ieee802-dot1q-types {
     }
     leaf priority3 {
       type priority-type;
+      default 3;
       description
         "Service access priority value for priority 3";
       reference
@@ -789,6 +600,7 @@ module ieee802-dot1q-types {
     }
     leaf priority4 {
       type priority-type;
+      default 4;
       description
         "Service access priority value for priority 4";
       reference
@@ -796,6 +608,7 @@ module ieee802-dot1q-types {
     }
     leaf priority5 {
       type priority-type;
+      default 5;
       description
         "Service access priority value for priority 5";
       reference
@@ -803,6 +616,7 @@ module ieee802-dot1q-types {
     }
     leaf priority6 {
       type priority-type;
+      default 6;
       description
         "Service access priority value for priority 6";
       reference
@@ -810,6 +624,7 @@ module ieee802-dot1q-types {
     }
     leaf priority7 {
       type priority-type;
+      default 7;
       description
         "Service access priority value for priority 7";
       reference
@@ -817,15 +632,14 @@ module ieee802-dot1q-types {
     }
   }
 
-  grouping traffic-class-table {
+  grouping traffic-class-table-grouping {
     description
       "The Traffic Class Table models the operations that can be
       performed on, or inquire about, the current contents of the
       Traffic Class Table (8.6.6) for a given Port.";
     reference
       "IEEE 802.1Q-2014 Clause 12.6.3, 8.6.6";
-    // To be confirmed
-    list tc-entries {
+    list traffic-class-map {
       key "priority";
       description
         "The priority index into the traffic class table.";
@@ -836,13 +650,22 @@ module ieee802-dot1q-types {
         reference
           "IEEE 802.1Q-2014 Clause 8.6.6";
       }
-      list available-TC {
-        key "traffic-class";
+      list available-traffic-class {
+        key "num-traffic-class";
         description
           "The traffic class index associated with a given priority
           within the traffic class table.";
         reference
           "IEEE 802.1Q-2014 Clause 8.6.6";
+        leaf num-traffic-class {
+          type uint8 {
+          	range "1..8";
+          }
+          description
+            "The available number of traffic classes.";
+          reference
+            "IEEE 802.1Q-2014 Clause 8.6.6";
+        }
         leaf traffic-class {
           type traffic-class-type;
           description
@@ -851,28 +674,21 @@ module ieee802-dot1q-types {
           reference
             "IEEE 802.1Q-2014 Clause 8.6.6";
         }
-        leaf num-tc {
-          type priority-type;
-          description
-            "The available number of traffic classes.";
-          reference
-            "IEEE 802.1Q-2014 Clause 8.6.6";
-        }
       }
     }
   }
 
-  grouping port-map {
+  grouping port-map-grouping {
     description
-      "A set of control indicators, one for each Port.";
+      "A set of control indicators, one for each Port. A Port Map,
+    	containing a control element for each outbound Port";
     reference
       "IEEE 802.1Q-2014 Clause 8.8.1, 8.8.2";
     list port-map {
-      key "port-number";
+      key "port-ref";
       description
         "The list of entries composing the port map.";
-      leaf port-number {
-        //type port-number-type;
+      leaf port-ref {
         type if:interface-ref;
         description
           "The interface port reference associated with this map.";
@@ -1066,7 +882,7 @@ module ieee802-dot1q-types {
     }
   }
 
-  grouping bridge-port-statistics {
+  grouping bridge-port-statistics-grouping {
     description
       "Grouping of bridge port statistics.";
     reference

--- a/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.tree
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.tree
@@ -1,3 +1,0 @@
-module: ieee802-dot1q-vlan-bridge
-augment /dot1q:bridges/dot1q:bridge:
-   +--rw vlan-bridge!

--- a/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.yang
@@ -3,7 +3,7 @@ module ieee802-dot1q-vlan-bridge {
   namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-vlan-bridge";
   prefix "dot1q-vlan-bridge";
 
-  import ieee802-dot1q-bridge { prefix "dot1q"; }
+  //import ieee802-dot1q-bridge { prefix "dot1q"; }
 
   organization
     "Institute of Electrical and Electronics Engineers";
@@ -60,21 +60,4 @@ module ieee802-dot1q-vlan-bridge {
       Virtual Bridged Local Area Networks.";
   }
 
-  augment "/dot1q:bridges/dot1q:bridge" {
-    when "/dot1q:components = '1' and
-      /dot1q:bridge-type = 'customer-vlan-bridge'" {
-      description
-        "Applies when there is a single Bridge component of bridge
-        type Customer VLAN Bridge.";
-    }
-    description
-      "Augment the dot1q Bridge model with Customer VLAN Bridge nodal
-      information.";
-    container vlan-bridge {
-      presence
-        "Customer VLAN Bridge";
-      description
-        "Customer VLAN bridge configuration data.";
-    }
-  }
 }

--- a/standard/ieee/802.1/draft/ieee802-dot1x.tree
+++ b/standard/ieee/802.1/draft/ieee802-dot1x.tree
@@ -23,6 +23,7 @@ augment /system:system-state:
 augment /if:interfaces/if:interface:
    +--rw pae
       +--rw pae-system?          dot1x:pae-system-ref
+      +--rw port-type?           enumeration
       +--rw vp-enable?           boolean
       +--rw port-capabilities
       |  +--rw supp?                  boolean

--- a/standard/ieee/802.1/draft/ieee802-dot1x.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1x.yang
@@ -664,8 +664,8 @@ module ieee802-dot1x {
    *  Port Authentication Entity (PAE) Nodes
    */
   augment "/if:interfaces/if:interface" {
-    when "/if:type = 'ianaif:ethernetCsmacd' or
-          /if:type = 'ianaif:ilan'" {
+    when "if:type = 'ianaif:ethernetCsmacd' or
+          if:type = 'ianaif:ilan'" {
       description
         "Applies to the Controlled Port of SecY or PAC shim.";
     }
@@ -682,9 +682,25 @@ module ieee802-dot1x {
         description
           "The PAE system that this PAE is a member of.";
       }
+      leaf port-type {
+      	type enumeration {
+          enum real-port {
+            description
+              "Real Port type.";
+          }
+          enum virtual-port {
+            description
+              "Virtual Port type.";
+          }
+        }
+        description
+          "The port type of the PAE.";
+        reference
+          "IEEE 802.1X-2010 Clause 12.9.2";
+      }
       leaf vp-enable {
-        when "dot1x:port-type = 'dot1x:real-port' and
-            ../port-capabilities/virtual-ports = 'true'" {
+        when "../port-type = 'real-port' and
+              ../port-capabilities/virtual-ports = 'true'" {
           description
             "Applies when port is Real Port and virtual port
             capabilities are supported.";
@@ -706,9 +722,9 @@ module ieee802-dot1x {
 
       container supplicant {
         // NOTE: Suppplicant only applicable to RealPort types.
-        when "dot1x:port-type = 'dot1x:real-port' and
-            ../port-capabilities/supp = 'true' and
-            ../port-capabilities/auth = 'false'" {
+        when "../port-type = 'real-port' and
+              ../port-capabilities/supp = 'true' and
+              ../port-capabilities/auth = 'false'" {
           description
             "Applies to Real Ports and when the Authenticator is
             disabled and supplicant port capabilities are
@@ -871,7 +887,7 @@ module ieee802-dot1x {
           }
         }
         container macsec {
-          when "../port-capabilities/macsec = 'true'" {
+          when "../../port-capabilities/macsec = 'true'" {
             description
               "Applies when the MACsec port capability is
               supported.";
@@ -1093,8 +1109,8 @@ module ieee802-dot1x {
   }
 
   augment "/if:interfaces-state/if:interface" {
-    when "/if:type = 'ianaif:ethernetCsmacd' or
-          /if:type = 'ianaif:ilan'" {
+    when "if:type = 'ianaif:ethernetCsmacd' or
+          if:type = 'ianaif:ilan'" {
       description
         "Applies to the Controlled Port of SecY or PAC shim.";
       }
@@ -1206,7 +1222,7 @@ module ieee802-dot1x {
         description
           "Contains Virtual Port operational state information.";
         leaf max {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when Port is a Real Port.";
           }
@@ -1217,7 +1233,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.9.2";
         }
         leaf current {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when Port is a Real Port.";
           }
@@ -1228,7 +1244,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.9.2";
         }
         leaf start {
-          when "dot1x:port-type = 'dot1x:virtual-port'" {
+          when "../../port-type = 'virtual-port'" {
             description
               "Applies when Port is a Virtual Port.";
           }
@@ -1240,7 +1256,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.9.7";
         }
         leaf peer-address {
-          when "dot1x:port-type = 'dot1x:virtual-port'" {
+          when "../../port-type = 'virtual-port'" {
             description
               "Applies when Port is a Virtual Port.";
           }
@@ -1255,8 +1271,8 @@ module ieee802-dot1x {
 
       container supplicant {
         // Suppplicant only applicable to RealPort types.
-        when "dot1x:port-type = 'dot1x:real-port' and
-             ../port-capabilities/supp = 'true'" {
+        when "../port-type = 'real-port' and
+              ../port-capabilities/supp = 'true'" {
           description
             "Applies when Port is a Real Port and the Supplicant
             port capability is supported.";
@@ -1375,7 +1391,6 @@ module ieee802-dot1x {
             "Applies when the MKA port capability feature is
             supported.";
         }
-        // May need to revisit this.
         description
           "Contains operational state system level information for
           each Interface supported by the KaY (Key Aggreement
@@ -1409,7 +1424,7 @@ module ieee802-dot1x {
           }
         }
         container macsec {
-          when "../port-capabilities/macsec = 'true'" {
+          when "../../port-capabilities/macsec = 'true'" {
             description
               "Applies when the MACsec port capability feature is
               supported.";
@@ -1667,7 +1682,6 @@ module ieee802-dot1x {
               "IEEE 802.1X-2010 Clause 10.4";
           }
           leaf access-status {
-            // Need to confirm these types.
             type pae-access-status;
             description
               "Access Status reflects connectivity as a result of
@@ -1795,7 +1809,7 @@ module ieee802-dot1x {
         description
           "Contains operational EAPOL statics.";
         leaf invalid-eapol-frame-rx {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }
@@ -1807,7 +1821,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.1";
         }
         leaf eap-length-error-frames {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }
@@ -1820,7 +1834,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.1";
         }
         leaf eapol-announcements-rx {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }
@@ -1832,7 +1846,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.1";
         }
         leaf eapol-announce-reqs-rx {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }
@@ -1844,8 +1858,8 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.1";
         }
         leaf eapol-port-unavailable {
-          when "dot1x:port-type = 'dot1x:real-port' and
-                ../port-capabilities/virtual-ports = 'true'" {
+          when "../../port-type = 'real-port' and
+                ../../port-capabilities/virtual-ports = 'true'" {
             description
               "Applies when port is Real Port and when the virtual
               ports capability is supported.";
@@ -1902,7 +1916,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.1";
         }
         leaf last-eapol-frame-source {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }
@@ -1921,7 +1935,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.2";
         }
         leaf eapol-supp-eap-frames-tx {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }
@@ -1933,7 +1947,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.3";
         }
         leaf eapol-logoff-frames-tx {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }
@@ -1945,7 +1959,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.3";
         }
         leaf eapol-announcements-tx {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }
@@ -1957,7 +1971,7 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.8.3";
         }
         leaf eapol-announce-reqs-tx {
-          when "dot1x:port-type = 'dot1x:real-port'" {
+          when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
           }

--- a/standard/ieee/draft/ieee802-types.yang
+++ b/standard/ieee/draft/ieee802-types.yang
@@ -51,33 +51,19 @@ module ieee802-types {
     }
     description
       "The mac-address type represents an 802 MAC address represented
-      in the canonical order defined by IEEE 802.";
+      in the canonical order defined by IEEE 802. The canonical
+    	representation uses lowercase characters.
+    	
+    	In the value set and its semantics, this type if equivalent to
+    	the MacAddress textual convention of the SMIv2.";
     reference
-      "IEEE 802.3-2012, Clause 3.2.3";
+      "IEEE 802.3-2012, Clause 3.2.3
+    	 RFC 2579: Textual Conventions for SMIv2";
   }
 
   /*
    * Collection of IEEE 802 related identifier types
    */
-
-  typedef bridgeid {
-    type string {
-      pattern '[0-9a-fA-F]{4}(:[0-9a-fA-F]{2}){6}';
-    }
-    description
-      "The bridgeid type represents identifiers that uniquely
-      identify a bridge. Its first four hexadecimal digits contain a
-      priority value followed by a colon. The remaining characters
-      contain the MAC address used to refer to a bridge in a unique
-      fashion (typically, the numerically smallest MAC address of all
-      ports on the bridge). This type is in the value set and its
-      semantics equivalent to the BridgeId textual convention of the
-      SMIv2. However, since the BridgeId textual convention does not
-      prescribe a lexical representation, the appearance might be
-      different.";
-    reference
-      "TBD";
-  }
 
   typedef vlanid {
     type uint16 {


### PR DESCRIPTION
Changes made as a result of P802.1Qcp D1.0 and P802.1Xck D1.0 working
group comment resolution.

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ ls
README.txt                ieee802-dot1ax.yang        ieee802-dot1q-pb.tree    ieee802-dot1q-tpmr.yang   ieee802-dot1q-vlan-bridge.tree  ieee802-dot1x.yang
ieee802-dot1-bridge.tree  ieee802-dot1q-bridge.tree  ieee802-dot1q-pb.yang    ieee802-dot1q-types.tree  ieee802-dot1q-vlan-bridge.yang
ieee802-dot1ax.tree       ieee802-dot1q-bridge.yang  ieee802-dot1q-tpmr.tree  ieee802-dot1q-types.yang  ieee802-dot1x.tree
cl
mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ clear

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1ax.yang
pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-types.yang
pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-bridge.yang
pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-tpmr.yang
pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-vlan-bridge.yang
pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-pb.yang
ieee802-dot1ax.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1ax"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1x.yang
ieee802-dot1x.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1x"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-types.yang
ieee802-dot1q-types.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-types"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-bridge.yang
ieee802-dot1q-bridge.yang:1: warning: IETF rule (RFC 6087: 4.9): too many top-level data nodes: bridges, bridges-state
ieee802-dot1q-bridge.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-bridge"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-tpmr.yang
ieee802-dot1q-tpmr.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-tpmr"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-vlan-bridge.yang
ieee802-dot1q-vlan-bridge.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-vlan-bridge"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$ pyang --ietf -p $HOME/Documents/GitHub/yang/standard/ietf/RFC:$HOME/Documents/GitHub/yang/standard/ieee/draft ieee802-dot1q-pb.yang
ieee802-dot1q-pb.yang:3: warning: IETF rule (RFC 6087: 4.8): namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-pb"

mholness@ONW-MHOLNESS-01 MINGW64 ~/Documents/GitHub/yang/standard/ieee/802.1/draft (YangModels/master)
$
