### PR TITLE
Add modules for IEEE 802.1Qci(experimental) and IEEE 802.1Qcr(draft).

### DIFF
--- a/experimental/ieee/802.1/ieee802-dot1q-psfp.yang
+++ b/experimental/ieee/802.1/ieee802-dot1q-psfp.yang
@@ -1,0 +1,751 @@
+module ieee802-dot1q-psfp {
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-psfp;
+  prefix psfp;
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ieee802-dot1q-bridge {
+    prefix dot1q;
+  }
+  import ieee802-dot1q-stream-filters-gates {
+    prefix sfsg;
+  }
+  organization
+    "University of Duisburg-Essen";
+  contact
+    "Web URL: http://www.uni-due.de
+    Johannes Specht
+    johannes.specht@uni-due.de";
+  description
+    "This module provides management of 802.1Q bridge components that
+    support Per Stream Filtering an Policing (PSFP). This experimental
+    YANG module is an individual contribution, does not represent a
+    formally sanctioned YANG module of IEEE. Therefore, this YANG
+    module will change in incompatible ways from its current revision
+    to the formally published YANG module for IEEE Std 802.1Q.";
+  revision 2017-12-20 {
+    description
+      "Initial module for Stream Filter and Stream Gate extensions for
+      PSFP, as specified in IEEE 802.1Qci.";
+    reference
+      "IEEE 802.1Qci";
+  }
+  identity type-of-operation {
+    description
+      "Represents the operation type (name).";
+  }
+  identity set-gate-and-ipv {
+    base type-of-operation;
+    description
+      "The StreamGateState parameter specifies a desired state, open
+      or closed, for the stream gate, and the IPV parameter specifies
+      a desired value of the IPV associated with the stream. On
+      execution, the StreamGateState and IPV parameter values are used
+      to set the operational values of the stream gate state and
+      internal priority specification parameters for the stream. After
+      TimeInterval ticks (8.6.9.4.16) has elapsed since the completion
+      of the previous stream gate control operation in the stream gate
+      control list, control passes to the next stream gate control
+      operation. The optional IntervalOctetMax parameter specifies the
+      maximum number of MSDU octets that are permitted to pass the
+      gate during the specified TimeInterval. If the IntervalOctetMax
+      parameter is omitted, there is no limit on the number of octets
+      that can pass the gate.";
+    reference
+      "IEEE 802.1Qci:
+         Clause 8.8.6.5.1.2";
+  }
+  typedef flow-meter-ref-type {
+    type leafref {
+      path
+        '/dot1q:bridges'+
+        '/dot1q:bridge'+
+        '/dot1q:component'+
+        '/psfp:flow-meters'+
+        '/psfp:flow-meter-instance-table'+
+        '/psfp:flow-meter-instance-id';
+    }
+    description
+      "This type is used to refer to a flow meter instance.";
+  }
+  grouping rationale-grouping {
+    description
+      "Definition of a non-negative rational number.";
+    leaf numerator {
+      type uint32;
+      description
+        "Numerator of the rationale number.";
+    }
+    leaf denominator {
+      type uint32;
+      description
+        "Numerator of the rationale number.";
+    }
+  }
+  grouping ptp-time-grouping {
+    description
+      "This grouping specifies a PTP timestamp, represented as a
+      48-bit unsigned integer number of seconds and a 32-bit unsigned
+      integer number of nanoseconds.";
+    reference
+      "IEEE Std 802.1AS:
+         Clause 6.3.3.4";
+    leaf seconds {
+      type uint64;
+      description
+        "This is the integer portion of the timestamp in units of
+        seconds. The upper 16 bits are always zero.";
+    }
+    leaf nanoseconds {
+      type uint32;
+      description
+        "This is the fractional portion of the timestamp in units of
+        nanoseconds. This value is always less than 10^9.";
+    }
+  }
+  grouping gate-control-entry {
+    description
+      "A PSFPGateControlEntry consists of an operation name, followed
+      by three parameters associated with the operation, as detailed
+      in Table 8-7.";
+    reference
+      "IEEE 802.1Qci:
+         Clause 12.31.3.2.2";
+    leaf operation-name {
+      type identityref {
+        base type-of-operation;
+      }
+      mandatory true;
+      description
+        "The name (type) of the operation for this entry.";
+    }
+    container parameters {
+      description
+        "The parameters associated with the operation";
+      reference
+        "IEEE 802.1Qci:
+           Clause 12.31.3.2.2";
+      leaf gate-state-value {
+        type sfsg:gate-state-value-type;
+        mandatory true;
+        description
+          "The PSFPgateStatesValue indicates the desired gate state,
+          open or closed, for the stream gate.";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.3.2.1";
+      }
+      leaf ipv-value {
+        type sfsg:ipv-type;
+        mandatory true;
+        description
+          "The IPV value indicates the IPV (12.31.3.3) to be
+          associated with frames that pass the gate (8.6.10.7).";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.3.2.3";
+      }
+      leaf time-interval-value {
+        type uint32;
+        mandatory true;
+        description
+          "An unsigned integer, denoting a TimeInterval in nanoseconds
+          (see TimeInterval in Table 8-7).";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.3.2.4";
+      }
+      leaf interval-octet-max {
+        type uint32;
+        description
+          "The optional IntervalOctetMax parameter specifies the
+          maximum number of MSDU octets that are permitted to pass the
+          gate during the specified TimeInterval. If the
+          IntervalOctetMax parameter is omitted, there is no limit on
+          the number of octets that can pass the gate.";
+        reference
+          "IEEE 802.1Qci:
+             Clause 8.6.5.1.2";
+      }
+    }
+  }
+  augment
+    "/dot1q:bridges"+
+    "/dot1q:bridge"+
+    "/dot1q:component"+
+    "/sfsg:stream-filters"+
+    "/sfsg:stream-filter-instance-table"+
+    "/sfsg:filter-specification-list"+
+    "/sfsg:filter-specification" {
+    description
+      "Augment the Bridge component Stream Filter specification type
+      by a flow meter filter specification type.";
+    case flow-meter-ref {
+      leaf flow-meter-ref {
+        type psfp:flow-meter-ref-type;
+        description
+          "A reference to the flow meter associated with this filter.";
+      }
+    }
+  }
+  augment
+    "/dot1q:bridges"+
+    "/dot1q:bridge"+
+    "/dot1q:component"+
+    "/sfsg:stream-filters"+
+    "/sfsg:stream-filter-instance-table"+
+    "/sfsg:filter-specification-list"+
+    "/sfsg:filter-specification"+
+    "/sfsg:maximum-sdu-size" {
+    description
+      "Augment the maximum SDU size filter by frame counters.";
+    leaf passing-sdu-count {
+      type yang:counter64;
+      config false;
+      description
+        "A count of frames that passed the Maximum SDU size filter.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 8.6.5.1";
+    }
+    leaf not-passing-sdu-count {
+      type yang:counter64;
+      config false;
+      description
+        "A count of frames that did not pass the Maximum SDU size
+        filter.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 8.6.5.1";
+    }
+  }
+  augment
+    "/dot1q:bridges"+
+    "/dot1q:bridge"+
+    "/dot1q:component"+
+    "/sfsg:stream-filters"+
+    "/sfsg:stream-filter-instance-table" {
+    description
+      "Augment the Bridge component Stream filter by frame counters.";
+    leaf matching-frames-count {
+      type yang:counter64;
+      config false;
+      description
+        "A count of frames matching both the stream_handle and
+        priority specifications.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 8.6.5.1";
+    }
+    leaf passing-frames-count {
+      type yang:counter64;
+      config false;
+      description
+        "A count of frames that passed the stream filter.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 8.6.5.1";
+    }
+    leaf not-passing-frames-count {
+      type yang:counter64;
+      config false;
+      description
+        "A count of frames that did not pass the stream filter.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 8.6.5.1";
+    }
+  }
+  augment
+    "/dot1q:bridges/dot1q:bridge/dot1q:component/sfsg:stream-gates" {
+    description
+      "Augment the Bridge component Stream Gates by maximum control
+      list limits, as used for PTP-controlled open and close
+      transitions";
+    leaf max-control-list-length {
+      type uint32;
+      config false;
+      description
+        "The maximum value supported by this Bridge component of the
+        AdminControlListLength and OperControlListLength parameters.
+        It is available for use by schedule computation software to
+        determine the Bridge component’s control list capacity prior
+        to computation.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 12.31.1.4";
+    }
+  }
+  augment
+    "/dot1q:bridges"+
+    "/dot1q:bridge"+
+    "/dot1q:component"+
+    "/sfsg:stream-gates"+
+    "/sfsg:stream-gate-instance-table" {
+    description
+      "Augment the Bridge component Stream Gate instances by
+       a) operational gate states
+       b) operational IPV values
+       c) PTP controlled open and close transitions
+       d) Management for PTP controlled open and close transitions";
+    leaf oper-gate-states {
+      type sfsg:gate-state-value-type;
+      config false;
+      description
+        "The current state of the gate. PSFPOperGateStates is set by
+        the List Execute state machine (8.6.9.2), and its initial
+        value is determined by the value of the PSFPAdminGateStates
+        variable (8.6.10.4).";
+      reference
+        "IEEE 802.1Qci:
+           Clause 12.31.3.2.1
+           Clause 8.6.10.5";
+    }
+    leaf oper-ipv {
+      type sfsg:ipv-type;
+      config false;
+      description
+        "The operational internal priority value specification.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 12.31.3.3
+           Clause 8.6.10.7
+           Clause 8.6.5.1.2";
+    }
+    leaf admin-control-list-length {
+      type uint32;
+      description
+        "The AdminControlList and OperControlList are ordered lists
+        containing AdminControlListLength or OperControlListLength
+        entries, respectively. Each entry represents a gate operation
+        as defined in Table 8-7. Each entry in the list is structured
+        as a GateControlEntry (12.31.3.2.2).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.4.6
+        IEEE 802.1Qci:
+           Clause 12.31.3.2";
+    }
+    leaf oper-control-list-length {
+      type uint32;
+      config false;
+      description
+        "The AdminControlList and OperControlList are ordered lists
+        containing AdminControlListLength or OperControlListLength
+        entries, respectively. Each entry represents a gate operation
+        as defined in Table 8-7. Each entry in the list is structured
+        as a GateControlEntry (12.31.3.2.2).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.4.23
+        IEEE 802.1Qci:
+           Clause 12.31.3.2";
+    }
+    list admin-control-list {
+      key "index";
+      description
+        "The AdminControlList and OperControlList are ordered lists
+        containing AdminControlListLength or OperControlListLength
+        entries, respectively. Each entry represents a gate operation
+        as defined in Table 8-7. Each entry in the list is structured
+        as a GateControlEntry (12.31.3.2.2).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.4.2
+        IEEE 802.1Qci:
+           Clause 12.31.3.2
+           Clause 12.31.3.2.2";
+      leaf index {
+        type uint32;
+        mandatory true;
+        description
+          "This index contains a unique key per list entry.";
+      }
+      uses gate-control-entry;
+    }
+    list oper-control-list {
+      key "index";
+      config false;
+      description
+        "The AdminControlList and OperControlList are ordered lists
+        containing AdminControlListLength or OperControlListLength
+        entries, respectively. Each entry represents a gate operation
+        as defined in Table 8-7. Each entry in the list is structured
+        as a GateControlEntry (12.31.3.2.2).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.4.19
+        IEEE 802.1Qci:
+           Clause 12.31.3.2
+           Clause 12.31.3.2.2";
+      leaf index {
+        type uint32;
+        description
+          "This index contains a unique key per list entry.";
+      }
+      uses gate-control-entry;
+    }
+    container admin-cycle-time {
+      description
+        "The administrative value of the gating cycle for the Port
+        (3.99). This value can be changed by management, and is used
+        by the List Config state machine (8.6.9.3) to set the value of
+        OperCycleTime (8.6.9.4.20). The AdminCycleTime variable is a
+        rational number of seconds, defined by an integer numerator
+        and an integer denominator.";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 12.29.1.3
+           Clause 8.6.9.4.3";
+      uses rationale-grouping;
+    }
+    container oper-cycle-time {
+      config false;
+      description
+        "The operational value of the gating cycle for the Port
+        (3.99). This variable is set dynamically from the
+        AdminCycleTime variable (8.6.9.4.3) under the control of the
+        List Config state machine (8.6.9.3) OperCycleTime is used by
+        the Cycle Timer state machine (8.6.9.1) to enforce the cycle
+        time for the Port. The OperCycleTime variable is a rational
+        number of seconds, defined by an integer numerator and an
+        integer denominator.";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 12.29.1.3
+           Clause 8.6.9.4.20";
+      uses rationale-grouping;
+    }
+    leaf admin-cycle-time-extension {
+      type uint32;
+      description
+        "An integer number of nanoseconds, defining the maximum amount
+        of time by which the gating cycle for the Port (3.99) is
+        permitted to be extended when a new cycle configuration is
+        being installed. This administrative value can be changed by
+        management, and is used by the List Config state machine
+        (8.6.9.3) to set the value of OperCycleTimeExtension
+        (8.6.9.4.21).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.4.4";
+    }
+    leaf oper-cycle-time-extension {
+      type uint32;
+      config false;
+      description
+        "An integer number of nanoseconds, defining the maximum amount
+        of time by which the gating cycle for the Port (3.99) is
+        permitted to be extended when a new cycle configuration is
+        installed. This operational value is set by the List Config
+        state machine (8.6.9.3) to the value of
+        AdminCycleTimeExtension (8.6.9.4.4). The value of
+        OperCycleTimeExtension is used by the SetCycleStartTime()
+        procedure (8.6.9.1.1).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.4.4";
+    }
+    container admin-base-time {
+      description
+        "The administrative value of base time, expressed as an IEEE
+        1588 precision time protocol (PTP) timescale (see 8.2 of IEEE
+        Std 802.1AS-2011). This value can be changed by management,
+        and is used by the List Config state machine (8.6.9.3) to set
+        the value of OperBaseTime (8.6.9.4.18).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 12.29.1.4
+           Clause 8.6.9.4.1";
+      uses ptp-time-grouping;
+    }
+    container oper-base-time {
+      config false;
+      description
+        "The operational value of base time, expressed as a PTP
+        timescale (see 8.2 of IEEE Std 802.1AS-2011). This variable is
+        used by the List Config state machine (8.6.9.3).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 12.29.1.4
+           Clause 8.6.9.4.18";
+      uses ptp-time-grouping;
+    }
+    leaf config-change {
+      type boolean;
+      description
+        "A Boolean variable that acts as a start signal to the List
+        Config state machine (8.6.9.3) that the administrative
+        variable values for the Port are ready to be copied into their
+        corresponding operational variables. This variable is set TRUE
+        by management and is set FALSE by the List Config state
+        machine.";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.4.7";
+    }
+    container config-change-time {
+      config false;
+      description
+        "The time at which the administrative variables that determine
+        the cycle are to be copied across to the corresponding
+        operational variables, expressed as a PTP timescale. The value
+        of this variable is set by the SetConfigChangeTime() procedure
+        (8.6.9.3.1) in the List Config state machine (8.6.9.3).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 12.29.1.4
+           Clause 8.6.9.4.9";
+      uses ptp-time-grouping;
+    }
+    leaf tick-granularity {
+      type uint32;
+      config false;
+      description
+        "Characteristics of an implementation’s cycle timer clock
+        (TickGranularity).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.4.16";
+    }
+    container current-time {
+      config false;
+      description
+        "The current time maintained by the local system, expressed as
+        a PTP timescale (see 8.2 of IEEE Std 802.1AS-2011).";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 12.29.1.4
+           Clause 8.6.9.4.10";
+      uses ptp-time-grouping;
+    }
+    leaf config-pending {
+      type boolean;
+      config false;
+      description
+        "A Boolean variable, set TRUE by the List Config state machine
+        (8.6.9.3) to signal that there is a new cycle configuration
+        awaiting installation. The variable is set FALSE when the List
+        Config state machine has installed the new configuration. The
+        variable is used by the SetCycleStartTime() procedure
+        (8.6.9.1.1) to control the length of the cycle that
+        immediately precedes the first cycle that uses the new
+        configuration values. This value can be read by management, as
+        specified in 12.29.1.";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.3
+           Clause 8.6.9.4.8";
+    }
+    leaf config-change-error {
+      type yang:counter64;
+      config false;
+      description
+        "An error counter that is incremented if AdminBaseTime
+        specifies a time in the past, and the current schedule is
+        running.";
+      reference
+        "IEEE 802.1Qbv:
+           Clause 8.6.9.3.1";
+    }
+    leaf gate-closed-due-to-invalid-rx-enable {
+      type boolean;
+      default "false";
+      description
+        "A value of TRUE indicates that the GateClosedDueToInvalidRx
+        function is enabled; a value of FALSE indicates that the
+        GateClosedDueToInvalidRx function is disabled. The default
+        value of GateClosedDueToInvalidRxEnable is FALSE.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 8.6.5.1.2";
+    }
+    leaf gate-closed-due-to-invalid-rx {
+      type boolean;
+      default "false";
+      description
+        "If GateClosedDueToInvalidRxEnable is TRUE, a value of TRUE in
+        GateClosedDueToInvalidRx indicates that all frames are dropped
+        (i.e., the gate behaves as if the operational stream gate
+        state is Closed). If GateClosedDueToInvalidRx is FALSE, it has
+        no effect. The default value of GateClosedDueToInvalidRx is
+        FALSE; if any frame is discarded because the gate is in the
+        Closed state, then GateClosedDueToInvalidRx is set TRUE.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 8.6.5.1.2";
+    }
+  }
+  augment "/dot1q:bridges/dot1q:bridge/dot1q:component" {
+    description
+      "Augment the Bridge component by Flow Meters.";
+    container flow-meters {
+      description
+        "This container comprises all flow meter related nodes.";
+      list flow-meter-instance-table {
+        key "flow-meter-instance-id";
+        description
+          "There is one Flow Meter Instance Table per Bridge
+          component. Each table row contains a set of parameters that
+          defines a single Flow Meter Instance (8.6.5.1), as detailed
+          in Table 12-33. Tables can be created or removed dynamically
+          in implementations that support dynamic configuration of
+          Bridge components. Rows in the table can be created or
+          removed dynamically in implementations that support dynamic
+          configuration of flow meters.";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.4";
+        leaf flow-meter-instance-id {
+          type uint32;
+          mandatory true;
+          description
+            "An integer table index that allows the Flow Meter to be
+            referenced from Stream Filter Instance Table entries.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf committed-information-rate {
+          type uint64;
+          mandatory true;
+          description
+            "Committed information rate (CIR), in bits per second.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf committed-burst-size {
+          type uint32;
+          mandatory true;
+          description
+            "Committed burst size (CBS), in octets.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf excess-information-rate {
+          type uint64;
+          mandatory true;
+          description
+            "Excess Information Rate (EIR), in bits per second.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf excess-burst-size {
+          type uint32;
+          mandatory true;
+          description
+            "Excess burst size (EBS) per bandwidth profile flow, in
+            octets.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf coupling-flag {
+          type enumeration {
+            enum zero {
+              value 0;
+              description
+                "Uncoupled";
+            }
+            enum one {
+              value 1;
+              description
+                "Coupled";
+            }
+          }
+          mandatory true;
+          description
+            "Coupling flag (CF), which takes the value 0 or 1.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf color-mode {
+          type enumeration {
+            enum color-blind {
+              description
+                "Color-blind (i.e., frames are marked either green or
+                red";
+            }
+            enum color-aware {
+              description
+                "Color-aware (i.e., frames are marked green, yellow,
+                or red";
+            }
+          }
+          mandatory true;
+          description
+            "Color mode (CM), which takes the value color-blind or
+            color-aware.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf drop-on-yellow {
+          type boolean;
+          mandatory true;
+          description
+            "DropOnYellow, which takes the value TRUE or FALSE. A
+            value of TRUE indicates that yellow frames are dropped
+            (i.e., discarded); a value of FALSE indicates that yellow
+            frames will have the drop_eligible parameter set to TRUE.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf mark-all-frames-red-enable {
+          type boolean;
+          default "false";
+          description
+            "MarkAllFramesRedEnable, which takes the value TRUE or
+            FALSE. A value of TRUE indicates that the MarkAllFramesRed
+            function is enabled; a value of FALSE indicates that the
+            MarkAllFramesRed function is disabled. The default value
+            of MarkAllFramesRedEnable is FALSE.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf mark-all-frames-red {
+          type boolean;
+          default "false";
+          config false;
+          description
+            "MarkAllFramesRed, which takes the value TRUE or FALSE. If
+            MarkAllFramesRedEnable is TRUE, a value of TRUE in
+            MarkAllFramesRed indicates that all frames are dropped
+            (i.e., discarded). If MarkAllFramesRed is False, it has no
+            effect. The default value of MarkAllFramesRed is FALSE; if
+            the operation of the flow meter causes any frame to be
+            discarded, then MarkAllFramesRed is set TRUE.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1.3";
+        }
+        leaf red-frames-count {
+          type yang:counter64;
+          config false;
+          description
+            "A count of frames that were discarded as a result of the
+            operation of the flow meter.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1";
+        }
+      }
+      leaf max-flow-meter-instances {
+        type uint32;
+        config false;
+        description
+          "The maximum number of Flow Meter instances supported by
+          this Bridge component.";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.1.3";
+      }
+    }
+  }
+}

--- a/standard/ieee/802.1/draft/ieee802-dot1q-ats.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-ats.yang
@@ -1,0 +1,202 @@
+module ieee802-dot1q-ats {
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-ats;
+  prefix ats;
+  import ieee802-dot1q-bridge {
+    prefix dot1q;
+  }
+  import ieee802-dot1q-stream-filters-gates {
+    prefix sfsg;
+  }
+  organization
+    "Institute of Electrical and Electronics Engineers";
+  contact
+    "WG-URL: http://grouper.ieee.org/groups/802/1/
+    WG-EMail: stds-802-1@ieee.org
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+    
+    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
+  description
+    "This module provides management of 802.1Q bridge components that
+    support Asynchronous Traffic Shaping (ATS). This experimental YANG
+    module is an individual contribution, does not represent a
+    formally sanctioned YANG module of IEEE. Therefore, this YANG
+    module will change in incompatible ways from its current revision
+    to the formally published YANG module for IEEE Std 802.1Q.";
+  revision 2017-12-20 {
+    description
+      "Initial module for Stream Filter and Stream Gate extensions for
+      ATS, as specified in IEEE 802.1Qcr.";
+    reference
+      "IEEE 802.1Qcr";
+  }
+  typedef shaper-ref-type {
+    type leafref {
+      path
+        '/dot1q:bridges'+
+        '/dot1q:bridge'+
+        '/dot1q:component'+
+        '/ats:shapers'+
+        '/ats:shaper-instance-table'+
+        '/ats:shaper-instance-id';
+    }
+    description
+      "This type is used to refer to an ATS shaper instance.";
+  }
+  typedef shaper-group-ref-type {
+    type leafref {
+      path
+        '/dot1q:bridges'+
+        '/dot1q:bridge'+
+        '/dot1q:component'+
+        '/ats:shaper-groups'+
+        '/ats:shaper-group-instance-table'+
+        '/ats:shaper-group-instance-id';
+    }
+    description
+      "This type is used to refer to an ATS shaper group instance.";
+  }
+  augment
+    "/dot1q:bridges"+
+    "/dot1q:bridge"+
+    "/dot1q:component"+
+    "/sfsg:stream-filters"+
+    "/sfsg:stream-filter-instance-table"+
+    "/sfsg:filter-specification-list"+
+    "/sfsg:filter-specification" {
+    description
+      "Augment the Bridge component Stream Filter specification type
+      by a ATS shaper filter specification type.";
+    case shaper-ref {
+      leaf shaper-ref {
+        type ats:shaper-ref-type;
+        mandatory true;
+        description
+          "A reference to the ATS shaper associated with this filter.";
+      }
+    }
+  }
+  augment "/dot1q:bridges/dot1q:bridge/dot1q:component" {
+    description
+      "Augment the Bridge component by
+       a) ATS Shapers
+       b) ATS Shaper Groups";
+    container shapers {
+      description
+        "This container comprises all ATS shaper instance related
+        nodes.";
+      list shaper-instance-table {
+        key "shaper-instance-id";
+        description
+          "Each table row in the Shaper Instance Table comprises a set
+          of parameters that defines a singe ATS shaper instance, as
+          detailed in 8.6.5.2.3.";
+        reference
+          "IEEE 802.1Qcr:
+             Clause 12.34.4";
+        leaf shaper-instance-id {
+          type uint32;
+          mandatory true;
+          description
+            "An integer table index that allows the shaper instance to
+            be referenced from Stream Filter Instance Table entries.";
+          reference
+            "IEEE 802.1Qcr:
+               Clause 12.33.4.1";
+        }
+        leaf committed-information-rate {
+          type uint64;
+          mandatory true;
+          description
+            "The committed information rate parameter of the shaper
+            instance, in bits per second (8.6.5.2.3).";
+          reference
+            "IEEE 802.1Qcr:
+               Clause 8.6.5.2.3";
+        }
+        leaf committed-burst-size {
+          type uint32;
+          mandatory true;
+          description
+            "The committed burst size parameter of the shaper
+            instance, in bits (8.6.5.2.3).";
+          reference
+            "IEEE 802.1Qcr:
+               Clause 8.6.5.2.3";
+        }
+        leaf shaper-group-ref {
+          type ats:shaper-group-ref-type;
+          mandatory true;
+          description
+            "The ShaperGroupInstanceID parameter identifies the shaper
+            group (12.32.5) that is associated with the shaper
+            instance. Multiple shaper instance can be associated to
+            one shaper group, as detailed in 8.6.5.2.3.";
+          reference
+            "IEEE 802.1Qcr:
+               Clause 12.33.4.4";
+        }
+      }
+      leaf max-shaper-instances {
+        type uint32;
+        config false;
+        description
+          "The maximum number of shaper instances supported by this
+          Bridge component.";
+        reference
+          "IEEE 802.1Qcr:
+             Clause 12.33.1.3";
+      }
+    }
+    container shaper-groups {
+      description
+        "This container comprises all ATS shaper group related nodes.";
+      list shaper-group-instance-table {
+        key "shaper-group-instance-id";
+        description
+          "Each table row in the Shaper Group Instance Table comprises
+          a set of parameters that defines a singe ATS shaper group
+          instance (8.6.5.2.3), as detailed in Table 12-38.";
+        reference
+          "IEEE 802.1Qcr:
+             Clause 12.34.5";
+        leaf shaper-group-instance-id {
+          type uint32;
+          description
+            "An integer table index that allows the shaper group
+            instance to be referenced from Shaper Instance Table
+            entries.";
+          reference
+            "IEEE 802.1Qcr:
+               Clause 12.33.5.1";
+        }
+        leaf max-residence-time {
+          type uint32;
+          mandatory true;
+          description
+            "The maximum residence time parameter of the shaper group,
+            in nanoseconds.";
+          reference
+            "IEEE 802.1Qcr:
+               Clause 8.6.5.2.3";
+        }
+      }
+      leaf max-shaper-group-instances {
+        type uint32;
+        config false;
+        description
+          "The maximum number of shaper group instances supported by
+          this Bridge component.";
+        reference
+          "IEEE 802.1Qcr:
+             Clause 12.33.1.4";
+      }
+    }
+  }
+}

--- a/standard/ieee/802.1/draft/ieee802-dot1q-stream-filters-gates.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-stream-filters-gates.yang
@@ -1,0 +1,398 @@
+module ieee802-dot1q-stream-filters-gates {
+  namespace
+    urn:ieee:std:802.1Q:yang:ieee802-dot1q-stream-filters-gates;
+  prefix sfsg;
+  import ieee802-dot1q-bridge {
+    prefix dot1q;
+  }
+  organization
+    "Institute of Electrical and Electronics Engineers";
+  contact
+    "WG-URL: http://grouper.ieee.org/groups/802/1/
+    WG-EMail: stds-802-1@ieee.org
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+    
+    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
+  description
+    "This module provides management of 802.1Q bridge components that
+    support Stream Filters and Stream Gates. This experimental YANG
+    module is an individual contribution, does not represent a
+    formally sanctioned YANG module of IEEE. Therefore, this YANG
+    module will change in incompatible ways from its current revision
+    to the formally published YANG module for IEEE Std 802.1Q.";
+  revision 2017-12-20 {
+    description
+      "Initial module for Stream Filters and Stream Gates, as
+      specified in IEEE 802.1Qci and IEEE 802.1Qcr.";
+    reference
+      "IEEE 802.1Q, IEEE 802.1Qci, IEEE 802.1Qcr";
+  }
+  feature closed-gate-state {
+    description
+      "The bridge component supports gate state closed.";
+    reference
+      "IEEE 802.1Qci
+      IEEE 802.1Qcr";
+  }
+  typedef ipv-type {
+    type enumeration {
+      enum zero {
+        value 0;
+        description
+          "Priority 0";
+      }
+      enum one {
+        value 1;
+        description
+          "Priority 1";
+      }
+      enum two {
+        value 2;
+        description
+          "Priority 2";
+      }
+      enum three {
+        value 3;
+        description
+          "Priority 3";
+      }
+      enum four {
+        value 4;
+        description
+          "Priority 4";
+      }
+      enum five {
+        value 5;
+        description
+          "Priority 5";
+      }
+      enum six {
+        value 6;
+        description
+          "Priority 6";
+      }
+      enum seven {
+        value 7;
+        description
+          "Priority 7";
+      }
+      enum wildcard {
+        description
+          "No Priority";
+      }
+    }
+    description
+      "An IPV can be either of the following:
+         1) The null value. For a frame that passes through the gate,
+            the priority value associated with theframe is used to
+            determine the frame’s traffic class, using the Traffic
+            Class Table as specified in 8.6.6.
+         2) An internal priority value. For a frame that passes
+            through the gate, the IPV is used, in place of the
+            priority value associated with the frame, to determine the
+            frame’s traffic class, using the Traffic Class Table as
+            specified in 8.6.6.";
+    reference
+      "IEEE 802.1Qci:
+         Clause 8.6.5.1.2";
+  }
+  typedef gate-state-value-type {
+    type enumeration {
+      enum open {
+        description
+          "Gate open";
+      }
+      enum closed {
+        description
+          "Gate closed";
+      }
+    }
+    description
+      "The PSFPgateStatesValue indicates the desired gate state, open
+      or closed, for the stream gate.";
+    reference
+      "IEEE 802.1Qci:
+         Clause 12.31.3.2.1";
+  }
+  typedef stream-gate-ref {
+    type leafref {
+      path
+        '/dot1q:bridges'+
+        '/dot1q:bridge'+
+        '/dot1q:component'+
+        '/sfsg:stream-gates'+
+        '/sfsg:stream-gate-instance-table'+
+        '/sfsg:stream-gate-instance-id';
+    }
+    description
+      "This type is used to refer to a stream gate instance.";
+  }
+  augment "/dot1q:bridges/dot1q:bridge/dot1q:component" {
+    description
+      "Augment the Bridge component with Stream Filters and Stream
+      Gates.";
+    container stream-filters {
+      description
+        "This container encapsulates all nodes related to Stream
+        Filters.";
+      reference
+        "IEEE 802.1Qci:
+           Clause 12.31.1
+           Clause 12.31.2";
+      list stream-filter-instance-table {
+        key "stream-filter-instance-id";
+        description
+          "There is one Stream Filter Instance Table per Bridge
+          component. Each table row contains a set of parameters that
+          defines a single Stream Filter (8.6.5.1), as detailed in
+          Table 12-31. The table rows form an ordered list of filter
+          instances, the order being determined by the
+          StreamFilterInstance parameter. Tables can be created or
+          removed dynamically in implementations that support dynamic
+          configuration of Bridge components. Rows in the table can be
+          created or removed dynamically in implementations that
+          support dynamic configuration of stream filters. The value
+          of the stream-handle-spec and priority-spec parameters
+          associated with a received frame determine which stream
+          filter is selected by the frame, and therefore what
+          combination of filtering and policing actions is applied to
+          the frame. If the stream-handle-spec and priority-spec
+          parameters associated with a received frame match more than
+          one stream filter, the stream filter that is selected is the
+          one that appears earliest in the ordered list. If a received
+          frame’s stream-handle-spec and priority-spec does not match
+          any of the stream filters in the table, the frame is
+          processed as would be the case if Stream Filters and Stream
+          Gates was not supported.";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.2
+             Clause 8.6.5.1.1";
+        leaf stream-filter-instance-id {
+          type uint32;
+          mandatory true;
+          description
+            "An integer index value that determines the place of the
+            stream filter in the ordered list of stream filter
+            instances. The values are ordered according to their
+            integer value; smaller values appear earlier in the
+            ordered list.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 12.31.2.1";
+        }
+        choice stream-handle-spec {
+          description
+            "The stream_handle specification data type allows either
+            of the following to be represented:
+             a) A stream_handle value, represented as an integer.
+             b) The wild card value, which matches any frame";
+          reference
+            "IEEE 802.1Qci:
+               Clause 12.31.2.2";
+          case wildcard {
+            leaf wildcard {
+              type empty;
+              description
+                "The stream handle specification represents a wild
+                card value.";
+            }
+          }
+          case stream-handle {
+            leaf stream-handle {
+              type uint32;
+              mandatory true;
+              description
+                "The stream handle specification refers to a
+                stram_handle.";
+            }
+          }
+        }
+        leaf priority-spec {
+          type ipv-type;
+          mandatory true;
+          description
+            "The priority specification data type allows either of the
+            following to be represented:
+             a) A priority value, represented as an integer.
+             b) The wild card value, which matches any priority.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 12.31.2.3";
+        }
+        leaf stream-gate-ref {
+          type stream-gate-ref;
+          mandatory true;
+          description
+            "The StreamGateInstance parameter identifies the stream
+            gate (12.31.3) that is associated with the stream filter.
+            The relationship between stream filters and stream gates
+            is many to one; a given stream filter can be associated
+            with only one stream gate, but there can be multiple
+            stream filters associated with a given stream gate.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 12.31.2.4";
+        }
+        list filter-specification-list {
+          key "index";
+          description
+            "The filter specification list contains one or more filter
+            specifications that are assigned with this stream filter.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 12.31.2.5";
+          leaf index {
+            type uint8;
+            description
+              "The index of this filter specification.";
+          }
+          choice filter-specification {
+            description
+              "The filter specification type, and its parameters.";
+            reference
+              "IEEE 802.1Qci:
+                 Clause 12.31.2.5";
+            case maximum-sdu-size {
+              description
+                "Maximum SDU size filer";
+              leaf maximum-sdu-size {
+                type uint32;
+                mandatory true;
+                description
+                  "The allowed maximum SDU size, in octets.";
+              }
+              leaf stream-blocked-due-to-oversize-frame-enabled {
+                type boolean;
+                default "false";
+                description
+                  "A value of TRUE indicates that the
+                  StreamBlockedDueToOversizeFrame function is enabled;
+                  a value of FALSE indicates that the
+                  StreamBlockedDueToOversizeFrame function is
+                  disabled. The default value of
+                  StreamBlockedDueToOversizeFrameEnable is FALSE.";
+                reference
+                  "IEEE 802.1Qci:
+                     Clause 8.6.5.1
+                     Clause 8.6.5.1.1";
+              }
+              leaf stream-blocked-due-to-oversize-frame {
+                type boolean;
+                default "false";
+                config false;
+                description
+                  "If StreamBlockedDueToOversizeFrameEnable is TRUE, a
+                  value of TRUE in StreamBlockedDueToOversizeFrame
+                  indicates that all frames are to be dropped (i.e.,
+                  the stream filter behaves as it would if the maximum
+                  SDU size were to be set to 0 octets). If
+                  StreamBlockedDueToOversizeFrame is FALSE, it has no
+                  effect. The default value of
+                  StreamBlockedDueToOversizeFrame is FALSE; if any
+                  frame is discarded because it exceeds the Maximum
+                  SDU size for the stream, then
+                  StreamBlockedDueToOversizeFrame is set TRUE.";
+                reference
+                  "IEEE 802.1Qci:
+                     Clause 8.6.5.1
+                     Clause 8.6.5.1.1";
+              }
+            }
+          }
+        }
+      }
+      leaf max-stream-filter-instances {
+        type uint32;
+        config false;
+        description
+          "The maximum number of Stream Filter instances supported by
+          this Bridge component.";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.1.1";
+      }
+    }
+    container stream-gates {
+      description
+        "This container encapsulates all nodes related to Stream
+        Gates.";
+      list stream-gate-instance-table {
+        key "stream-gate-instance-id";
+        description
+          "There is one Stream Gate Instance Table per Bridge
+          component. Each table row contains a set of parameters that
+          defines a single Stream Gate (8.6.5.1.2), as detailed in
+          Table 12-32. Tables can be created or removed dynamically in
+          implementations that support dynamic configuration of Bridge
+          components. Rows in the table can be created or removed
+          dynamically in implementations that support dynamic
+          configuration of stream gates.";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.3";
+        leaf stream-gate-instance-id {
+          type uint32;
+          description
+            "An integer table index that allows the stream gate to be
+            referenced from Stream Filter Instance Table entries.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 8.6.5.1
+               Clause 8.6.5.1.2";
+        }
+        leaf gate-enable {
+          type boolean;
+          default "false";
+          description
+            "A Boolean variable that indicates whether the operation
+            of the state machines is enabled (TRUE) or disabled
+            (FALSE). This variable is set by management. The default
+            value of this variable is FALSE.";
+          reference
+            "IEEE 802.1Qbv:
+               Clause 8.6.9.4.14";
+        }
+        leaf admin-gate-states {
+          type gate-state-value-type;
+          default "open";
+          description
+            "The administrative state associated with this gate, as
+            set by the management.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 12.31.3.2.1
+               Clause 8.6.10.4";
+        }
+        leaf admin-ipv {
+          type ipv-type;
+          default "wildcard";
+          description
+            "The administrative internal priority value specification.";
+          reference
+            "IEEE 802.1Qci:
+               Clause 12.31.3.3
+               Clause 8.6.10.6
+               Clause 8.6.5.1.2";
+        }
+      }
+      leaf max-stream-gate-instances {
+        type uint32;
+        config false;
+        description
+          "The maximum number of Stream Gate instances supported by
+          this Bridge component.";
+        reference
+          "IEEE 802.1Qci:
+             Clause 12.31.1.2";
+      }
+    }
+  }
+}


### PR DESCRIPTION
The modules of IEEE 802.1Qci(PSFP) and IEEE 802.1Qcr(ATS) are based on a common draft module for stream filters and stream gates.
This module augments the draft modules of IEEE 802.1Qcp (editor Marc Holness).