### PR TITLE
Edits to openconfig models to allow compilation with NSO

### DIFF
--- a/vendor/cisco/xr/621/cisco-xr-openconfig-bgp-deviations.yang
+++ b/vendor/cisco/xr/621/cisco-xr-openconfig-bgp-deviations.yang
@@ -113,13 +113,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -130,13 +130,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -147,13 +147,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -164,13 +164,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -181,13 +181,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -198,13 +198,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -215,13 +215,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -232,13 +232,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -249,13 +249,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -266,13 +266,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -283,13 +283,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -300,13 +300,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -317,13 +317,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -334,13 +334,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -351,13 +351,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -368,13 +368,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -385,13 +385,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -402,13 +402,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -419,13 +419,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -436,13 +436,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:global/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -609,13 +609,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -626,13 +626,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -643,13 +643,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -660,13 +660,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -677,13 +677,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -694,13 +694,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -711,13 +711,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -728,13 +728,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -745,13 +745,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -762,13 +762,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -779,13 +779,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -796,13 +796,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -813,13 +813,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -830,13 +830,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -847,13 +847,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -864,13 +864,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -881,13 +881,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -898,13 +898,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -915,13 +915,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -932,13 +932,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:neighbors/bgp:neighbor/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1093,13 +1093,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1110,13 +1110,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1127,13 +1127,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1144,13 +1144,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1161,13 +1161,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1178,13 +1178,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv4-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1195,13 +1195,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1212,13 +1212,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:ipv6-labelled-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1229,13 +1229,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1246,13 +1246,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1263,13 +1263,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1280,13 +1280,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-unicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1297,13 +1297,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1314,13 +1314,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv4-multicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1331,13 +1331,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1348,13 +1348,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l3vpn-ipv6-multicast/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1365,13 +1365,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1382,13 +1382,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-vpls/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1399,13 +1399,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:config/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:config/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }
@@ -1416,13 +1416,13 @@ module cisco-xr-openconfig-bgp-deviations {
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:state/bgp:max-prefixes {
     deviate add {
-      must "shutdown-threshold-pct";
+      must "../shutdown-threshold-pct";
     }
   }
 
   deviation /bgp:bgp/bgp:peer-groups/bgp:peer-group/bgp:afi-safis/bgp:afi-safi/bgp:l2vpn-evpn/bgp:prefix-limit/bgp:state/bgp:shutdown-threshold-pct {
     deviate add {
-      must "max-prefixes";
+      must "../max-prefixes";
       default 75;
     }
   }

--- a/vendor/cisco/xr/621/openconfig-if-aggregate.yang
+++ b/vendor/cisco/xr/621/openconfig-if-aggregate.yang
@@ -438,7 +438,7 @@ grouping aggregation-lacp-members-statistics {
 
     leaf aggregate-id {
       type ocif:interface-ref;
-      must "ocif:type = 'ift:ieee8023adLag'" {
+      must "../../../ocif:config/ocif:type = 'ift:ieee8023adLag'" {
         description "The referenced interface must be a
         LAG interface.";
       }
@@ -480,7 +480,7 @@ grouping aggregation-lacp-members-statistics {
           //TODO: this should be active only for non-LACP LAGs,
           //otherwise the LAG state has the list of members and
           // their status
-          when "lag:lag-type = 'STATIC'" {
+          when "../../config/lag:lag-type = 'STATIC'" {
             description
               "The simple list of member interfaces is active
               when the aggregate is statically configured";
@@ -502,7 +502,7 @@ grouping aggregation-lacp-members-statistics {
   // augment statements
 
   augment "/ocif:interfaces/ocif:interface" {
-    when "ocif:type = 'ift:ieee8023adLag'" {
+    when "ocif:config/ocif:type = 'ift:ieee8023adLag'" {
       description "active when the interface is set to type LAG";
     }
     description "Adds LAG configuration to the interface module";
@@ -512,7 +512,7 @@ grouping aggregation-lacp-members-statistics {
 
   augment "/ocif:interfaces/ocif:interface/eth:ethernet/" +
     "eth:config" {
-    when "ocif:type = 'ift:ethernetCsmacd'" {
+    when "../../ocif:config/ocif:type = 'ift:ethernetCsmacd'" {
       description "active when the interface is Ethernet";
     }
     description "Adds LAG settings to individual Ethernet
@@ -523,7 +523,7 @@ grouping aggregation-lacp-members-statistics {
 
   augment "/ocif:interfaces/ocif:interface/eth:ethernet/" +
     "eth:state" {
-    when "ocif:type = 'ift:ethernetCsmacd'" {
+    when "../../ocif:config/ocif:type = 'ift:ethernetCsmacd'" {
       description "active when the interface is Ethernet";
     }
     description "Adds LAG settings to individual Ethernet

--- a/vendor/cisco/xr/621/openconfig-if-ethernet.yang
+++ b/vendor/cisco/xr/621/openconfig-if-ethernet.yang
@@ -306,7 +306,7 @@ module openconfig-if-ethernet {
   // augment statements
 
   augment "/ocif:interfaces/ocif:interface" {
-    when "ocif:type = 'ift:ethernetCsmacd'" {
+    when "ocif:config/ocif:type = 'ift:ethernetCsmacd'" {
       description "Additional interface configuration parameters when
       the interface type is Ethernet";
     }

--- a/vendor/cisco/xr/621/openconfig-mpls-ldp.yang
+++ b/vendor/cisco/xr/621/openconfig-mpls-ldp.yang
@@ -94,7 +94,7 @@ module openconfig-mpls-ldp {
       }
 
       container p2p-lsp {
-        when "tunnel-type = 'P2P'" {
+        when "../tunnel-type = 'P2P'" {
           description
             "container active when LSP tunnel type is
             point to point";
@@ -111,7 +111,7 @@ module openconfig-mpls-ldp {
       }
 
       container p2mp-lsp {
-        when "tunnel-type = 'P2MP'" {
+        when "../tunnel-type = 'P2MP'" {
           description
             "container is active when LSP tunnel type is
             point to multipoint";
@@ -125,7 +125,7 @@ module openconfig-mpls-ldp {
       }
 
       container mp2mp-lsp {
-        when "tunnel-type = 'MP2MP'" {
+        when "../tunnel-type = 'MP2MP'" {
           description
             "container is active when LSP tunnel type is
             multipoint to multipoint";

--- a/vendor/cisco/xr/621/openconfig-mpls-sr.yang
+++ b/vendor/cisco/xr/621/openconfig-mpls-sr.yang
@@ -332,7 +332,7 @@ module openconfig-mpls-sr {
       }
 
       container p2p-lsp {
-        when "tunnel-type = 'P2P'" {
+        when "../tunnel-type = 'P2P'" {
           description
             "container active when LSP tunnel type is
             point to point";

--- a/vendor/cisco/xr/621/openconfig-telemetry.yang
+++ b/vendor/cisco/xr/621/openconfig-telemetry.yang
@@ -697,9 +697,8 @@ module openconfig-telemetry {
 
       leaf telemetry-sensor-group {
         type leafref {
-          path "/telemetry-system/telemetry-subscriptions"
-          + "/telemetry-sensor-specification/telemetry-sensor-group"
-          + "/telemetry-sensor-group-id";
+          path "/telemetry-system/subscriptions/persistent/subscription"
+          + "/sensor-profiles/sensor-profile/sensor-group";
           //require-instance true;
         }
         description

--- a/vendor/cisco/xr/621/openconfig-terminal-device.yang
+++ b/vendor/cisco/xr/621/openconfig-terminal-device.yang
@@ -459,7 +459,7 @@ module openconfig-terminal-device {
           "oc-opt-term:logical-channels/oc-opt-term:channel/" +
           "oc-opt-term:index";
       }
-      must "assignment-type = LOGICAL_CHANNEL" {
+      must "../assignment-type = 'LOGICAL_CHANNEL'" {
         description
           "The assignment-type must be set to LOGICAL_CHANNEL for
           this leaf to be valid";
@@ -473,7 +473,7 @@ module openconfig-terminal-device {
         path "/oc-platform:components/oc-platform:component/" +
           "oc-platform:name";
       }
-      must "assignment-type = OPTICAL_CHANNEL" {
+      must "../assignment-type = 'OPTICAL_CHANNEL'" {
         description
           "The assignment-type must be set to OPTICAL_CHANNEL for
           this leaf to be valid";
@@ -788,14 +788,14 @@ module openconfig-terminal-device {
         }
 
         uses terminal-otn-protocol-top {
-          when "../config/protocol-type = PROT_OTN" {
+          when "config/logical-channel-type = 'oc-opt-types:PROT_OTN'" {
             description
               "Include the OTN protocol data only when the
               channel is using OTN framing.";
           }
         }
         uses terminal-ethernet-protocol-top {
-          when "../config/protocol-type = PROT_ETHERNET" {
+          when "config/logical-channel-type = 'oc-opt-types:PROT_ETHERNET'" {
             description
               "Include the Ethernet protocol statistics only when the
               protocol used by the link is Ethernet.";
@@ -833,8 +833,7 @@ module openconfig-terminal-device {
       // this must statement checks for existence of the
       // operational mode in the list of supported operational
       // modes
-      must "boolean(../../../../operational-modes/state/" +
-        "supported-modes[mode-id=current()])" {
+      must "boolean(/terminal-device/operational-modes/mode[mode-id=current()])" {
         description
           "The referenced operational mode must exist in the list of
           supported operational modes supplied by the device";

--- a/vendor/cisco/xr/621/openconfig-vlan.yang
+++ b/vendor/cisco/xr/621/openconfig-vlan.yang
@@ -209,7 +209,7 @@ module openconfig-vlan {
     }
 
     leaf native-vlan {
-      when "interface-mode = 'TRUNK'" {
+      when "../interface-mode = 'TRUNK'" {
         description
           "Native VLAN is valid for trunk mode interfaces";
       }
@@ -224,7 +224,7 @@ module openconfig-vlan {
     }
 
   leaf access-vlan {
-      when "interface-mode = 'ACCESS'" {
+      when "../interface-mode = 'ACCESS'" {
         description
           "Access VLAN assigned to the interfaces";
       }
@@ -237,7 +237,7 @@ module openconfig-vlan {
     }
 
     leaf-list trunk-vlans {
-      when "interface-mode = 'TRUNK'" {
+      when "../interface-mode = 'TRUNK'" {
         description
           "Allowed VLANs may be specified for trunk mode
           interfaces.";
@@ -478,7 +478,7 @@ module openconfig-vlan {
   augment "/ocif:interfaces/ocif:interface/eth:ethernet" {
     //TODO: augmentation path will need to be updated for
     //full device model
-    when "ocif:type = 'ift:ethernetCsmacd'" {
+    when "../ocif:config/ocif:type = 'ift:ethernetCsmacd'" {
       description "Active when the interface is Ethernet";
     }
     description "Adds VLAN settings to individual Ethernet
@@ -490,7 +490,7 @@ module openconfig-vlan {
   augment "/ocif:interfaces/ocif:interface/lag:aggregation" {
     //TODO: augmentation path will need to be updated for
     //full device model
-    when "ocif:type = 'ift:ieee8023adLag'" {
+    when "../ocif:config/ocif:type = 'ift:ieee8023adLag'" {
       description "Active when the interface is a LAG";
     }
     description "Adds VLAN settings to a LAG interface";
@@ -499,7 +499,7 @@ module openconfig-vlan {
   }
 
   augment "/ocif:interfaces/ocif:interface" {
-    when "ocif:type = 'ift:l3ipvlan'" {
+    when "ocif:config/ocif:type = 'ift:l3ipvlan'" {
       description
         "Active when the interface is a logical interface providing
         L3 routing for VLANs";


### PR DESCRIPTION
There are a few errors in the constraints expressed in the openconfig models downloadable from IOS-XR 6.2.1 images that are not picked up by pyang, but are picked up by the YANG compiler in NSO. This commit provides a version of the affected openconfig models that compile correctly with NSO.
