### PR TITLE
Fix warning in ieee802-dot1q-sched.yang

### DIFF
--- a/experimental/ieee/802.1/ieee802-dot1q-lldp.yang
+++ b/experimental/ieee/802.1/ieee802-dot1q-lldp.yang
@@ -1,0 +1,2081 @@
+module ieee802-dot1q-lldp {
+  yang-version 1.1;
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-lldp";
+  prefix "lldp";
+
+  import ietf-yang-types { prefix "yang"; }
+  import ietf-interfaces { prefix "if"; }
+  import ieee802-types { prefix "ieee"; }
+
+  organization
+    "National Instruments";
+
+  contact
+    "Web URL: http://ni.com 
+    Rodney Cummings 
+    Rodney.Cummings@ni.com";
+
+  description
+    "This module provides for management of IEEE Std 802.1AB,
+    Station and Media Access Control Connectivity Discovery, also
+    known as the Link Layer Discovery Protocol (LLDP). This module
+    corresponds to the features of the LLDP Version 2 MIB.
+    
+    This experimental YANG module is an individual contribution, and
+    does not represent a formally sanctioned YANG module of IEEE.
+    Therefore, this YANG module will change in incompatible ways
+    from its current revision to the formally published YANG
+    module for IEEE Std 802.1AB-2016.";
+
+  revision 2017-01-01 {
+    description
+      "Module for IEEE Std 802.1AB-2016";
+    reference
+      "IEEE Std 802.1AB-2016";
+  }
+
+  feature lldp-rx {
+    description
+      "This LLDP agent supports receive (Rx) mode or
+      transmit/receive (TxRx) mode.
+      
+      Use of if-feature in this module specifies conformance
+      in a manner analogous to Table 11-1 of IEEE Std 802.1AB-2016
+      (MIB object groups and operating mode applicability) and the
+      corresponding conformance group in the MIB (11.5).";
+    reference
+      "IEEE Std 802.1AB-2016: 11.2, 11.5";
+  }
+  
+  feature lldp-tx {
+    description
+      "This LLDP agent supports transmit (Tx) mode or
+      transmit/receive (TxRx) mode.
+      
+      Use of if-feature in this module specifies conformance
+      in a manner analogous to Table 11-1 of IEEE Std 802.1AB-2016
+      (MIB object groups and operating mode applicability) and the
+      corresponding conformance group in the MIB (11.5).";
+    reference
+      "IEEE Std 802.1AB-2016: 11.2, 11.5";
+  }
+  
+  typedef chassis-id-subtype {
+    type enumeration {
+      enum chassisComponent {
+        value 1;
+        description
+          "This subtype represents a chassis identifier 
+          based on the value of entPhysicalAlias MIB object
+          (defined in IETF RFC 6933) for a chassis component
+          (i.e. an entPhysicalClass value of 'chassis(3)').
+          
+          This subtype is not directly applicable to YANG.
+          
+          TODO: For this subtype and other subtypes of the
+          Entity MIB, if an Entity YANG is developed in IETF, 
+          the preceding description can be replaced with a node
+          from that standard.";
+      }
+      enum interfaceAlias {
+        value 2;
+        description
+          "This subtype represents a chassis identifier 
+          based on the value of ifAlias MIB object (defined in
+          IETF RFC 2863) for an interface on the containing chassis.
+          
+          As specified in RFC 7223, the ifAlias MIB object may be
+          mapped to the YANG description for the interface.";
+      }
+      enum portComponent {
+        value 3;
+        description
+          "This subtype represents a chassis identifier 
+          based on the value of entPhysicalAlias object
+          (defined in IETF RFC 6933) for a port or backplane
+          component (i.e., entPhysicalClass value of 'port(10)' or
+          'backplane(4)'), within the containing chassis.
+          
+          This subtype is not directly applicable to YANG.";
+      }
+      enum macAddress {
+        value 4;
+        description
+          "This subtype represents a chassis identifier 
+          based on the value of a unicast source address
+          (encoded in network byte order and IEEE 802.3 canonical bit
+          order), of a port on the containing chassis as defined in
+          IEEE Std 802.";
+      }
+      enum networkAddress {
+        value 5;
+        description
+          "This subtype represents a chassis identifier 
+          based on a network address, associated with
+          a particular chassis. The encoded address is
+          composed of two fields. The first field is a single octet,
+          representing the IANA AddressFamilyNumbers value for the
+          specific address type, and the second field is the network
+          address value.";
+      }
+      enum interfaceName {
+        value 6;
+        description
+          "This subtype represents a port identifier 
+          based on the YANG interface name (defined in IETF RFC 7223) 
+          for an interface on the containing chassis. This name can
+          be used as a reference (i.e. interface-ref) to the interface
+          in other YANG modules.";
+      }
+      enum locallyAssigned {
+        value 7;
+        description
+          "This subtype represents a chassis identifier 
+          based on a locally defined value.";
+      }
+    }
+    description
+      "This is the subtype of a chassis identifier.";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5.2.2";
+  }
+
+  typedef chassis-id-type {
+    type binary {
+      length "1..255";
+    }
+    description
+      "This is the type for a chassis identifier string.
+      Leafs of this type are always used with an associated
+      leaf of type chassis-id-subtype, which identifies the 
+      format of the particular chassis identifier string.";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5.2.3";
+  }
+
+  typedef port-id-subtype {
+    type enumeration {
+      enum interfaceAlias {
+        value 1;
+        description
+          "This subtype represents a port identifier 
+          based on the ifAlias MIB object, defined in IETF
+          RFC 2863.
+          
+          As specified in RFC 7223, the ifAlias MIB object may be
+          mapped to the YANG description for the interface.";
+      }
+      enum portComponent {
+        value 2;
+        description
+          "This subtype represents a port identifier 
+          based on the value of entPhysicalAlias (defined in
+          IETF RFC 6933) for a port component (i.e., entPhysicalClass
+          value of 'port(10)'), within the containing chassis.
+          
+          This subtype is not directly applicable to YANG.";
+      }
+      enum macAddress {
+        value 3;
+        description
+          "This subtype represents a port identifier 
+          based on a unicast source address (encoded in network
+          byte order and IEEE 802.3 canonical bit order), which has
+          been detected by the agent and associated with a particular
+          port (IEEE Std 802).";
+      }
+      enum networkAddress {
+        value 4;
+        description
+          "This subtype represents a port identifier 
+          based on a network address, associated with
+          a particular port. The encoded address is
+          composed of two fields. The first field is a single octet,
+          representing the IANA AddressFamilyNumbers value for the
+          specific address type, and the second field is the network
+          address value.";
+      }
+      enum interfaceName {
+        value 5;
+        description
+          "This subtype represents a port identifier 
+          based on the YANG interface name (defined in IETF RFC 7223) 
+          for an interface on the containing chassis. This name can
+          be used as a reference (i.e. interface-ref) to the interface
+          in other YANG modules.";
+      }
+      enum agentCircuitId {
+        value 6;
+        description
+          "This subtype represents a port identifier 
+          based on the agent-local identifier of the circuit
+          (defined in IETF RFC 3046), detected by the agent 
+          and associated with a particular port.";
+      }
+      enum locallyAssigned {
+        value 7;
+        description
+          "This subtype represents a port identifier 
+          based on a locally defined value.";
+      }
+    }
+    description
+      "This is the subtype of a port identifier.";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5.3.2";
+  }
+
+  typedef port-id-type {
+    type binary {
+      length "1..255";
+    }
+    description
+      "This is the type for a port identifier string.
+      Leafs of this type are always used with an associated
+      leaf of type port-id-subtype, which identifies the 
+      format of the particular port identifier string.";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5.3.3";
+  }
+
+  typedef man-addr-if-subtype {
+    type enumeration {
+      enum unknown {
+        value 1;
+        description
+          "This subtype represents the case where the
+          interface is not known. In this case, the corresponding
+          interface number is of zero length.";
+      }
+      enum ifIndex {
+        value 2;
+        description
+          "This subtype represents an interface identifier
+          based on the ifIndex MIB object (defined in 
+          IETF RFC 2863). The ifIndex MIB object is provided
+          as if-index in YANG (see IETF RFC 7223).";
+      }
+      enum systemPortNumber {
+        value 7;
+        description
+          "This subtype represents an interface identifier 
+          based on the system port numbering convention.";
+      }
+    }
+    description
+      "This is the subtype of a management address 
+      interface number.";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5.9.5";
+  }
+
+  typedef man-addr-type {
+    type binary {
+      length "1..31";
+    }
+    description
+      "The value of a management address associated with the LLDP
+      agent that may be used to reach higher layer entities to
+      assist discovery by network management.
+      
+      It should be noted that appropriate security credentials,
+      may be required to access the LLDP agent using a management 
+      address. These necessary credentials should be known by 
+      the network management and the nodes associated with 
+      the credentials are not included in the LLDP agent.";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5.9.4";
+  }
+
+  typedef system-capabilities-map {
+    type bits {
+      bit other {
+        position 0;
+        description
+          "This bit indicates that the system has capabilities
+          other than those listed below.";
+      }
+      bit repeater {
+        position 1;
+        description
+          "This bit indicates that the system has repeater
+          capability.";
+      }
+      bit bridge {
+        position 2;
+        description
+          "This bit indicates that the system has bridge
+          capability.";
+      }
+      bit wlanAccessPoint {
+        position 3;
+        description
+          "This bit indicates that the system has
+          WLAN access point capability.";
+      }
+      bit router {
+        position 4;
+        description
+          "This bit indicates that the system has router
+          capability.";
+      }
+      bit telephone {
+        position 5;
+        description
+          "This bit indicates that the system has telephone
+          capability.";
+      }
+      bit docsisCableDevice {
+        position 6;
+        description
+          "This bit indicates that the system has
+          DOCSIS Cable Device capability (IETF RFC 4639 & 2670).";
+      }
+      bit stationOnly {
+        position 7;
+        description
+          "This bit indicates that the system has only
+          station capability and nothing else.";
+      }
+      bit cVLANComponent {
+        position 8;
+        description
+          "This bit indicates that the system has
+          C-VLAN component functionality.";
+      }
+      bit sVLANComponent {
+        position 9;
+        description
+          "This bit indicates that the system has
+          S-VLAN component functionality.";
+      }
+      bit twoPortMACRelay {
+        position 10;
+        description
+          "This bit indicates that the system has
+          Two-port MAC Relay (TPMR) functionality.";
+      }
+    }
+    description
+      "This describes system capabilities.";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5.8.1";
+  }
+
+  typedef dest-address-index-type {
+    type uint32 {
+      range "1..4096";
+    }
+    description
+      "An index value used as the key to the list of destination
+      MAC addresses used both as the destination addresses on
+      transmitted LLDPDUs and on received LLDPDUs. This index value
+      is also used as a secondary key in lists that use interface
+      as a primary key.";
+  }
+  
+  container configuration {
+    description
+      "LLDP Configuration group";
+    reference
+      "IEEE Std 802.1AB-2016: 10.5.1";
+    
+    leaf msg-tx-interval {
+      if-feature "lldp-tx";
+      type uint32;
+      units "second";
+      default "30";
+      description
+        "The interval at which LLDP frames are transmitted on
+        behalf of this LLDP agent.
+        
+        The default value is 30 seconds.
+        
+        The value of this leaf is used as the initial value of
+        port-config-list[].msg-tx-interval when the element
+        is created in port-config-list[].
+        
+        The leaf's value is restored from non-volatile
+        storage after a re-initialization of the management 
+        system.";
+      reference
+        "IEEE Std 802.1AB-2016: 9.2.5.7";
+    }
+    
+    leaf msg-tx-hold-multiplier {
+      if-feature "lldp-tx";
+      type uint32;
+      default "4";
+      description
+        "The time to live value expressed as a multiple of
+        msg-tx-interval. The actual time to live value used in 
+        LLDP frames, transmitted on behalf of this
+        LLDP agent, can be expressed by the following formula:
+        TTL = min(65535, (msg-tx-interval*msg-tx-hold-multiplier)+1)
+        For example, if the value of msg-tx-interval is
+        '30', and the value of msg-tx-hold-multiplier
+        is '4', then the value '121' is encoded in the
+        TTL field in the LLDP header.
+        
+        The default value is 4 seconds.
+        
+        The value of this leaf is used as the initial value of
+        port-config-list[].msg-tx-hold-multiplier when the 
+        element is created in port-config-list[].
+        
+        The leaf's value is restored from non-volatile
+        storage after a re-initialization of the management
+        system.";
+      reference
+        "IEEE Std 802.1AB-2016: 9.2.5.6";
+    }
+    
+    leaf reinit-delay {
+      if-feature "lldp-tx";
+      type uint32;
+      units "second";
+      default "2";
+      description
+        "The reinit-delay indicates the delay (in units of
+        seconds) from when port-config-list[].admin-status of a
+        particular port becomes disabled until re-initialization
+        is attempted.
+         
+        The default value is 2 seconds.
+        
+        The value of this leaf is used as the initial value of
+        port-config-list[].reinit-delay when the element
+        is created in port-config-list[].
+        
+        The leaf's value is restored from non-volatile
+        storage after a re-initialization of the management
+        system.";
+      reference
+        "IEEE Std 802.1AB-2016: 9.2.5.10";
+    }
+    
+    leaf notification-interval {
+      if-feature "lldp-rx";
+      type uint32;
+      units "second";
+      default "30";
+      description
+        "The notification-interval controls the interval between 
+        transmission of LLDP notifications during normal
+        transmission periods.
+
+        The default value is 30 seconds.
+        
+        The value of this leaf is used as the initial value of
+        port-config-list[].notification-interval when the
+        element is created in port-config-list[].
+        
+        The leaf's value is restored from non-volatile
+        storage after a re-initialization of the management
+        system.";
+    }
+    
+    leaf tx-credit-max {
+      if-feature "lldp-tx";
+      type uint32;
+      units "PDUs";
+      default "5";
+      description
+        "The maximum number of consecutive LLDPDUs that can be
+        transmitted at any time.
+        
+        The default value is 5 PDUs.
+        
+        The value of this leaf is used as the initial value of
+        port-config-list[].tx-credit-max when the
+        element is created in port-config-list[].
+        
+        The leaf's value is restored from non-volatile
+        storage after a re-initialization of the management
+        system.";
+      reference
+        "IEEE Std 802.1AB-2016: 9.2.5.17";
+    }
+    
+    leaf message-fast-tx {
+      if-feature "lldp-tx";
+      type uint32;
+      units "second";
+      default "1";
+      description
+        "The interval at which LLDP frames are transmitted on
+        behalf of this LLDP agent during fast transmission period
+        (e.g., when a new neighbor is detected).
+         
+        The default value is 1 second.
+        
+        The value of this leaf is used as the initial value of
+        port-config-list[].message-fast-tx when the element
+        is created in port-config-list[].
+        
+        The leaf's value is restored from non-volatile
+        storage after a re-initialization of the management
+        system.";
+      reference
+        "IEEE Std 802.1AB-2016: 9.2.5.5";
+    }
+    
+    leaf tx-fast-init {
+      if-feature "lldp-tx";
+      type uint32;
+      default "4";
+      description
+        "The value used to initialize the txFast variable
+        which determines the number of transmissions that are
+        made in fast transmission mode.
+          
+        The default value is 4.
+        
+        The value of this leaf is used as the initial value of
+        port-config-list[].tx-fast-init when the element
+        is created in port-config-list[].
+        
+        The leaf's value is restored from non-volatile
+        storage after a re-initialization of the management
+        system.";
+      reference
+        "IEEE Std 802.1AB-2016: 9.2.5.19";
+    }
+    
+    list port-config-list {
+      key "interface dest-address-index";
+      description
+        "This list contains LLDP configuration keyed on a 
+        per port, per destination address basis. The interface
+        (YANG interface-ref), coupled with a key to the 
+        dest-address-list, are used as keys to the list.
+        
+        These configuration parameters control the transmission and
+        the reception of LLDP frames on those interface/address
+        combinations whose elements are created in this list.
+        Elements in this list can only be created for MAC addresses
+        that can validly be used in association with the type of
+        interface concerned, as defined by Table 7-2.
+        The contents of this list is persistent across
+        re-initializations or re-boots.";
+      
+      leaf interface {
+        type if:interface-ref;
+        description
+          "Reference to the interface for this port's information.
+          The reference consists of an interface name as specified
+          by RFC 7223 (ietf-interfaces.yang).
+          
+          The interface-ref is used as a key to
+          port-config-list";
+      }
+      
+      leaf dest-address-index {
+        type dest-address-index-type;
+        description
+          "The key (index) value used to identify the destination
+          MAC address associated with this element in
+          port-config-list. Its value identifies
+          the element in the dest-address-list where the MAC address
+          can be found.";
+      }
+      
+      leaf admin-status {
+        if-feature "lldp-rx or lldp-tx";
+        type enumeration {
+          enum txOnly {
+            value 1;
+            description
+              "Transmit only";
+          }
+          enum rxOnly {
+            value 2;
+            description
+              "Receive only";
+          }
+          enum txAndRx {
+            value 3;
+            description
+              "Transmit and receive";
+          }
+          enum disabled {
+            value 4;
+            description
+              "Disabled";
+          }
+        }
+        description
+          "The administratively desired status of the 
+          local LLDP agent.
+          
+          If admin-status is set to a value of 'txOnly(1)', 
+          then LLDP agent transmits LLDP frames on this port 
+          and it does not store any information about the 
+          remote systems connected.
+          
+          If admin-status is set to a value of 'rxOnly(2)', 
+          then the LLDP agent receives, but it does not transmit, 
+          LLDP frames on this port.
+          
+          If admin-status is set to a value of 'txAndRx(3)', 
+          then the LLDP agent transmits and receives LLDP frames 
+          on this port.
+          
+          If admin-status is set to a value of 'disabled(4)', 
+          then LLDP agent does not transmit or receive 
+          LLDP frames on this port. If there is
+          remote systems information that is received on this port
+          and stored, before the port's admin-status becomes 
+          disabled, then that information is deleted.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.1";
+      }
+      
+      leaf msg-tx-interval {
+        if-feature "lldp-tx";
+        type uint32;
+        units "second";
+        description
+          "The interval at which LLDP frames are transmitted on
+          behalf of this LLDP agent.
+          
+          This leaf takes its initial value from
+          configuration.msg-tx-interval (chassis value) when
+          this port's element is created in port-config-list.
+          
+          The leaf's value is restored from non-volatile
+          storage after a re-initialization of the management 
+          system.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.7";
+      }
+      
+      leaf msg-tx-hold-multiplier {
+        if-feature "lldp-tx";
+        type uint32;
+        description
+          "The time to live value expressed as a multiple of
+          msg-tx-interval. The actual time to live value used in 
+          LLDP frames, transmitted on behalf of this
+          LLDP agent, can be expressed by the following formula:
+          TTL = min(65535, (msg-tx-interval*msg-tx-hold-multiplier)+1)
+          For example, if the value of msg-tx-interval is
+          '30', and the value of msg-tx-hold-multiplier
+          is '4', then the value '121' is encoded in the
+          TTL field in the LLDP header.
+          
+          This leaf takes its initial value from
+          configuration.msg-tx-hold-multiplier (chassis value) when
+          this port's element is created in port-config-list.
+                    
+          The leaf's value is restored from non-volatile
+          storage after a re-initialization of the management
+          system.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.6";
+      }
+      
+      leaf reinit-delay {
+        if-feature "lldp-tx";
+        type uint32;
+        units "second";
+         description
+          "The reinit-delay indicates the delay (in units of
+          seconds) from when port-config-list[].admin-status of a
+          particular port becomes disabled until re-initialization
+          is attempted.
+           
+          This leaf takes its initial value from
+          configuration.reinit-delay (chassis value) when
+          this port's element is created in port-config-list.
+          
+          The leaf's value is restored from non-volatile
+          storage after a re-initialization of the management
+          system.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.10";
+      }
+      
+      leaf notification-interval {
+        if-feature "lldp-tx";
+        type uint32;
+        units "second";
+        description
+          "The notification-interval controls the interval between 
+          transmission of LLDP notifications during normal
+          transmission periods.
+
+          This leaf takes its initial value from
+          configuration.notification-interval (chassis value) when
+          this port's element is created in port-config-list.
+          
+          The leaf's value is restored from non-volatile
+          storage after a re-initialization of the management
+          system.";
+      }
+      
+      leaf tx-credit-max {
+        if-feature "lldp-tx";
+        type uint32;
+        units "PDUs";
+        description
+          "The maximum number of consecutive LLDPDUs that can be
+          transmitted at any time.
+          
+          This leaf takes its initial value from
+          configuration.tx-credit-max (chassis value) when
+          this port's element is created in port-config-list.
+          
+          The leaf's value is restored from non-volatile
+          storage after a re-initialization of the management
+          system.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.17";
+      }
+      
+      leaf message-fast-tx {
+        if-feature "lldp-tx";
+        type uint32;
+        units "second";
+        description
+          "The interval at which LLDP frames are transmitted on
+          behalf of this LLDP agent during fast transmission period
+          (e.g., when a new neighbor is detected).
+           
+          This leaf takes its initial value from
+          configuration.message-fast-tx (chassis value) when
+          this port's element is created in port-config-list.
+          
+          The leaf's value is restored from non-volatile
+          storage after a re-initialization of the management
+          system.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.5";
+      }
+      
+      leaf tx-fast-init {
+        if-feature "lldp-tx";
+        type uint32;
+        description
+          "The value used to initialize the txFast variable
+          which determines the number of transmissions that are
+          made in fast transmission mode.
+            
+          This leaf takes its initial value from
+          configuration.tx-fast-init (chassis value) when
+          this port's element is created in port-config-list.
+          
+          The leaf's value is restored from non-volatile
+          storage after a re-initialization of the management
+          system.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.19";
+      }
+      
+      leaf notification-enable {
+        if-feature "lldp-rx";
+        type boolean;
+        default "false";
+        description
+          "The notification-enable leaf controls, on a per
+          agent basis, whether or not notifications from the agent
+          are enabled. The value true means that notifications are
+          enabled; the value false means that they are not.";
+      }
+      
+      leaf tlvs-tx-enable {
+        if-feature "lldp-tx";
+        type bits {
+          bit portDesc {
+            position 0;
+            description
+              "Port Description TLV";
+          }
+          bit sysName {
+            position 1;
+            description
+              "System Name TLV. 
+              This bit indicates that the system has repeater
+              capability.";
+          }
+          bit sysDesc {
+            position 2;
+            description
+              "System Description TLV";
+          }
+          bit sysCap {
+            position 3;
+            description
+              "System Capabilities TLV";
+          }
+        }
+        default "";
+        description
+          "The tlvs-tx-enable, defined as a bitmap,
+          includes the basic set of LLDP TLVs whose transmission is
+          allowed on the local LLDP agent by the network management.
+          Each bit in the bitmap corresponds to a TLV type associated
+          with a specific optional TLV.
+          
+          It should be noted that the organizationally-specific TLVs
+          are excluded from the tlvs-tx-enable bitmap.
+          LLDP Organization Specific Information Extension YANGs 
+          should have similar configuration nodes to control 
+          transmission of their organizationally defined TLVs.
+          
+          The bit 'portDesc(0)' indicates that LLDP agent should
+          transmit 'Port Description TLV'.
+          
+          The bit 'sysName(1)' indicates that LLDP agent should 
+          transmit 'System Name TLV'.
+          
+          The bit 'sysDesc(2)' indicates that LLDP agent should 
+          transmit 'System Description TLV'.
+          
+          The bit 'sysCap(3)' indicates that LLDP agent should 
+          transmit 'System Capabilities TLV'.
+          
+          There is no bit reserved for the management address TLV
+          type since transmission of management address TLVs are 
+          controlled by another list, man-addr-config-tx-port-list.
+          
+          The default value for tlvs-tx-enable is
+          empty set, which means no transmit of the specified
+          optional TLVs.
+          
+          The leaf's value is restored from non-volatile
+          storage after a re-initialization of the management
+          system.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.1.2.1";
+      }
+    }
+    
+    list dest-address-list {
+      key "dest-address-index";
+      description
+        "The list that contains the set of MAC addresses used
+        by LLDP for transmission and reception of LLDPDUs.
+        
+        Elements in this list are created as necessary, to support
+        MAC addresses needed by other list in this YANG that
+        are keyed by MAC address.
+        
+        A given element in this list cannot be deleted if the MAC
+        address list key value is in use in any other list
+        in the YANG.
+        
+        The contents of this list are persistent across
+        re-initializations or re-boots.";   
+      
+      leaf dest-address-index {
+        type dest-address-index-type;
+        description
+          "Key (index) to the list of destination MAC addresses.";
+      }
+      
+      leaf dest-mac-address {
+        type ieee:mac-address;
+        description
+          "The MAC address associated with this element.
+          
+          The octet string identifies an individual or a group
+          MAC address that is in use by LLDP as a destination
+          MAC address.
+          
+          The MAC address is encoded in the octet string in
+          canonical format (see IEEE Std 802).";
+      }
+    }
+
+    list man-addr-config-tx-port-list {
+      key "interface dest-address-index loc-man-addr-subtype loc-man-addr";
+      description
+        "This list controls selection of LLDP management address
+        TLV instances to be transmitted on individual port/
+        destination address pairs.
+        
+        Each active man-addr-config-tx-port-list element is
+        restored from non-volatile storage and re-created
+        after a re-initialization of the management system.";   
+
+      leaf interface {
+        type if:interface-ref;
+        description
+          "Reference to the interface for this port's information.
+          The reference consists of an interface name as specified
+          by RFC 7223 (ietf-interfaces.yang).
+          
+          The interface-ref is used as a key to
+          man-addr-config-tx-port-list";
+      }
+      
+      leaf dest-address-index {
+        type dest-address-index-type;
+        description
+          "The key (index) value used to identify the destination
+          MAC address associated with this element in
+          man-addr-config-tx-port-list. Its value identifies
+          the element in the dest-address-list where the MAC address
+          can be found.";
+      }
+      
+      leaf loc-man-addr-subtype {
+        type uint8;
+        description
+          "The type of management address identifier encoding used in
+          the associated loc-man-addr node.
+          
+          The enumeration for this leaf is contained in the
+          IANA Address Family Numbers registry of the IETF RFC 3232 
+          on-line database that is accessible through a
+          web page (http://www.iana.org).
+          
+          TODO: For this subtype of the
+          IANA-ADDRESS-FAMILY-NUMBERS-MIB, if a corresponding
+          YANG is developed in IETF 
+          (e.g. draft-ietf-netmod-iana-afn-safi),
+          the preceding description can be replaced with a node
+          from that standard. This applies to 
+          rem-man-addr-subtype as well.
+          
+          The loc-man-addr-subtype is used as a key to
+          man-addr-config-tx-port-list
+          
+          It should be noted that only a subset of the possible
+          address encodings enumerated in IANA Address Family Numbers
+          are appropriate for use as a LLDP management
+          address, either because some are just not applicable or
+          because the maximum size of a loc-man-addr octet string
+          would prevent the use of some address identifier 
+          encodings.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.9.3";
+      }
+      
+      leaf loc-man-addr {
+        type man-addr-type;
+        description
+          "The string value used to identify the management address
+          component associated with the local system. The purpose of
+          this address is to contact the management entity.
+          
+          The loc-man-addr is used as a key to
+          man-addr-config-tx-port-list.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.9.4";
+      }
+      
+      leaf tx-enable {
+        if-feature "lldp-tx";
+        type boolean;
+        default "false";
+        description
+          "A boolean controlling the transmission of system
+          management address instance for the specified port,
+          destination, subtype, and man address used to key
+          this list. If set to the default value of false,
+          no transmission occurs. If set to true, the
+          appropriate information is transmitted out of the
+          port specified in the element's key.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.1.2.1";
+      }
+    }
+  }
+  
+  container statistics {
+    description
+      "LLDP Statistics group";
+    reference
+      "IEEE Std 802.1AB-2016: 10.5.2";
+    
+    leaf rem-lists-last-change-time {
+      if-feature "lldp-rx";
+      type yang:timestamp;
+      description
+        "The value of 'sysUpTime' at the time an element is 
+        created, modified, or deleted in the remote-systems lists,
+        and all LLDP extension nodes associated with remote 
+        systems.
+        
+        The 'sysUpTime' is defined as the time (in hundredths 
+        of a second) since the network management server was last
+        re-initialized. Using the YANG module of 
+        RFC 7317 (ietf-system), 'sysUpTime' is 
+        system-state.clock.current-datetime minus
+        system-state.clock.boot-datetime, converted to hundredths
+        of a second.
+        
+        TODO: If the protocol-independent objects of 
+        RFC 3418 (SNMPv2-MIB) are developed as YANG by IETF, the
+        the preceding description of 'sysUpTime' can be replaced 
+        with a node from that standard.
+        
+        An management client can use this leaf to reduce 
+        polling of the remote-systems lists.";
+    }
+    
+    leaf rem-lists-inserts {
+      if-feature "lldp-rx";
+      type yang:zero-based-counter32;
+      units "list elements";
+      description
+        "The number of times the complete set of information
+        advertised by a particular MSAP has been inserted into lists
+        contained in remote-systems.
+        
+        The complete set of information received from a particular
+        MSAP should be inserted into related lists. If partial
+        information cannot be inserted for a reason such as lack
+        of resources, all of the complete set of information should
+        be removed.
+        
+        This counter should be incremented only once after the
+        complete set of information is successfully recorded
+        in all related lists. Any failures during inserting
+        information set that result in deletion of previously
+        inserted information should not trigger any changes in
+        rem-lists-inserts since the insert is not completed
+        yet or in rem-lists-deletes since the deletion
+        would only be a partial deletion. If the failure was the
+        result of lack of resources, the rem-lists-drops
+        counter should be incremented once.";
+    }
+    
+    leaf rem-lists-deletes {
+      if-feature "lldp-rx";
+      type yang:zero-based-counter32;
+      units "list elements";
+      description
+        "The number of times the complete set of information
+        advertised by a particular MSAP has been deleted from
+        lists contained in remote-systems.
+        
+        This counter should be incremented only once when the
+        complete set of information is completely deleted from all
+        related lists. Partial deletions, such as deletion of
+        elements associated with a particular MSAP from some lists,
+        but not from all lists are not allowed, thus should not
+        change the value of this counter.";
+    }
+    
+    leaf rem-lists-drops {
+      if-feature "lldp-rx";
+      type yang:zero-based-counter32;
+      units "list elements";
+      description
+        "The number of times the complete set of information
+        advertised by a particular MSAP could not be entered into
+        lists contained in remote-systems because of 
+        insufficient resources.";
+    }
+
+    leaf rem-lists-ageouts {
+      if-feature "lldp-rx";
+      type yang:zero-based-counter32;
+      units "list elements";
+      description
+        "The number of times the complete set of information
+        advertised by a particular MSAP has been deleted from lists
+        contained in remote-systems because the information 
+        timeliness interval has expired.
+        
+        This counter should be incremented only once when the complete
+        set of information is completely invalidated (aged out)
+        from all related lists. Partial ageing, similar to deletion
+        case, is not allowed, and thus, should not change the value
+        of this counter.";
+    }
+
+    list tx-port-list {
+      key "interface dest-address-index";
+      description
+        "A list containing LLDP transmission statistics for
+        individual port/destination address combinations.
+        The port is contained in the same chassis as the
+        local LLDP agent.
+        
+        Entries are not required to exist in
+        this list while the corresponding 
+        configuration.port-config-list[].adminStatus
+        is equal to 'disabled(4)'.
+        
+        All counter values in a particular element shall be
+        maintained on a continuing basis and shall not be deleted
+        upon expiration of rxInfoTTL timing counters in the 
+        corresponding remote-systems element, or the receipt 
+        of a shutdown frame from a remote LLDP agent.
+        
+        All statistical counters associated with a particular
+        port on the local LLDP agent become frozen whenever the
+        adminStatus is disabled for the same port.
+        
+        Elements in this list can only be created for MAC addresses
+        that can validly be used in association with the type of
+        interface concerned, as defined by Table 7-2.";   
+      reference
+        "IEEE Std 802.1AB-2016: 7.1, 9.2.2.1, 9.2.6";
+
+      leaf interface {
+        type if:interface-ref;
+        description
+          "Reference to the interface for this port's information.
+          The reference consists of an interface name as specified
+          by RFC 7223 (ietf-interfaces.yang).
+          
+          The interface-ref is used as a key to
+          tx-port-list.";
+      }
+      
+      leaf dest-address-index {
+        type dest-address-index-type;
+        description
+          "The key (index) value used to identify the destination
+          MAC address associated with this element in
+          tx-port-list. Its value identifies
+          the element in the dest-address-list where the MAC address
+          can be found.";
+      }
+      
+      leaf frames-out-total {
+        if-feature "lldp-tx";
+        type yang:counter32;
+        units "LLDP frames";
+        description
+          "The number of LLDP frames transmitted by this LLDP agent
+          on the indicated port to the destination MAC address
+          associated with this element of the list.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.6.5";
+      }
+
+      leaf lldpdu-length-errors {
+        if-feature "lldp-tx";
+        type yang:counter32;
+        units "LLDP frames";
+        description
+          "The number of LLDPDU Length Errors recorded for 
+          the port.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.6.8";
+      }
+    }
+    
+    list rx-port-list {
+      key "interface dest-address-index";
+      description
+        "A list containing LLDP reception statistics for
+        individual port/destination address combinations.
+        The port is contained in the same chassis as the
+        local LLDP agent.
+        
+        Entries are not required to exist in
+        this list while the corresponding 
+        configuration.port-config-list[].adminStatus
+        is equal to 'disabled(4)'.
+        
+        All counter values in a particular element shall be
+        maintained on a continuing basis and shall not be deleted
+        upon expiration of rxInfoTTL timing counters in the 
+        corresponding remote-systems element, or the receipt 
+        of a shutdown frame from a remote LLDP agent.
+        
+        All statistical counters associated with a particular
+        port on the local LLDP agent become frozen whenever the
+        adminStatus is disabled for the same port.
+        
+        Elements in this list can only be created for MAC addresses
+        that can validly be used in association with the type of
+        interface concerned, as defined by Table 7-2.
+        
+        The contents of this list is persistent across
+        re-initializations or re-boots.";   
+      reference
+        "IEEE Std 802.1AB-2016: 7.1, 9.2.2.1, 9.2.6";
+
+      leaf interface {
+        type if:interface-ref;
+        description
+          "Reference to the interface for this port's information.
+          The reference consists of an interface name as specified
+          by RFC 7223 (ietf-interfaces.yang).
+          
+          The interface-ref is used as a key to
+          rx-port-list.";
+      }
+      
+      leaf dest-address-index {
+        type dest-address-index-type;
+        description
+          "The key (index) value used to identify the destination
+          MAC address associated with this element in
+          rx-port-list. Its value identifies
+          the element in the dest-address-list where the MAC address
+          can be found.";
+      }
+      
+      leaf frames-discarded-total {
+        if-feature "lldp-rx";
+        type yang:counter32;
+        units "LLDP frames";
+        description
+          "The number of LLDP frames received by this LLDP agent on
+          the indicated port, and then discarded for any reason.
+          This counter can provide an indication that LLDP header
+          formatting problems may exist with the local LLDP agent in
+          the sending system or that LLDPDU validation problems may
+          exist with the local LLDP agent in the receiving system.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.6.2";
+      }
+      
+      leaf frames-in-errors-total {
+        if-feature "lldp-rx";
+        type yang:counter32;
+        units "LLDP frames";
+        description
+          "The number of invalid LLDP frames received by this LLDP
+          agent on the indicated port, while this LLDP agent is 
+          enabled.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.6.3";
+      }
+
+      leaf frames-in-total {
+        if-feature "lldp-rx";
+        type yang:counter32;
+        units "LLDP frames";
+        description
+          "The number of valid LLDP frames received by this 
+          LLDP agent on the indicated port, while this LLDP agent 
+          is enabled.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.6.4";
+      }
+
+      leaf tlvs-discarded-total {
+        if-feature "lldp-rx";
+        type yang:counter32;
+        units "TLVs";
+        description
+          "The number of LLDP TLVs discarded for any reason 
+          by this LLDP agent on the indicated port.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.6.6";
+      }
+
+      leaf tlvs-unrecognized-total {
+        if-feature "lldp-rx";
+        type yang:counter32;
+        units "TLVs";
+        description
+          "The number of LLDP TLVs received on the given port that
+          are not recognized by this LLDP agent on the indicated 
+          port. An unrecognized TLV is referred to as the TLV 
+          whose type value is in the range of reserved TLV 
+          types (000 1001 - 111 1110) in Table 8-1 of 
+          IEEE Std 802.1AB-2016. An unrecognized TLV may be 
+          a basic management TLV from a later LLDP version.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.4.1, 9.2.6.7";
+      }
+
+      leaf ageouts-total {
+        if-feature "lldp-rx";
+        type yang:zero-based-counter32;
+        description
+          "The counter that represents the number of age-outs that
+          occurred on a given port. An age-out is the number of
+          times the complete set of information advertised by a
+          particular MSAP has been deleted from lists contained in
+          remote-systems because the information timeliness interval 
+          has expired.
+          
+          This counter is similar to rem-lists-ageouts, except
+          that the counter is on a per port basis. This enables 
+          the management client to poll lists associated with the 
+          remote-systems on the indicated port only.
+          
+          This counter is set to zero during agent initialization
+          and its value should not be saved in non-volatile storage.
+          
+          This counter is incremented only once when the
+          complete set of information is invalidated (aged out) from
+          all related lists on a particular port. Partial aging
+          is not allowed.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.6.1";
+      }
+    }
+  }   
+
+  container local-system {
+    description
+      "LLDP Local System Data group";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5, 10.5.3";
+    
+    leaf chassis-id-subtype {
+      if-feature "lldp-tx";
+      type chassis-id-subtype;
+      description
+        "The type of chassis identifier encoding used in the 
+        associated chassis-id in the local system.";
+      reference
+        "IEEE Std 802.1AB-2016: 8.5.2.2";
+    }
+    
+    leaf chassis-id {
+      if-feature "lldp-tx";
+      type chassis-id-type;
+      description
+        "The string value used to identify the chassis component
+        associated with the local system.";
+      reference
+        "IEEE Std 802.1AB-2016: 8.5.2.3";
+    }
+    
+    leaf sys-name {
+      if-feature "lldp-tx";
+      type string {
+        length "0..255";
+      }
+      description
+        "The string value used to identify the system name of the
+        local system.";
+      reference
+        "IEEE Std 802.1AB-2016: 8.5.6.2";
+    }
+    
+    leaf sys-desc {
+      if-feature "lldp-tx";
+      type string {
+        length "0..255";
+      }
+      description
+        "The string value used to identify the system description
+        of the local system.";
+      reference
+        "IEEE Std 802.1AB-2016: 8.5.7.2";
+    }
+    
+    leaf sys-cap-supported {
+      if-feature "lldp-tx";
+      type system-capabilities-map;
+      description
+        "The bitmap value used to identify which system capabilities
+        are supported on the local system.";
+      reference
+        "IEEE Std 802.1AB-2016: 8.5.8.1";
+    }
+    
+    leaf sys-cap-enabled {
+      if-feature "lldp-tx";
+      type system-capabilities-map;
+      description
+        "The bitmap value used to identify which system capabilities
+        are enabled on the local system.";
+      reference
+        "IEEE Std 802.1AB-2016: 8.5.8.2";
+    }
+    
+    list port-list {
+      key "interface";
+      description
+        "This list contains one element per port of information
+        associated with the local system known to this agent.
+        
+        Elements may be created and deleted in this list by the
+        agent.
+        
+        Elements in this list can only be created for MAC addresses
+        that can validly be used in association with the type of
+        interface concerned, as defined by Table 7-2.
+        
+        The contents of this list is persistent across
+        re-initializations or re-boots.";   
+      
+      leaf interface {
+        type if:interface-ref;
+        description
+          "Reference to the interface for this port's information.
+          The reference consists of an interface name as specified
+          by RFC 7223 (ietf-interfaces.yang).
+          
+          The interface-ref is used as a key to
+          port-list.";
+      }
+      
+      leaf port-id-subtype {
+        if-feature "lldp-tx";
+        type port-id-subtype;
+        description
+          "The type of port identifier encoding used in the 
+          associated port-id inthe local system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.3.2";
+      }
+      
+      leaf port-id {
+        if-feature "lldp-tx";
+        type port-id-type;
+        description
+          "The string value used to identify the port component
+          associated with this port in the local system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.3.3";
+      }
+      
+      leaf port-desc {
+        if-feature "lldp-tx";
+        type string {
+          length "0..255";
+        }
+        description
+          "The string value used to identify the 
+          IEEE 802 LAN station's port description 
+          associated with the local system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.5.2";
+      }  
+    }
+    
+    list man-addr-list {
+      key "loc-man-addr-subtype loc-man-addr";
+      description
+        "This list contains management address information on the
+        local system known to this agent.
+        
+        There may be multiple management addresses
+        configured on the system identified by a particular
+        chassis-id. Each management address should have
+        distinct loc-man-addr-subtype and loc-man-addr.
+        
+        Entries may be created and deleted in this list by the
+        agent.";   
+
+      leaf loc-man-addr-subtype {
+        type uint8;
+        description
+          "The type of management address identifier encoding used in
+          the associated loc-man-addr node.
+          
+          The enumeration for this leaf is contained in the
+          IANA Address Family Numbers registry of the IETF RFC 3232 
+          on-line database that is accessible through a
+          web page (http://www.iana.org).
+          
+          The loc-man-addr-subtype is used as a key to
+          man-addr-list.
+          
+          It should be noted that only a subset of the possible
+          address encodings enumerated in IANA Address Family Numbers
+          are appropriate for use as a LLDP management
+          address, either because some are just not applicable or
+          because the maximum size of a loc-man-addr octet string
+          would prevent the use of some address identifier 
+          encodings.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.9.3";
+      }
+      
+      leaf loc-man-addr {
+        type man-addr-type;
+        description
+          "The string value used to identify the management address
+          component associated with the local system. The purpose of
+          this address is to contact the management entity.
+          
+          The loc-man-addr is used as a key to
+          man-addr-list.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.9.4";
+      }
+      
+      leaf loc-man-addr-len {
+        if-feature "lldp-tx";
+        type uint32;
+        description
+          "The total length of the management address subtype and the
+          management address fields in LLDPDUs transmitted by the
+          local LLDP agent.
+          
+          The management address length field is needed so that the
+          receiving systems that do not implement a network 
+          management protocol are not required to implement 
+          an Internet Assigned Numbers Authority (IANA) 
+          family numbers/address length equivalency
+          table in order to decode the management address.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.9.2";
+      }
+      
+      leaf loc-man-addr-if-subtype {
+        if-feature "lldp-tx";
+        type man-addr-if-subtype;
+        description
+          "The enumeration value that identifies the interface numbering
+          method used for defining the interface number
+          (loc-man-addr-if-id), associated with the local system.
+          
+          TODO: The OID is not directly useful for YANG, and the
+          ifIndex no longer serves as a reference for YANG. When the
+          802.1 working group enhances 802.1AB for YANG, it may make
+          sense to specify a new man-addr-if-subtype in 8.5.9.5:
+            4) interface-ref
+          and re-use the object identifier (8.5.9.8) to carry the
+          contents of interface-ref (interface name). This applies to
+          rem-man-addr-if-subtype as well.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.9.5";
+      }
+      
+      leaf loc-man-addr-if-id {
+        if-feature "lldp-tx";
+        type uint32;
+        description
+          "The integer value used to identify the interface number
+          regarding the management address component associated with
+          the local system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.9.6";
+      }
+      
+      leaf loc-man-addr-if-oid {
+        if-feature "lldp-tx";
+        type yang:object-identifier-128;
+        description
+          "The OID value used to identify the type of hardware component
+          or protocol entity associated with the management address
+          advertised by the local system agent.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.9.8";
+      }    
+    }
+  }   
+
+  container remote-systems {
+    description
+      "LLDP Remote Systems Data group";
+    reference
+      "IEEE Std 802.1AB-2016: 8.5, 10.5.3";
+    
+    list system-list {
+      key "time-mark interface dest-address-index index";
+      description
+        "This list contains one or more elements per physical network
+        connection known to this agent. The agent may wish to ensure
+        that only one element is present for each local port
+        and destination MAC address, or it may choose to maintain 
+        multiple elements for the same local port and 
+        destination MAC address.
+        
+        Elements may be created and deleted in this list by 
+        the agent, if a physical topology discovery process is
+        active.
+        
+        Elements in this list can only be created for MAC addresses
+        that can validly be used in association with the type of
+        interface concerned, as defined by Table 7-2.
+        
+        The contents of this list is persistent across
+        re-initializations or re-boots.
+        
+        The following procedure may be used to retrieve remote
+        systems information updates from an LLDP agent:
+        
+        1. Management client polls all lists associated with 
+        remote systems and keeps a local copy of the information 
+        retrieved. Management client polls periodically the 
+        values of the following leafs:
+          a. statistics.rem-lists-inserts
+          b. statistics.rem-lists-deletes
+          c. statistics.rem-lists-drops
+          d. statistics.rem-lists-ageouts
+          e. statistics.rx-port-list[].ageouts-total, for all ports
+        
+        2. LLDP agent updates remote-systems lists, and
+        sends out notifications to a list of notification
+        destinations.
+        
+        3. Management client receives the notifications and 
+        compares the new values of leafs listed in step 1.
+        
+        Periodically, management client should poll the leaf
+        statistics.rem-lists-last-change-time to find out if 
+        anything has changed since the last poll. If something has
+        changed, management client polls the leafs listed in 
+        step 1 to figure out what kind of changes occurred 
+        in the lists.
+        
+        If statistics.rem-lists-inserts has changed,
+        then the management client walks all lists by employing 
+        a time-mark with the last-polled time value. This request
+        returns new leafs or leafs whose values have been
+        updated since the last poll.
+        
+        If statistics.rem-lists-ageouts has changed,
+        then the management client walks the 
+        rx-port-list[].ageouts-total and compares the new values 
+        with previously recorded ones. For ports whose 
+        rx-port-list[].ageouts-total value is greater than the 
+        recorded value, the management client can
+        retrieve leafs associated with those ports from
+        list(s) without employing a time-mark (i.e. time-mark zero).
+        
+        statistics.rem-lists-deletes and statistics.rem-lists-drops
+        are provided for informational purposes.";   
+
+      leaf time-mark {
+        type yang:timeticks;
+        description
+          "A TimeFilter for this list, used to return all changes since
+          a specified time. 
+          
+          The specifications for the TimeFilter are in IETF RFC 4502, in its
+          TimeFilter textual convention, and in its 'Appendix - TimeFilter
+          Implementation Notes'). Since RFC 4502 is written for SNMP and MIB,
+          in order to understand the specifications for YANG, perform the
+          following substitutions in your mind when reading RFC 4502:
+          - Replace 'MIB' with 'YANG'.
+          - Replace 'textual convention' with 'data type'.
+          - Replace 'table' with 'list'.
+          - Replace 'index' with 'key'.
+          - Replace 'row' with 'element of the list'.
+          - Replace 'column' with 'leaf in the element'.
+          
+          Implementations of TimeFilter for this YANG module shall 
+          provide only one pass through a time-filtered
+          list for each 'get' operation (i.e. do not use the
+          'traditional' methodology).
+          
+          TODO: The preceding description clearly is not ideal.
+          If no IETF project has addressed 'YANG-ification' of
+          TimeFilter when this YANG module is standardized,
+          this YANG module will specify such a typedef.";
+      }
+      
+      leaf interface {
+        type if:interface-ref;
+        description
+          "Reference to the interface for this port's information.
+          The reference consists of an interface name as specified
+          by RFC 7223 (ietf-interfaces.yang).
+          
+          The interface-ref is used as a key to
+          system-list.";
+      }
+      
+      leaf dest-address-index {
+        type dest-address-index-type;
+        description
+          "The key (index) value used to identify the destination
+          MAC address associated with this element in
+          system-list. Its value identifies
+          the element in the dest-address-list where the MAC address
+          can be found.";
+      }
+      
+      leaf index {
+        type uint32;
+        description
+          "This leaf represents an arbitrary local integer value used
+          by this agent to identify a particular connection instance,
+          unique only for the indicated remote system.
+          
+          An agent is encouraged to assign monotonically increasing
+          index values to new entries, starting with one, after each
+          reboot. It is considered unlikely that this index
+          can wrap between reboots.  
+          
+          This index is used as a key to system-list.";
+      }
+      
+      leaf chassis-id-subtype {
+        if-feature "lldp-rx";
+        type chassis-id-subtype;
+        description
+          "The type of chassis identifier encoding used in the 
+          associated chassis-id in the remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.2.2";
+      }
+      
+      leaf chassis-id {
+        if-feature "lldp-rx";
+        type chassis-id-type;
+        description
+          "The string value used to identify the chassis component
+          associated with the remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.2.3";
+      }
+      
+      leaf port-id-subtype {
+        if-feature "lldp-rx";
+        type port-id-subtype;
+        description
+          "The type of port identifier encoding used in the 
+          associated port-id in the remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.3.2";
+      }
+      
+      leaf port-id {
+        if-feature "lldp-rx";
+        type port-id-type;
+        description
+          "The string value used to identify the port component
+          associated with this port in the remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.3.3";
+      }
+      
+      leaf port-desc {
+        if-feature "lldp-rx";
+        type string {
+          length "0..255";
+        }
+        description
+          "The string value used to identify the 
+          IEEE 802 LAN station's port description 
+          associated with the remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.5.2";
+      }  
+      
+      leaf sys-name {
+        if-feature "lldp-rx";
+        type string {
+          length "0..255";
+        }
+        description
+          "The string value used to identify the system name of the
+          remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.6.2";
+      }
+      
+      leaf sys-desc {
+        if-feature "lldp-rx";
+        type string {
+          length "0..255";
+        }
+        description
+          "The string value used to identify the system description
+          of the remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.7.2";
+      }
+      
+      leaf sys-cap-supported {
+        if-feature "lldp-rx";
+        type system-capabilities-map;
+        description
+          "The bitmap value used to identify which system capabilities
+          are supported on the remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.8.1";
+      }
+      
+      leaf sys-cap-enabled {
+        if-feature "lldp-rx";
+        type system-capabilities-map;
+        description
+          "The bitmap value used to identify which system capabilities
+          are enabled on the remote system.";
+        reference
+          "IEEE Std 802.1AB-2016: 8.5.8.2";
+      }   
+      
+      leaf remote-changes {
+        if-feature "lldp-rx";
+        type boolean;
+        description
+          "Indicates that there are changes in the remote systems
+          YANG, as determined by the variable remoteChanges.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.11";
+      }
+      
+      leaf too-many-neighbors {
+        if-feature "lldp-rx";
+        type boolean;
+        description
+          "Indicates that there are too many neighbors
+          as determined by the variable tooManyNeighbors.";
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.5.15";
+      }     
+    
+      list man-addr-list {
+        key "rem-man-addr-subtype rem-man-addr";
+        description
+          "Management address information about a particular 
+          remote chassis component. 
+  
+          There may be multiple management addresses
+          configured on the remote system identified by a particular
+          man-addr-list element, whose information is received on 
+          an interface of the local system and a given destination
+          MAC address. Each management address should have
+          distinct rem-man-addr-subtype and rem-man-addr.
+          
+          Entries may be created and deleted in this list by the
+          agent.";   
+       
+        leaf rem-man-addr-subtype {
+          type uint8;
+          description
+            "The type of management address identifier encoding used in
+            the associated rem-man-addr node.
+            
+            The enumeration for this leaf is contained in the
+            IANA Address Family Numbers registry of the IETF RFC 3232 
+            on-line database that is accessible through a
+            web page (http://www.iana.org).
+            
+            The rem-man-addr-subtype is used as a key to
+            man-addr-list.
+            
+            It should be noted that only a subset of the possible
+            address encodings enumerated in IANA Address Family Numbers
+            are appropriate for use as a LLDP management
+            address, either because some are just not applicable or
+            because the maximum size of a rem-man-addr octet string
+            would prevent the use of some address identifier 
+            encodings.";
+          reference
+            "IEEE Std 802.1AB-2016: 8.5.9.3";
+        }
+        
+        leaf rem-man-addr {
+          type man-addr-type;
+          description
+            "The string value used to identify the management address
+            component associated with the remote system. The purpose of
+            this address is to contact the management entity.
+            
+            The rem-man-addr is used as a key to
+            man-addr-list.";
+          reference
+            "IEEE Std 802.1AB-2016: 8.5.9.4";
+        }
+        
+        leaf rem-man-addr-if-subtype {
+          if-feature "lldp-rx";
+          type man-addr-if-subtype;
+          description
+            "The enumeration value that identifies the interface numbering
+            method used for defining the interface number
+            (rem-man-addr-if-id), associated with the remote system.";
+          reference
+            "IEEE Std 802.1AB-2016: 8.5.9.5";
+        }
+        
+        leaf rem-man-addr-if-id {
+          if-feature "lldp-rx";
+          type uint32;
+          description
+            "The integer value used to identify the interface number
+            regarding the management address component associated with
+            the remote system. The value depends upon the value of the
+            rem-man-addr-if-subtype.";
+          reference
+            "IEEE Std 802.1AB-2016: 8.5.9.6";
+        }
+        
+        leaf rem-man-addr-if-oid {
+          if-feature "lldp-rx";
+          type yang:object-identifier-128;
+          description
+            "The OID value used to identify the type of hardware component
+            or protocol entity associated with the management address
+            advertised by the remote system agent.";
+          reference
+            "IEEE Std 802.1AB-2016: 8.5.9.8";
+        }    
+      }
+    
+      list unknown-tlv-list {
+        key "unknown-tlv-type";
+        description
+          "This list contains information about an incoming TLV that
+          is not recognized by the receiving LLDP agent. The TLV can
+          be from a later version of the basic management set.
+          
+          This list should only contain TLVs that are found in
+          a single LLDP frame. Elements in this list, associated
+          with an MAC service access point (MSAP, the access point
+          for MAC services provided to the LCC sublayer, defined
+          in IEEE Standards Dictionary Online) are overwritten 
+          with most recently received unrecognized TLV from the 
+          same MSAP, or they naturally age out when the rxInfoTTL 
+          timer (associated with the MSAP) expires.
+          
+          Entries may be created and deleted in this list by the
+          agent, if a physical topology discovery process 
+          is active."; 
+        reference
+          "IEEE Std 802.1AB-2016: 9.2.7.7.1";
+        
+        leaf unknown-tlv-type {
+          type uint32 {
+            range "9..126";
+          }
+          description
+            "This leaf represents the value extracted from the type
+            field of the TLV.";
+          reference
+            "IEEE Std 802.1AB-2016: 9.2.7.7.1";
+        }
+        
+        leaf unknown-tlv-info {
+          if-feature "lldp-rx";
+          type binary {
+            length "0..511";
+          }
+          description
+            "This leaf represents the octets extracted from the 
+            value field of the TLV.";
+          reference
+            "IEEE Std 802.1AB-2016: 9.2.7.7.1";
+        }
+      }
+      
+      list org-def-info-list {
+        key "odi-oui odi-subtype odi-index";
+        description
+          "This list contains one or more elements per physical 
+          network connection which advertises the organizationally 
+          defined information.
+          
+          Note that this list contains one or more elements of
+          organizationally defined information that is not recognized
+          by the local agent.
+          
+          If the local system is capable of recognizing any
+          organizationally defined information, appropriate extension
+          YANGs from the organization should be used for information
+          retrieval.
+          
+          Each element contains information about the unrecognized 
+          organizationally defined information advertised by the 
+          remote system. Within each element of the remote 
+          system-list, the leafs odi-oui, odi-subtype, and odi-index
+          act as keys to this org-def-info-list.
+          
+          Entries may be created and deleted in this list by the
+          agent.";   
+        
+        leaf odi-oui {
+          type binary {
+            length "3";
+          }
+          description
+            "The Organizationally Unique Identifier (OUI), as defined
+            in IEEE Std 802, is a 24 bit (three octets) globally
+            unique assigned number referenced by various standards,
+            of the information received from the remote system.";
+          reference
+            "IEEE Std 802.1AB-2016: 8.6.1.3";
+        }
+        
+        leaf odi-subtype {
+          type uint32 {
+            range "1..255";
+          }
+          description
+            "The integer value used to identify the subtype of the
+            organizationally defined information received from the
+            remote system.
+            
+            The subtype value is required to identify different 
+            instances of organizationally defined information that 
+            could not be retrieved without a unique identifier that 
+            indicates the particular type of information contained 
+            in the information string.";
+          reference
+            "IEEE Std 802.1AB-2016: 8.6.1.4";
+        }
+     
+        leaf odi-index {
+          type uint32 {
+            range "1..2147483647";
+          }
+          description
+            "This leaf represents an arbitrary local integer value
+            used by this agent to identify a particular unrecognized
+            organizationally defined information instance, 
+            unique only for the odi-oui and odi-subtype from the 
+            same remote system.
+            
+            An agent is encouraged to assign monotonically increasing
+            index values to new entries, starting with one, 
+            after each reboot. It is considered unlikely that the
+            odi-index can wrap between reboots.";
+        }
+
+        leaf odi-info {
+          if-feature "lldp-rx";
+          type binary {
+            length "0..507";
+          }
+          description
+            "This leaf represents the octets extracted from the 
+            organizationally defined information string of the TLV.";
+          reference
+            "IEEE Std 802.1AB-2016: 8.6.1.5";
+        }
+      }
+    }
+  }
+  
+  notification rem-lists-change {
+    if-feature "lldp-rx";
+    description
+      "A rem-lists-change notification is sent when the value
+      of statistics.rem-lists-last-change-time changes. It can be
+      utilized by an management client to trigger LLDP remote 
+      systems list maintenance polls.
+      
+      Note that transmission of rem-lists-change
+      notifications are throttled by the agent, 
+      as specified by the notification-interval in
+      configuration.";
+    
+    leaf rem-lists-inserts {
+      type leafref {
+        path "/statistics/rem-lists-inserts";
+      }
+      description
+        "Remote list inserts";
+    }
+    
+    leaf rem-lists-deletes {
+      type leafref {
+        path "/statistics/rem-lists-deletes";
+      }
+      description
+        "Remote list deletes";
+    }
+
+    leaf rem-lists-drops {
+      type leafref {
+        path "/statistics/rem-lists-drops";
+      }
+      description
+        "Remote list drops";
+    }
+
+    leaf rem-lists-ageouts {
+      type leafref {
+        path "/statistics/rem-lists-ageouts";
+      }
+      description
+        "Remote list ageouts";
+    }
+  }
+}
+

--- a/experimental/ieee/802.1/ieee802-dot1q-sched.yang
+++ b/experimental/ieee/802.1/ieee802-dot1q-sched.yang
@@ -2,7 +2,8 @@ module ieee802-dot1q-sched {
   namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-sched";
   prefix "sched";
 
-  import ietf-yang-types { prefix yang; }
+  import ietf-yang-types { prefix "yang"; }
+  import ieee802-dot1q-types { prefix "dot1q-types"; }
   import ietf-interfaces { prefix "if"; }
   import ieee802-dot1q-bridge { prefix "dot1q"; }
 
@@ -24,7 +25,7 @@ module ieee802-dot1q-sched {
     from its current revision to the formally published YANG
     module for IEEE Std 802.1Qbv-2015.";
 
-  revision 2016-11-11 {
+  revision 2017-03-16 {
     description
       "Module for IEEE Std 802.1Qbv-2015, Enhancements for 
       Scheduled Traffic";
@@ -52,22 +53,6 @@ module ieee802-dot1q-sched {
       "IEEE Std 802.1Qbv-2015";
   }
   
-  typedef traffic-class {
-    type uint8 {
-      range "0..7";
-    }
-    description
-      "This is the numerical value associated with a traffic
-      class in a Bridge. Larger values are associated with
-      higher priority traffic classes.
-      
-      TODO: The typedef is likely to be included in an update
-      to the draft ieee802-dot1q-types as part of the
-      IEEE P802.1Qcp project.";
-    reference
-      "IEEE Std 802.1Q-2014: 3.239";
-  }
-
   grouping ptp-timestamp {
     description
       "This grouping specifies a PTP timestamp, 
@@ -105,7 +90,7 @@ module ieee802-dot1q-sched {
         "The name (type) of the operation for this entry.";
     }
     container sgs-params {
-      when "sched:operation-name = 'set-gate-states'" {
+      when "../operation-name = 'set-gate-states'" {
         description
           "Applies to the SetGateStates operation.";
       }
@@ -151,14 +136,14 @@ module ieee802-dot1q-sched {
     list max-sdu-table {
       key "traffic-class";
       description
-        "A table (list) containing a set of max SDU
+        "A list containing a set of max SDU
         parameters, one for each traffic class.
         All writable objects in this table must be
         persistent over power up restart/reboot.";   
       reference
         "IEEE Std 802.1Qbv-2015: 8.6.8.4, 8.6.9, 12.29.1";
       leaf traffic-class {
-        type traffic-class;
+        type dot1q-types:traffic-class-type;
         description
           "Traffic class";
       }     
@@ -188,7 +173,7 @@ module ieee802-dot1q-sched {
       
     container gate-parameters {
       description
-        "A table (list) that contains the per-port 
+        "A list that contains the per-port 
         managable parameters for traffic scheduling.
         For a given Port, an entry in the table exists.
         All writable objects in this table must be
@@ -442,7 +427,7 @@ module ieee802-dot1q-sched {
         reference
           "IEEE Std 802.1Qbv-2015: 8.6.9.3.1, 12.29.1";
       }
-      leaf support-list-max {
+      leaf supported-list-max {
         type uint32;
         description
           "The maximum value supported by this Port for the


### PR DESCRIPTION
Fix warning in:
   http://www.claise.be/IEEEExperimentalYANGPageCompilation.html
by adding "../" to the "when" on line 108.
Using
  http://www.yangvalidator.com/validator
the warning existed in confdc prior to the fix, and is resolved by the fix.

The pull also includes minor editorial changes, including use of the traffic-class-type
from ieee802-dot1q-types.yang.