### PR TITLE
Removed "function" statement in shellscript

### DIFF
--- a/vendor/cisco/nx/7.0-3-I5-1/check-models.sh
+++ b/vendor/cisco/nx/7.0-3-I5-1/check-models.sh
@@ -20,7 +20,7 @@ PYANG_FLAGS="-p ../../../../standard/ietf/RFC"
 
 trap ctrl_c INT
 
-function ctrl_c() {
+ctrl_c() {
   echo 'User interruption, exiting ..' 
   exit -1
 }


### PR DESCRIPTION
The presence of the "function" keyword causes the script to fail. (Might need this across all versions).

