### PR TITLE
Migrate Cisco native model validation to using yanglint, with pyang as fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,26 @@
+sudo: required
+dist: trusty
 language: python
 python:
   - "2.7"
+before_install:
+  - wget -nv https://download.opensuse.org/repositories/home:liberouter/xUbuntu_14.04/Release.key -O Release.key
+  - sudo apt-key add - < Release.key
+  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/liberouter/xUbuntu_14.04/ /' > /etc/apt/sources.list.d/libyang.list"
+  - sudo apt-get update
+  - sudo apt-get install libyang
 install: "pip install pyang==1.7.3 requests"
-notifications:
-  webhooks:
-    urls:
-      - https://yangcatalog.org:8443/checkComplete
-    on_success: always # default: always
-    on_failure: never # default: always
-    on_start: never   # default: never
-    on_cancel: never # default: always
-    on_error: never # default: always
+#notifications:
+#  webhooks:
+#    urls:
+#      - https://yangcatalog.org:8443/checkComplete
+#    on_success: always # default: always
+#    on_failure: never # default: always
+#    on_start: never   # default: never
+#    on_cancel: never # default: always
+#    on_error: never # default: always
 script:
-  - travis_wait 30 ./vendor/cisco/check.sh
+  - ./vendor/cisco/check.sh
   - ./standard/ietf/check.sh
   - ./standard/bbf/check.sh
   - ./experimental/ieee/check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install libyang
 install: "pip install pyang==1.7.3 requests"
-#notifications:
-#  webhooks:
-#    urls:
-#      - https://yangcatalog.org:8443/checkComplete
-#    on_success: always # default: always
-#    on_failure: never # default: always
-#    on_start: never   # default: never
-#    on_cancel: never # default: always
-#    on_error: never # default: always
+notifications:
+  webhooks:
+    urls:
+      - https://yangcatalog.org:8443/checkComplete
+    on_success: always # default: always
+    on_failure: never # default: always
+    on_start: never   # default: never
+    on_cancel: never # default: always
+    on_error: never # default: always
 script:
   - travis_wait 30 ./vendor/cisco/check.sh
   - ./standard/ietf/check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install: "pip install pyang==1.7.3 requests"
 #    on_cancel: never # default: always
 #    on_error: never # default: always
 script:
-  - ./vendor/cisco/check.sh
+  - travis_wait 30 ./vendor/cisco/check.sh
   - ./standard/ietf/check.sh
   - ./standard/bbf/check.sh
   - ./experimental/ieee/check.sh

--- a/vendor/cisco/nx/check-yanglint.sh
+++ b/vendor/cisco/nx/check-yanglint.sh
@@ -6,15 +6,13 @@
 # Deviation modules are NOT checked as they require specific imports
 # typically not available locally.
 #
-# This script will only be run for the last three releases. When a new
-# release is added, the current first release (left to right) should
-# be removed.
+# This script will only be run for the last release of a version branch.
+# When a new set of models is committed for a version, the previous
+# should be removed.
 #
 platform_dir="vendor/cisco/nx"
 to_check="7.0-3-I5-2 7.0-3-I6-1 7.0-3-I7-1"
-inc_path="."
-pyang_flags="--lax-quote-checks"
-debug="0"
+debug=1
 
 checkDir () {
     if [ "$debug" -eq "1" ]; then
@@ -23,15 +21,24 @@ checkDir () {
     exit_status=""
     cwd=`pwd`
     cd $1
-    for f in *.yang; do
+    to_process=`grep -L submodule *.yang`
+    for f in $to_process; do
         if test "${f#*"openconfig-"}" != "$f"; then
             continue
         fi
-    	errors=`YANG_INSTALL="." pyang $pyang_flags $f 2>&1 | grep -v "syntax error in pattern" | grep "error:"`
-        if [ ! -z "$errors" ]; then
-            echo Errors in $f
-            echo "$errors"
-            exit_status="failed!"
+	if [ "$debug" -eq "1" ]; then
+	    echo Checking $f...
+	fi
+        errors=`yanglint $f 2>&1`
+        if [ "$?" -eq 1 ]; then
+	    realerrors=`echo $error | \
+		perl -ne 'if (!/^err : Invalid keyword \"[^(\"\"\.)]/){print;}' | \
+		perl -ne 'if (!/^err : Module \"[^(\")]+\" parsing failed\./){print;}'`
+	    if [ ! -z "$realerrors" ]; then
+		echo Errors in $f
+		echo $realerrors
+		exit_status="failed!"
+	    fi
         fi
     done
     cd $cwd
@@ -49,12 +56,13 @@ if [ -e "$platform_dir" ]; then
     cd $platform_dir
 fi
 
-declare -a pids
+#declare -a pids
 for d in $to_check; do
-    (checkDir $d) &
-    pids+=("$!")
+    checkDir $d
+    # (checkDir $d) &
+    # pids+=("$!")
 done
 
-for p in $pids; do
-    wait $p || exit 1
-done
+#for p in $pids; do
+#    wait $p || exit 1
+#done

--- a/vendor/cisco/xr/check.sh
+++ b/vendor/cisco/xr/check.sh
@@ -12,8 +12,7 @@
 #
 platform_dir="vendor/cisco/xr"
 to_check="602 613 622 631"
-pyang_flags="--lax-quote-checks"
-debug=1
+debug=0
 
 checkDir () {
     if [ "$debug" -eq "1" ]; then
@@ -44,8 +43,7 @@ checkDir () {
 }
 
 if [ "$debug" -eq "1" ]; then
-    printf "\nChecking modules with pyang command:\n"
-    printf "\n    pyang $pyang_flags MODULE\n\n"
+    printf "\nChecking modules with yanglint, using 'lax quote checks' via perlre filtering\n"
 fi
 
 if [ -e "$platform_dir" ]; then


### PR DESCRIPTION
With the volume of native models, pyang has been taking a long time to perform validation as part of CI test runs. This commit uses yanglint for the bulk of models, only falling back to pyang on a failure to validate with yanglint. The fallback is because some issues are currently logged as errors by yanglint that are only warnings with pyang, and which do not cause terminal issues with the use of the yang models in question. For example, the presence of backslashes in double-quoted strings, which is now illegal in yang, with single quoted strings being mandated instead.

The use of yanglint is currently limited to the IOS-XE and IOS-XR models as yanglint also has an arbitrary restriction on the number of typedefs in a module (max 255), which the NX-OS models break. As a result, pyang is still used for those models.

While travis_wait is still used, observed Travis runtimes for Cisco models are now <10 minutes, a substantial improvement! Note that the use of yanglint has meant a move to a VM-based CI instance, which has a slightly longer setup time. This is because the installation of the yanglint libraries and binary needs sudo access.
