### PR TITLE
Update IEEE 802.1Qcp and Xck D2.0 YANG modules

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
@@ -63,12 +63,12 @@ module ieee802-dot1q-bridge {
   identity provider-edge-bridge {
     base type-of-bridge;
     description
-      "Base identity fro a Provider Edge Bridge (PEB).";
+      "Base identity for a Provider Edge Bridge (PEB).";
   }
   identity two-port-mac-relay-bridge {
     base type-of-bridge;
     description
-      "Base identity for a Tow Port MAC Relay (TPMR) Bridge.";
+      "Base identity for a Two Port MAC Relay (TPMR) Bridge.";
   }
 
   /*
@@ -1422,7 +1422,7 @@ module ieee802-dot1q-bridge {
             "IEEE 802.1Q-2017 Clause 12.10.1.7";
         }
         leaf-list vid {
-        	type ieee:vlanid;
+        	type dot1qtypes:vlanid;
         	description
             "The VLAN identifier to which this entry applies.";
           reference
@@ -1533,7 +1533,7 @@ module ieee802-dot1q-bridge {
       			position 2;
       			description
       				"Supports the discarding of any frame received on
-      				a Port whose VLAN classificaiton does not include
+      				a Port whose VLAN classification does not include
       				that Port in its member set.";
       		}
       	}
@@ -1706,9 +1706,9 @@ module ieee802-dot1q-bridge {
           Translation Configuration object defines a single
           bidirectional mapping. In this case, the Bridge should
         	not allow multiple keys ('local-vid') mapped to the same
-        	'reelay-vid' value.";
+        	'relay-vid' value.";
         leaf local-vid {
-          type ieee:vlanid;
+          type dot1qtypes:vlanid;
           description
             "The Local VID after translation received at the ISS or
             EISS.";
@@ -1716,7 +1716,7 @@ module ieee802-dot1q-bridge {
             "IEEE 802.1Q-2017 Clause 12.10.1.8, 6.9";
         }
         leaf relay-vid {
-          type ieee:vlanid;
+          type dot1qtypes:vlanid;
           description
             "The Relay VID received before translation received at
             ISS or EISS.";
@@ -1739,7 +1739,7 @@ module ieee802-dot1q-bridge {
         	VID is configured, then it is assumed that the local VID
         	is the same value as the relay VID.";
         leaf relay-vid {
-          type ieee:vlanid;
+          type dot1qtypes:vlanid;
           description
             "The Relay VID received before translation received at
             ISS or EISS.";
@@ -1747,7 +1747,7 @@ module ieee802-dot1q-bridge {
             "IEEE 802.1Q-2017 Clause 12.10.1.9, 6.9";
         }
         leaf local-vid {
-          type ieee:vlanid;
+          type dot1qtypes:vlanid;
           description
             "The Local VID after translation received at the ISS or
             EISS.";

--- a/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
@@ -5,7 +5,7 @@ module ieee802-dot1q-pb {
 
   import ieee802-dot1q-bridge { prefix dot1q; }
   import ieee802-dot1q-types { prefix "dot1qtypes"; }
-  import ieee802-types { prefix "ieee"; }
+  //import ieee802-types { prefix "ieee"; }
   import ietf-interfaces { prefix "if"; }
 
   organization
@@ -44,7 +44,7 @@ module ieee802-dot1q-pb {
       "Augment the interface model with 802.1Q Bridge Port
       configuration specific nodes.";
     leaf svid {
-      type ieee:vlanid;
+      type dot1qtypes:vlanid;
       description
         "Service VLAN identifier.";
       reference
@@ -72,7 +72,7 @@ module ieee802-dot1q-pb {
               C-VLAN (if it is desired that frames forwarded to that
               port are transmitted untagged for this C-VLAN).";
       leaf cvid {
-        type ieee:vlanid;
+        type dot1qtypes:vlanid;
         description
           "Customer VLAN identifiers associated with this bridge
           port.";
@@ -80,7 +80,7 @@ module ieee802-dot1q-pb {
           "IEEE 802.1Q-2017 Clause 12.13.2.1";
       }
       leaf svid {
-        type ieee:vlanid;
+        type dot1qtypes:vlanid;
         description
           "Service VLAN identifier.";
         reference
@@ -120,7 +120,7 @@ module ieee802-dot1q-pb {
         Priority Regeneration Table (12.6.2) for each internal CNP
         connected to the C-VLAN component associated with the CEP.";
       leaf svid {
-        type ieee:vlanid;
+        type dot1qtypes:vlanid;
         description
           "Service VLAN identifier.";
         reference
@@ -151,7 +151,7 @@ module ieee802-dot1q-pb {
       	port. This Port-mapping S-VLAN component includes one internal
         PNP.";
       leaf external-svid {
-        type ieee:vlanid;
+        type dot1qtypes:vlanid;
         description
           "External Service VLAN identifier.";
         reference
@@ -165,7 +165,7 @@ module ieee802-dot1q-pb {
           "IEEE 802.1Q-2017 Clause 12.13.3.2";
       }
       leaf internal-svid {
-        type ieee:vlanid;
+        type dot1qtypes:vlanid;
         description
           "Internal Service VLAN Identifier (not applicable for a
           C-tagged RCSI).";

--- a/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
@@ -4,7 +4,6 @@ module ieee802-dot1q-types {
   prefix "dot1q-types";
 
   import ietf-yang-types { prefix "yang"; }
-  import ieee802-types { prefix "ieee"; }
 
   organization
     "Institute of Electrical and Electronics Engineers";
@@ -27,10 +26,10 @@ module ieee802-dot1q-types {
   description
     "Common types used within dot1Q-bridge modules.";
   
-  revision 2017-07-20 {
+  revision 2017-10-16 {
     description
       "Updates based upon comment resolution on draft
-      D1.1 of P802.1Qcp.";
+      D1.3 of P802.1Qcp.";
     reference
       "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
       Virtual Bridged Local Area Networks.";
@@ -134,7 +133,21 @@ module ieee802-dot1q-types {
     	range 1 to 4094, and included in the list in non overlapping
     	ascending order.
     	
-    	For example: 1,10-100,50,500-1000";
+    	For example: 1,10-100,250,500-1000";
+  }
+  
+  typedef vlanid {
+    type uint16 {
+      range "1..4094";
+    }
+    description
+      "The vlanid type uniquely identifies a VLAN. This is the 12-bit
+      VLAN-ID used in the VLAN Tag header. The range is defined by
+      the referenced specification. This type is in the value set and
+      its semantics equivalent to the VlanId textual convention of
+      the SMIv2.";
+    reference
+      "IEEE Std 802.1Q-2017: Virtual Bridged Local Area Networks.";
   }
 
   typedef vlan-index-type {
@@ -168,19 +181,19 @@ module ieee802-dot1q-types {
     type enumeration {
       enum 8P0D {
         description
-          "8 priorities, 0 discard";
+          "8 priorities, 0 drop eligible";
       }
       enum 7P1D {
         description
-          "7 priorities, 1 discard";
+          "7 priorities, 1 drop eligible";
       }
       enum 6P2D {
         description
-          "6 priorities, 2 discards";
+          "6 priorities, 2 drop eligible";
       }
       enum 5P3D {
         description
-          "5 priorities, 3 discards";
+          "5 priorities, 3 drop eligible";
       }
     }
     description
@@ -267,7 +280,7 @@ module ieee802-dot1q-types {
         "VLAN type";
     }
     leaf vlan-id {
-      type ieee:vlanid;
+      type vlanid;
       mandatory true;
       description
         "VLAN Id";
@@ -287,7 +300,7 @@ module ieee802-dot1q-types {
     }
     leaf vlan-id {
       type union {
-        type ieee:vlanid;
+        type vlanid;
         type enumeration {
           enum "any" {
             value 4095;

--- a/standard/ieee/802.1/draft/ieee802-dot1x.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1x.yang
@@ -6,8 +6,8 @@ module ieee802-dot1x {
   import ieee802-types { prefix "ieee"; }
   import ietf-yang-types { prefix "yang"; }
   import ietf-interfaces { prefix "if"; }
-  import ietf-system { prefix "system"; }
-  import iana-if-type { prefix "ianaif"; }
+  import ietf-system { prefix "sys"; }
+  import iana-if-type { prefix "ianaift"; }
 
   organization
     "Institute of Electrical and Electronics Engineers";
@@ -39,7 +39,7 @@ module ieee802-dot1x {
     restarting) authentication exchanges and MKA operation, based on
     a data model described in a set of YANG modules.";
   
-  revision 2017-07-20 {
+  revision 2017-10-15 {
     description
       "Updates based upon comment resolution on draft
       D1.1 of P802.1Xck.";
@@ -115,7 +115,7 @@ module ieee802-dot1x {
 
   typedef pae-system-ref {
     type leafref {
-      path "/system:system/dot1x:pae-system/dot1x:name";
+      path "/sys:system/dot1x:pae-system/dot1x:name";
     }
     description
       "This type is used by data models that need to reference
@@ -318,12 +318,13 @@ module ieee802-dot1x {
 
   grouping nid-group {
     description
-      "The PAE NID Group configuration inforamtion.";
+      "The PAE NID Group configuration and operational inforamtion.";
     list pae-nid-group {
       key "nid";
       description
-        "A list that contains the configuration nodes for the network
-        announcement information for the Logon Process.";
+        "A list that contains the configuration and operational
+      	nodes for the network announcement information for the
+      	Logon Process.";
       leaf nid {
         type pae-nid;
         description
@@ -447,26 +448,10 @@ module ieee802-dot1x {
         reference
           "IEEE 802.1X-2010 Clause 10.1";
       }
-    }
-  }
-
-  grouping nid-group-state {
-    description
-      "The PAE NID Group state information.";
-    list pae-nid-group-state {
-      key "nid";
-      description
-        "A list that contains the operational state nodes for the
-        network announcement information for the Logon Process.";
-      leaf nid {
-        type pae-nid;
-        description
-          "Identification of the network or network service.";
-        reference
-          "IEEE 802.1X-2010 Clause 12.5";
-      }
+      
       leaf kmd {
         type pae-kmd;
+        config false;
         description
           "The Key Management Domain for the NID.";
         reference
@@ -542,14 +527,14 @@ module ieee802-dot1x {
    * Configuration objects used by 802.1X YANG module
    * ---------------------------------------------------
    */
-  augment "/system:system" {
+  augment "/sys:system" {
     description
       "Augment system with 802.1X PAE System specific configuration
       nodes.";
     container pae-system {
       description
         "Contains all 802.1X PAE System specific related
-        configuration.";
+        configuration and operational data.";
       leaf name {
         type string;
         description
@@ -608,19 +593,9 @@ module ieee802-dot1x {
         reference
           "IEEE 802.1X-2010 Clause 12.9.1";
       }
-    }
-  }
-
-  augment "/system:system-state" {
-    description
-      "Augment system-state model with 802.1X PAE System specific
-      operational state nodes.";
-    container pae-system {
-      description
-        "Contains all 802.1X specific operational state related
-        nodes.";
       leaf eapol-protocol-version {
         type uint32;
+        config false;
         description
           "The EAPOL protocol version for this system.";
         reference
@@ -628,6 +603,7 @@ module ieee802-dot1x {
       }
       leaf mka-version {
         type uint32;
+        config false;
         description
           "The MKA protocol version for this system.";
         reference
@@ -635,6 +611,7 @@ module ieee802-dot1x {
       }
       leaf-list pae {
         type if:interface-ref;
+        config false;
         description
           "List of PAE references.";
       }
@@ -645,39 +622,27 @@ module ieee802-dot1x {
    *  Port Authentication Entity (PAE) Nodes
    */
   augment "/if:interfaces/if:interface" {
-    when "if:type = 'ianaif:ethernetCsmacd' or
-          if:type = 'ianaif:ilan'" {
+    when "if:type = 'ianaift:ethernetCsmacd' or
+          if:type = 'ianaift:ilan' or
+          if:type = 'ianaift:macSecControlledIF' or
+          if:type = 'ianaift:ptm'" {
       description
-        "Applies to the Controlled Port of SecY or PAC shim.";
+        "Applies to the Controlled Port of SecY or PAC shim or
+      	Ethernet related Interface.";
     }
     description
-      "Augment interface model with PAE configuration nodes.";
+      "Augment interface model with PAE configuration and
+    	operational nodes.";
     reference
       "IEEE 802.1AE Clause 11.7 and IEEE 802.1X-2010 Clause 6.5 and
       Clause 13.3.2";
     container pae {
       description
-        "Contains PAE configuration related nodes.";
+        "Contains PAE configuration and operational related nodes.";
       leaf pae-system {
         type dot1x:pae-system-ref;
         description
           "The PAE system that this PAE is a member of.";
-      }
-      leaf port-type {
-      	type enumeration {
-          enum real-port {
-            description
-              "Real Port type.";
-          }
-          enum virtual-port {
-            description
-              "Virtual Port type.";
-          }
-        }
-        description
-          "The port type of the PAE.";
-        reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
       }
       leaf vp-enable {
         when "../port-type = 'real-port' and
@@ -699,6 +664,150 @@ module ieee802-dot1x {
         description
           "Per port PAE feature capabilities.";
         uses port-capabilities;
+      }
+      
+      leaf port-name {
+        type if:interface-ref;
+        config false;
+        description
+          "Each PAE is uniquely identified by a port name.";
+        }
+      leaf port-number {
+        type pae-if-index;
+        config false;
+        description
+          "Each PAE is uniquely identified by a port number. The
+          port number used is unique amongst all port names for the
+          system, and directly or indirectly identifies the
+          Uncontrolled Port that supports the PAE. If the PAE has
+          been dynamically instantiated to support an existing or
+          potential virtual port, this portNumber, the
+          uncontrolledPortNumber and the controlledPortNumber are
+          allocated by the real ports PAE, and this portNumber is the
+          uncontrolledPortNumber. If the PAE supports a real port,
+          this portNumber is the commonPortNumber for the associated
+          PAC or SecY.";
+        reference
+          "IEEE 802.1X-2010 Clause 12.9.2";
+        }
+      leaf controlled-port-name {
+        type if:interface-ref;
+        config false;
+        description
+          "Each PAE is uniquely identified by a port name.";
+      }
+      leaf controlled-port-number {
+        type pae-if-index;
+        config false;
+        description
+          "The port for the associated PAC or SecYs Controlled
+          Port.";
+        reference
+          "IEEE 802.1X-2010 Clause 12.9.2";
+      }
+      leaf uncontrolled-port-name {
+        type if:interface-ref;
+        config false;
+        description
+          "The uncontrolled port name reference.";
+      }
+      leaf uncontrolled-port-number {
+        type pae-if-index;
+        config false;
+        description
+          "The port for the associated PAC or SecYs Uncontrolled
+          Port.";
+        reference
+          "IEEE 802.1X-2010 Clause 12.9.2";
+      }
+      leaf common-port-name {
+        type if:interface-ref;
+        config false;
+        description
+          "The common port name reference.";
+      }
+      leaf common-port-number {
+        type pae-if-index;
+        config false;
+        description
+          "The port for the associated PAC or SecYs Common Port. All
+          the virtual ports created for a given real port share the
+          same Common Port and commonPortNumber.";
+        reference
+          "IEEE 802.1X-2010 Clause 12.9.2";
+      }
+      leaf port-type {
+        type enumeration {
+          enum real-port {
+            description
+              "Real Port type.";
+          }
+          enum virtual-port {
+            description
+              "Virtual Port type.";
+          }
+        }
+        //config false;
+        description
+          "The port type of the PAE.";
+        reference
+          "IEEE 802.1X-2010 Clause 12.9.2";
+      }
+      container virtual-port {
+        when "../port-capabilities/virtual-ports = 'true'" {
+          description
+            "Applies when the virtual ports port capability is
+            supported.";
+        }
+        config false;
+        description
+          "Contains Virtual Port operational state information.";
+        leaf max {
+          when "../../port-type = 'real-port'" {
+            description
+              "Applies when Port is a Real Port.";
+          }
+          type uint32;
+          description
+            "The guaranteed maximum number of virtual ports.";
+          reference
+            "IEEE 802.1X-2010 Clause 12.9.2";
+        }
+        leaf current {
+          when "../../port-type = 'real-port'" {
+            description
+              "Applies when Port is a Real Port.";
+          }
+          type yang:gauge32;
+          description
+            "The current number of virtual ports.";
+          reference
+            "IEEE 802.1X-2010 Clause 12.9.2";
+        }
+        leaf start {
+          when "../../port-type = 'virtual-port'" {
+            description
+              "Applies when Port is a Virtual Port.";
+          }
+          type uint32;
+          description
+            "Set if the virtual port was created by receipt of an
+            EAPOL-Start frame.";
+          reference
+            "IEEE 802.1X-2010 Clause 12.9.7";
+        }
+        leaf peer-address {
+          when "../../port-type = 'virtual-port'" {
+            description
+              "Applies when Port is a Virtual Port.";
+          }
+          type ieee:mac-address;
+          description
+            "The source MAC Address of the EAPOL-Start (if vpStart is
+            set).";
+          reference
+            "IEEE 802.1X-2010 Clause 12.9.7";
+        }
       }
 
       container supplicant {
@@ -733,6 +842,57 @@ module ieee802-dot1x {
             unauthorized.";
           reference
             "IEEE 802.1X-2010 Clause 8.7";
+        }
+        
+        leaf enabled {
+          type boolean;
+          config false;
+          description
+            "Set by PACP if the PAE can provide authentication. Will
+            be FALSE if the Port is not enabled, if the functionality
+            provided by the PAE is not available, or not implemented,
+            or the control variable enable has been cleared by
+            management, e.g. because the application scenario
+            authenticates a user and there is no user logged on.";
+          reference
+            "IEEE 802.1X-2010 Clause 8.4";
+        }
+        leaf authenticate {
+          type boolean;
+          config false;
+          description
+            "Set by the PAE client to request authentication, and
+            allows reauthentication while set. Cleared by the client
+            to revoke authentication. To enable authentication the
+            client also needs to clear failed (if set).";
+          reference
+            "IEEE 802.1X-2010 Clause 8.4";
+        }
+        leaf authenticated {
+          type boolean;
+          config false;
+          description
+            "Set by PACP if the PAE is currently authenticated, and
+            cleared if the authentication fails or is revoked.";
+          reference
+            "IEEE 802.1X-2010 Clause 8.4";
+        }
+        leaf failed {
+          type boolean;
+          config false;
+          description
+            "Set by PACP if the authentication has failed or has been
+            terminated. The cause could be a Fail returned by EAP,
+            either immediately or following a reauthentication, an
+            excessive number of attempts to authenticate (either
+            immediately or upon reauthentication), or the client
+            deasserting authenticate. The PACP will clear
+            authenticated as well as setting failed. Any ongoing
+            authentication exchange will be terminated (by the state
+            machines) if enable becomes FALSE and enabled will be
+            cleared, but failed will not be set.";
+          reference
+            "IEEE 802.1X-2010 Clause 8.4";
         }
       }
 
@@ -785,6 +945,57 @@ module ieee802-dot1x {
           reference
             "IEEE 802.1X-2010 Clause 8.9";
         }
+        
+        leaf enabled {
+          type boolean;
+          config false;
+          description
+            "Set by PACP if the PAE can provide authentication. Will
+            be FALSE if the Port is not enabled, if the functionality
+            provided by the PAE is not available, or not implemented,
+            or the control variable enable has been cleared by
+            management, e.g. because the application scenario
+            authenticates a user and there is no user logged on.";
+          reference
+            "IEEE 802.1X-2010 Clause 8.4";
+        }
+        leaf authenticate {
+          type boolean;
+          config false;
+          description
+            "Set by the PAE client to request authentication, and
+            allows reauthentication while set. Cleared by the client
+            to revoke authentication. To enable authentication the
+            client also needs to clear failed (if set).";
+          reference
+            "IEEE 802.1X-2010 Clause 8.4";
+        }
+        leaf authenticated {
+          type boolean;
+          config false;
+          description
+            "Set by PACP if the PAE is currently authenticated, and
+            cleared if the authentication fails or is revoked.";
+          reference
+            "IEEE 802.1X-2010 Clause 8.4";
+        }
+        leaf failed {
+          type boolean;
+          config false;
+          description
+            "Set by PACP if the authentication has failed or has been
+            terminated. The cause could be a Fail returned by EAP,
+            either immediately or following a reauthentication, an
+            excessive number of attempts to authenticate (either
+            immediately or upon reauthentication), or the client
+            deasserting authenticate. The PACP will clear
+            authenticated as well as setting failed. Any ongoing
+            authentication exchange will be terminated (by the state
+            machines) if enable becomes FALSE and enabled will be
+            cleared, but failed will not be set.";
+          reference
+            "IEEE 802.1X-2010 Clause 8.4";
+        }
       }
 
       container kay {
@@ -806,7 +1017,8 @@ module ieee802-dot1x {
         }
         container actor {
           description
-            "Contains configuration nodes associated with the actor";
+            "Contains configuration and operational nodes 
+          	associated with the actor";
           leaf priority {
             type uint8;
             description
@@ -814,10 +1026,20 @@ module ieee802-dot1x {
             reference
               "IEEE 802.1X-2010 Clause 9.16";
           }
+          leaf sci {
+            type sci-list-entry;
+            config false;
+            description
+              "The SCI assigned by the system to the port (applies
+              to all the ports actors).";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
         }
         container key-server {
           description
-            "Contains configuration nodes associated with the key
+            "Contains configuration and operational nodes
+          	associated with the key
             server.";
           leaf priority {
             type uint8;
@@ -825,6 +1047,17 @@ module ieee802-dot1x {
               "The Key Server Priority for the Key Server for the
               principal actor. Matches the actorPriority if the
               actor is the Key Server";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf sci {
+            type sci-list-entry;
+            config false;
+            description
+              "The SCI for Key Server for the principal actor. Null
+              if there is no principal actor, or that actor has no
+              live peers. Matches the actorSCI if the actor is the
+              Key Server.";
             reference
               "IEEE 802.1X-2010 Clause 9.16";
           }
@@ -864,6 +1097,7 @@ module ieee802-dot1x {
               "IEEE 802.1X-2010 Clause 9.16";
           }
         }
+        
         container macsec {
           when "../../port-capabilities/macsec = 'true'" {
             description
@@ -871,7 +1105,8 @@ module ieee802-dot1x {
               supported.";
           }
           description
-            "Contains configuration nodes associated with macsec.";
+            "Contains configuration and operational nodes
+          	associated with macsec.";
           leaf capable {
             type boolean;
             description
@@ -886,6 +1121,31 @@ module ieee802-dot1x {
             description
               "Set for the port and applicable to all actors, by
               management.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          
+          leaf protect {
+            type boolean;
+            config false;
+            description
+              "As used by the CP state machine, see 12.4.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf validate {
+            type boolean;
+            config false;
+            description
+              "As used by the CP state machine, see 12.4.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf replay-protect {
+            type boolean;
+            config false;
+            description
+              "As used by the CP state machine, see 12.4.";
             reference
               "IEEE 802.1X-2010 Clause 9.16";
           }
@@ -910,12 +1170,111 @@ module ieee802-dot1x {
           reference
             "IEEE 802.1X-2010 Clause 9.18";
         }
+        
+        leaf suspended-while {
+          type uint8;
+          config false;
+          description
+            "Read by management to determine if a suspension is in
+            progress and (when available) to discover the remaining
+            duration of that suspension";
+          reference
+            "IEEE 802.1X-2010 Clause 9.18";
+        }
+        leaf active {
+          type boolean;
+          config false;
+          description
+            "Set if there is at least one active actor, transmitting
+            MKPDUs.";
+          reference
+            "IEEE 802.1X-2010 Clause 9.16";
+        }
+        leaf authenticated {
+          type boolean;
+          config false;
+          description
+            "Set if the principal actor, i.e. the participant that
+            has the highest priority Key Server and one or more live
+            peers, has determined that Controlled Port communication
+            should proceed without MACsec.";
+          reference
+            "IEEE 802.1X-2010 Clause 9.16";
+        }
+        leaf secured {
+          type boolean;
+          config false;
+          description
+            "Set if the principal actor has determined that
+            communication should use MACsec.";
+          reference
+            "IEEE 802.1X-2010 Clause 9.16";
+        }
+        leaf failed {
+          type boolean;
+          config false;
+          description
+            "Cleared when authenticated or secured are set, set if
+            the latter are clear and MKA Life Time has elapsed since
+            an MKA participant was last created.";
+          reference
+            "IEEE 802.1X-2010 Clause 9.16";
+        }
+        container key-number {
+        	config false;
+          description
+            "Contains operation state nodes for Key Numbers.";
+          leaf tx {
+            type mak-kn;
+            description
+              "The Key Number assigned by the Key Server to the SAK
+              currently being used for transmission. Null if MACsec
+              is not being used.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf rx {
+            type mak-kn;
+            description
+              "The Key Number assigned by the Key Server to the
+              oldest SAK currently being used for reception. The same
+              as txKN if a single SAK is currently in use (as will
+              most often be the case). Null if MACsec is not being
+              used.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+        }
+        container association-number {
+        	config false;
+          description
+            "Contains operation state nodes for Association
+            Numbers.";
+          leaf tx {
+            type mak-an;
+            description
+              "The Association Number assigned by the Key Server for
+              use with txKN. Zero if MACsec is not in use.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf rx {
+            type mak-an;
+            description
+              "The Association Number assigned by the Key Server for
+              use with rxKN. The same as txAN if a single SAK is
+              currently in use. Zero if MACsec is not in use.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+        }
 
         list participants {
           key "participant";
           description
-            "Contains list of configuration nodes for each MKA
-            participant supported by the KaY MKA entity.";
+            "Contains list of configuration and operational nodes
+          	for each MKA participant supported by the KaY MKA
+          	entity.";
           leaf participant {
             type uint32;
             description
@@ -995,15 +1354,92 @@ module ieee802-dot1x {
             reference
               "IEEE 802.1X-2010 Clause 9.16";
           }
+          
+          container peers {
+          	config false;
+            description
+              "Contains operational state nodes associated with the
+              Peers.";
+            leaf-list live {
+              type sci-list-entry;
+                description
+                  "A list of the SCIs of the participants live
+                  peers.";
+                reference
+                  "IEEE 802.1X-2010 Clause 9.16";
+            }
+            leaf-list potential {
+              type sci-list-entry;
+              description
+                "A list of the SCIs of the participants potential
+                peers.";
+              reference
+                "IEEE 802.1X-2010 Clause 9.16";
+            }
+          }
+          leaf ckn {
+            type pae-ckn;
+            config false;
+            description
+              "The secure Connectivity Association Key Name for the
+              participant.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf kmd {
+            type pae-kmd;
+            config false;
+            description
+              "The Key Management Domain for the participant.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf nid {
+            type pae-nid;
+            config false;
+            description
+              "The NID for the participant.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf auth-data {
+            type pae-auth-data;
+            config false;
+            description
+              "Authorization data associated with the secure
+              Connectivity Association Key.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf principal {
+            type boolean;
+            config false;
+            description
+              "Set if the participant is currently the principal
+              actor.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
+          leaf dist-ckn {
+            type pae-ckn;
+            config false;
+            description
+              "The CKN for the last CAK distributed (either by the
+              actor or one of its partners). Null if this participant
+              has not been used to distribute a CAK.";
+            reference
+              "IEEE 802.1X-2010 Clause 9.16";
+          }
         }
       }
 
       container logon-nid {
         description
-          "Contains the configuration related NID information for the
-          Logon Process. The Logon Process may use Network
-          Identifiers (NIDs) to manage its use of authentication
-          credentials, cached CAKs, and announcements.";
+          "Contains the configuration and operational related NID
+        	information for the Logon Process. The Logon Process may
+        	use Network Identifiers (NIDs) to manage its use of
+        	authentication credentials, cached CAKs, and 
+        	announcements.";
         leaf selected {
           type pae-nid;
           description
@@ -1014,6 +1450,27 @@ module ieee802-dot1x {
             "IEEE 802.1X-2010 Clause 12.5";
         }
         uses nid-group;
+        
+        leaf connected {
+          type pae-nid;
+          config false;
+          description
+            "The NID associated with the current connectivity
+            (possibly unauthenticated) provided by the operation of
+            the CP state machine.";
+          reference
+            "IEEE 802.1X-2010 Clause 12.5";
+        }
+        leaf requested {
+          type pae-nid;
+          config false;
+          description
+            "The NID marked as Access requested in announcements, as
+            determined from EAPOL-Start frames. Defaults to the
+            selectedNID.";
+          reference
+            "IEEE 802.1X-2010 Clause 12.5";
+        }
       }
 
       container announcer {
@@ -1046,6 +1503,26 @@ module ieee802-dot1x {
               "Key into Announce list.";
           }
           uses nid-group;
+          
+          leaf nid {
+            type pae-nid;
+            config false;
+            description
+              "The NID information to identify a received network
+              announcement for the PAE.";
+            reference
+              "IEEE 802.1X-2010 Clause 10.4";
+          }
+          leaf access-status {
+            type pae-access-status;
+            config false;
+            description
+              "Access Status reflects connectivity as a result of
+              authentication attempts, and might be set directly by
+              the system or configured by AAA protocols.";
+            reference
+              "IEEE 802.1X-2010 Clause 10.4, Clause 12.5";
+          }
         }
       }
 
@@ -1056,8 +1533,8 @@ module ieee802-dot1x {
             supported.";
         }
         description
-          "Contains the configuration Listener node related
-          information.";
+          "Contains the configuration and operational Listener
+        	node related information.";
         leaf enable {
           type boolean;
           default "false";
@@ -1067,614 +1544,10 @@ module ieee802-dot1x {
           reference
             "IEEE 802.1X-2010 Clause 10.4";
         }
-      }
-
-      container logon-process {
-        description
-          "Contains configuration system level information for each
-          port to support the Logon Process(es) status information.";
-        leaf logon {
-          type boolean;
-          default "false";
-          description
-            "A boolean indicating if the logon-process is enabled or
-            not.";
-          reference
-            "IEEE 802.1X-2010 Clause 12.5";
-        }
-      }
-    }
-  }
-
-  augment "/if:interfaces-state/if:interface" {
-    when "if:type = 'ianaif:ethernetCsmacd' or
-          if:type = 'ianaif:ilan'" {
-      description
-        "Applies to the Controlled Port of SecY or PAC shim.";
-      }
-    description
-      "Augment interface-state model with PAE configuration nodes.";
-    reference
-      "IEEE 802.1AE Clause 11.7 and IEEE 802.1X-2010 Clause 6.5 and
-      Clause 13.3.2.";
-    container pae {
-      description
-        "Contains PAE operational state related nodes.";
-      leaf port-name {
-        type if:interface-ref;
-        description
-          "Each PAE is uniquely identified by a port name.";
-        }
-      leaf port-number {
-        type pae-if-index;
-        description
-          "Each PAE is uniquely identified by a port number. The
-          port number used is unique amongst all port names for the
-          system, and directly or indirectly identifies the
-          Uncontrolled Port that supports the PAE. If the PAE has
-          been dynamically instantiated to support an existing or
-          potential virtual port, this portNumber, the
-          uncontrolledPortNumber and the controlledPortNumber are
-          allocated by the real ports PAE, and this portNumber is the
-          uncontrolledPortNumber. If the PAE supports a real port,
-          this portNumber is the commonPortNumber for the associated
-          PAC or SecY.";
-        reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
-        }
-      leaf controlled-port-name {
-        type if:interface-ref;
-        description
-          "Each PAE is uniquely identified by a port name.";
-      }
-      leaf controlled-port-number {
-        type pae-if-index;
-        description
-          "The port for the associated PAC or SecYs Controlled
-          Port.";
-        reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
-      }
-      leaf uncontrolled-port-name {
-        type if:interface-ref;
-        description
-          "The uncontrolled port name reference.";
-      }
-      leaf uncontrolled-port-number {
-        type pae-if-index;
-        description
-          "The port for the associated PAC or SecYs Uncontrolled
-          Port.";
-        reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
-      }
-      leaf common-port-name {
-        type if:interface-ref;
-        description
-          "The common port name reference.";
-      }
-      leaf common-port-number {
-        type pae-if-index;
-        description
-          "The port for the associated PAC or SecYs Common Port. All
-          the virtual ports created for a given real port share the
-          same Common Port and commonPortNumber.";
-        reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
-      }
-      container port-capabilities {
-        description
-          "Per port PAE feature capabilities.";
-        uses port-capabilities;
-      }
-      leaf port-type {
-        type enumeration {
-          enum real-port {
-            description
-              "Real Port type.";
-          }
-          enum virtual-port {
-            description
-              "Virtual Port type.";
-          }
-        }
-        description
-          "The port type of the PAE.";
-        reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
-      }
-      container virtual-port {
-        when "../port-capabilities/virtual-ports = 'true'" {
-          description
-            "Applies when the virtual ports port capability is
-            supported.";
-        }
-        description
-          "Contains Virtual Port operational state information.";
-        leaf max {
-          when "../../port-type = 'real-port'" {
-            description
-              "Applies when Port is a Real Port.";
-          }
-          type uint32;
-          description
-            "The guaranteed maximum number of virtual ports.";
-          reference
-            "IEEE 802.1X-2010 Clause 12.9.2";
-        }
-        leaf current {
-          when "../../port-type = 'real-port'" {
-            description
-              "Applies when Port is a Real Port.";
-          }
-          type yang:gauge32;
-          description
-            "The current number of virtual ports.";
-          reference
-            "IEEE 802.1X-2010 Clause 12.9.2";
-        }
-        leaf start {
-          when "../../port-type = 'virtual-port'" {
-            description
-              "Applies when Port is a Virtual Port.";
-          }
-          type uint32;
-          description
-            "Set if the virtual port was created by receipt of an
-            EAPOL-Start frame.";
-          reference
-            "IEEE 802.1X-2010 Clause 12.9.7";
-        }
-        leaf peer-address {
-          when "../../port-type = 'virtual-port'" {
-            description
-              "Applies when Port is a Virtual Port.";
-          }
-          type ieee:mac-address;
-          description
-            "The source MAC Address of the EAPOL-Start (if vpStart is
-            set).";
-          reference
-            "IEEE 802.1X-2010 Clause 12.9.7";
-        }
-      }
-
-      container supplicant {
-        // Suppplicant only applicable to RealPort types.
-        when "../port-type = 'real-port' and
-              ../port-capabilities/supp = 'true'" {
-          description
-            "Applies when Port is a Real Port and the Supplicant
-            port capability is supported.";
-        }
-        description
-          "Contains the operational state nodes for the Supplicant
-          PAE associated with each port.";
-        leaf enabled {
-          type boolean;
-          description
-            "Set by PACP if the PAE can provide authentication. Will
-            be FALSE if the Port is not enabled, if the functionality
-            provided by the PAE is not available, or not implemented,
-            or the control variable enable has been cleared by
-            management, e.g. because the application scenario
-            authenticates a user and there is no user logged on.";
-          reference
-            "IEEE 802.1X-2010 Clause 8.4";
-        }
-        leaf authenticate {
-          type boolean;
-          description
-            "Set by the PAE client to request authentication, and
-            allows reauthentication while set. Cleared by the client
-            to revoke authentication. To enable authentication the
-            client also needs to clear failed (if set).";
-          reference
-            "IEEE 802.1X-2010 Clause 8.4";
-        }
-        leaf authenticated {
-          type boolean;
-          description
-            "Set by PACP if the PAE is currently authenticated, and
-            cleared if the authentication fails or is revoked.";
-          reference
-            "IEEE 802.1X-2010 Clause 8.4";
-        }
-        leaf failed {
-          type boolean;
-          description
-            "Set by PACP if the authentication has failed or has been
-            terminated. The cause could be a Fail returned by EAP,
-            either immediately or following a reauthentication, an
-            excessive number of attempts to authenticate (either
-            immediately or upon reauthentication), or the client
-            deasserting authenticate. The PACP will clear
-            authenticated as well as setting failed. Any ongoing
-            authentication exchange will be terminated (by the state
-            machines) if enable becomes FALSE and enabled will be
-            cleared, but failed will not be set.";
-          reference
-            "IEEE 802.1X-2010 Clause 8.4";
-        }
-      }
-
-      container authenticator {
-        when "../port-capabilities/auth = 'true'" {
-          description
-            "Applies when the Authenticator port capability feature
-            is supported.";
-        }
-        description
-          "Contains operational state nodes for the Authenticator
-          PAE associated with each port.";
-        leaf enabled {
-          type boolean;
-          description
-            "Set by PACP if the PAE can provide authentication. Will
-            be FALSE if the Port is not enabled, if the functionality
-            provided by the PAE is not available, or not implemented,
-            or the control variable enable has been cleared by
-            management, e.g. because the application scenario
-            authenticates a user and there is no user logged on.";
-          reference
-            "IEEE 802.1X-2010 Clause 8.4";
-        }
-        leaf authenticate {
-          type boolean;
-          description
-            "Set by the PAE client to request authentication, and
-            allows reauthentication while set. Cleared by the client
-            to revoke authentication. To enable authentication the
-            client also needs to clear failed (if set).";
-          reference
-            "IEEE 802.1X-2010 Clause 8.4";
-        }
-        leaf authenticated {
-          type boolean;
-          description
-            "Set by PACP if the PAE is currently authenticated, and
-            cleared if the authentication fails or is revoked.";
-          reference
-            "IEEE 802.1X-2010 Clause 8.4";
-        }
-        leaf failed {
-          type boolean;
-          description
-            "Set by PACP if the authentication has failed or has been
-            terminated. The cause could be a Fail returned by EAP,
-            either immediately or following a reauthentication, an
-            excessive number of attempts to authenticate (either
-            immediately or upon reauthentication), or the client
-            deasserting authenticate. The PACP will clear
-            authenticated as well as setting failed. Any ongoing
-            authentication exchange will be terminated (by the state
-            machines) if enable becomes FALSE and enabled will be
-            cleared, but failed will not be set.";
-          reference
-            "IEEE 802.1X-2010 Clause 8.4";
-        }
-      }
-
-      container kay {
-        when "../port-capabilities/mka = 'true'" {
-          description
-            "Applies when the MKA port capability feature is
-            supported.";
-        }
-        description
-          "Contains operational state system level information for
-          each Interface supported by the KaY (Key Aggreement
-          Entity).";
-        container actor {
-          description
-            "Contains operational state nodes associated with the
-            actor";
-          leaf sci {
-            type sci-list-entry;
-            description
-              "The SCI assigned by the system to the port (applies
-              to all the ports actors).";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-        }
-        container key-server {
-          description
-            "Contains operational state nodes associated with the
-            key server.";
-          leaf sci {
-            type sci-list-entry;
-            description
-              "The SCI for Key Server for the principal actor. Null
-              if there is no principal actor, or that actor has no
-              live peers. Matches the actorSCI if the actor is the
-              Key Server.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-        }
-        container macsec {
-          when "../../port-capabilities/macsec = 'true'" {
-            description
-              "Applies when the MACsec port capability feature is
-              supported.";
-          }
-          description
-            "Contains operational state nodes associated with
-            macsec.";
-          leaf protect {
-            type boolean;
-            description
-              "As used by the CP state machine, see 12.4.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf validate {
-            type boolean;
-            description
-              "As used by the CP state machine, see 12.4.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf replay-protect {
-            type boolean;
-            description
-              "As used by the CP state machine, see 12.4.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-        }
-        leaf suspended-while {
-          type uint8;
-          description
-            "Read by management to determine if a suspension is in
-            progress and (when available) to discover the remaining
-            duration of that suspension";
-          reference
-            "IEEE 802.1X-2010 Clause 9.18";
-        }
-        leaf active {
-          type boolean;
-          description
-            "Set if there is at least one active actor, transmitting
-            MKPDUs.";
-          reference
-            "IEEE 802.1X-2010 Clause 9.16";
-        }
-        leaf authenticated {
-          type boolean;
-          description
-            "Set if the principal actor, i.e. the participant that
-            has the highest priority Key Server and one or more live
-            peers, has determined that Controlled Port communication
-            should proceed without MACsec.";
-          reference
-            "IEEE 802.1X-2010 Clause 9.16";
-        }
-        leaf secured {
-          type boolean;
-          description
-            "Set if the principal actor has determined that
-            communication should use MACsec.";
-          reference
-            "IEEE 802.1X-2010 Clause 9.16";
-        }
-        leaf failed {
-          type boolean;
-          description
-            "Cleared when authenticated or secured are set, set if
-            the latter are clear and MKA Life Time has elapsed since
-            an MKA participant was last created.";
-          reference
-            "IEEE 802.1X-2010 Clause 9.16";
-        }
-        container key-number {
-          description
-            "Contains operation state nodes for Key Numbers.";
-          leaf tx {
-            type mak-kn;
-            description
-              "The Key Number assigned by the Key Server to the SAK
-              currently being used for transmission. Null if MACsec
-              is not being used.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf rx {
-            type mak-kn;
-            description
-              "The Key Number assigned by the Key Server to the
-              oldest SAK currently being used for reception. The same
-              as txKN if a single SAK is currently in use (as will
-              most often be the case). Null if MACsec is not being
-              used.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-        }
-        container association-number {
-          description
-            "Contains operation state nodes for Association
-            Numbers.";
-          leaf tx {
-            type mak-an;
-            description
-              "The Association Number assigned by the Key Server for
-              use with txKN. Zero if MACsec is not in use.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf rx {
-            type mak-an;
-            description
-              "The Association Number assigned by the Key Server for
-              use with rxKN. The same as txAN if a single SAK is
-              currently in use. Zero if MACsec is not in use.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-        }
-
-        list participant {
-          key "participants";
-          description
-            "Contains list of operational state nodes for each MKA
-            participant supported by the KaY MKA entity.";
-          leaf participants {
-            type uint32;
-            description
-              "Index into Participants list.";
-          }
-          container peers {
-            description
-              "Contains operational state nodes associated with the
-              Peers.";
-            leaf-list live {
-              type sci-list-entry;
-                description
-                  "A list of the SCIs of the participants live
-                  peers.";
-                reference
-                  "IEEE 802.1X-2010 Clause 9.16";
-            }
-            leaf-list potential {
-              type sci-list-entry;
-              description
-                "A list of the SCIs of the participants potential
-                peers.";
-              reference
-                "IEEE 802.1X-2010 Clause 9.16";
-            }
-          }
-          leaf ckn {
-            type pae-ckn;
-            description
-              "The secure Connectivity Association Key Name for the
-              participant.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf kmd {
-            type pae-kmd;
-            description
-              "The Key Management Domain for the participant.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf nid {
-            type pae-nid;
-            description
-              "The NID for the participant.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf auth-data {
-            type pae-auth-data;
-            description
-              "Authorization data associated with the secure
-              Connectivity Association Key.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf principal {
-            type boolean;
-            description
-              "Set if the participant is currently the principal
-              actor.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-          leaf dist-ckn {
-            type pae-ckn;
-            description
-              "The CKN for the last CAK distributed (either by the
-              actor or one of its partners). Null if this participant
-              has not been used to distribute a CAK.";
-            reference
-              "IEEE 802.1X-2010 Clause 9.16";
-          }
-        }
-      }
-
-      container logon-nid {
-        description
-          "Contains the operation state related NID information for
-          the Logon Process. The Logon Process may use Network
-          Identifiers (NIDs) to manage its use of authentication
-          credentials, cached CAKs, and announcements.";
-        leaf connected {
-          type pae-nid;
-          description
-            "The NID associated with the current connectivity
-            (possibly unauthenticated) provided by the operation of
-            the CP state machine.";
-          reference
-            "IEEE 802.1X-2010 Clause 12.5";
-        }
-        leaf requested {
-          type pae-nid;
-          description
-            "The NID marked as Access requested in announcements, as
-            determined from EAPOL-Start frames. Defaults to the
-            selectedNID.";
-          reference
-            "IEEE 802.1X-2010 Clause 12.5";
-        }
-        uses nid-group-state;
-      }
-
-      container announcer {
-        when "../port-capabilities/announcements = 'true'" {
-          description
-            "Applies when the Announcements port capability feature
-            is supported.";
-        }
-        description
-          "Contains the operational state related Announcer
-          information.";
-        list announce {
-          key "announces";
-          description
-            "Contains the operational state related status
-            information that the Announcers announce in the network
-            announcement of the PAE system.";
-          leaf announces {
-            type uint32;
-            description
-              "Key into Announce list.";
-          }
-          leaf nid {
-            type pae-nid;
-            description
-              "The NID information to identify a received network
-              announcement for the PAE.";
-            reference
-              "IEEE 802.1X-2010 Clause 10.4";
-          }
-          leaf access-status {
-            type pae-access-status;
-            description
-              "Access Status reflects connectivity as a result of
-              authentication attempts, and might be set directly by
-              the system or configured by AAA protocols.";
-            reference
-              "IEEE 802.1X-2010 Clause 10.4, Clause 12.5";
-          }
-          uses nid-group-state;
-        }
-      }
-
-      container listener {
-        when "../port-capabilities/listener = 'true'" {
-          description
-            "Applies when the Listener port capability feature is
-            supported.";
-        }
-        description
-          "Contains the operational state Listener node related
-          information.";
+        
         list announcement {
           key "announcements";
+          config false;
           description
             "A list containing the operational status information
             that the Listeners receive in the network announcement of
@@ -1767,10 +1640,11 @@ module ieee802-dot1x {
                 "Cipher Suite capability.";
             }
           }
-        }
+        }        
       }
-
+      
       container eapol-statistics {
+      	config false;
         description
           "Contains operational EAPOL statics.";
         leaf invalid-eapol-frame-rx {
@@ -1975,8 +1849,19 @@ module ieee802-dot1x {
 
       container logon-process {
         description
-          "Contains operational system level information for each
-          port to support the Logon Process(es) status information.";
+          "Contains configuration and operational system level
+        	information for each port to support the Logon Process(es)
+        	status information.";
+        leaf logon {
+          type boolean;
+          default "false";
+          description
+            "A boolean indicating if the logon-process is enabled or
+            not.";
+          reference
+            "IEEE 802.1X-2010 Clause 12.5";
+        }
+        
         leaf connect {
           type enumeration {
             enum pending {
@@ -2009,6 +1894,7 @@ module ieee802-dot1x {
                 Authenticated.";
             }
           }
+          config false;
           description
             "The Logon Process sets this variable to one of the
             above values.";
@@ -2017,6 +1903,7 @@ module ieee802-dot1x {
         }
         leaf port-valid {
           type boolean;
+          config false;
           description
             "Set if Controlled Port communication is secured as
             specified by the MACsec control macsecProtect.";
@@ -2025,6 +1912,7 @@ module ieee802-dot1x {
         }
         list session-statistics {
           key "session-id";
+          config false;
           description
             "Contains operational state nodes associated with the
             session statistics.";
@@ -2130,7 +2018,6 @@ module ieee802-dot1x {
       "Contains both configuration and operational state nodes
       associated with the PAE NID group.";
     uses nid-group;
-    uses nid-group-state;
   }
 
 }

--- a/standard/ieee/check.sh
+++ b/standard/ieee/check.sh
@@ -3,42 +3,45 @@
 # check script. Assumes that pyang is on path and that
 # all standard modules are on its internal module path.
 #
-base_dir="`pwd`/standard/ieee/"
+base_dir="`pwd`"
 to_check="802.1 802.3"
 
 # relax constraint for now
 # add --ietf if you want to do strict IETF checking
-pyang_flags="--verbose -p ../../../standard/ietf/RFC/ -p ../../../standard/ieee/draft/ -p ../../../standard/ieee/802.1/draft/ -p ../../../standard/ieee/802.3/draft/ "
+#pyang_flags="--verbose --canonical --max-identifier-length 70 ../../../ietf/RFC/ -p ../../draft/"
+pyang_flags="--verbose ../../../ietf/RFC/ -p ../../draft/"
 
-checkDir () {
-    echo Checking yang files in $1
+checkDir () 
+{
+    #echo Checking yang files in $1
     exit_status=""
     cwd=`pwd`
-    cd "$base_dir/$1"
+    cd "$base_dir/$1/draft"
     printf "\n"
     for f in *.yang; do
         printf "pyang $pyang_flags $f\n"
-	errors=`pyang $pyang_flags $f 2>&1 | grep "error:"`
-	if [ ! -z "$errors" ]; then
-	    echo Errors in $f
-            printf "\n  $errors \n"
-	    exit_status="failed!"
-	fi
+        errors=`pyang $pyang_flags $f 2>&1 | grep "error:"`
+        if [ ! -z "$errors" ]; then
+        	echo Errors in $f
+        	printf "\n  $errors \n"
+        	exit_status="failed!"
+        fi
     done
     if [ ! -z "$exit_status" ]; then
-	exit 1
+    	exit 1
     fi
     cd $cwd
 }
 
+# check modules in IEEE 802.* subdirectories
+printf "\n Checking IEEE modules in directory $base_dir \n" 
 
-# check modules in IEEE 802.X subdirectories
-printf "\n Checking IEEE modules in $base_dir \n" 
-
-echo cd "./$base_dir"
+#echo cd "./$base_dir"
+echo cd "$base_dir"
 
 for d in $to_check; do
-    printf "\n Checking modules with pyang in $to_check : \n"
+    #printf "\n Checking modules with pyang in $to_check : \n"
+    printf "\n Checking modules with pyang in $d : \n"
     checkDir $d
 done
 

--- a/standard/ieee/draft/ieee802-types.yang
+++ b/standard/ieee/draft/ieee802-types.yang
@@ -25,10 +25,10 @@ module ieee802-types {
     "This module contains a collection of generally useful derived
     data types for IEEE YANG models.";
 
-  revision 2017-07-20 {
+  revision 2017-10-16 {
     description
       "Updates based upon comment resolution on draft
-      D1.1 of P802.1Qcp.";
+      D1.3 of P802.1Qcp.";
     reference
       "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
       Virtual Bridged Local Area Networks.";
@@ -53,19 +53,5 @@ module ieee802-types {
   /*
    * Collection of IEEE 802 related identifier types
    */
-
-  typedef vlanid {
-    type uint16 {
-      range "1..4094";
-    }
-    description
-      "The vlanid type uniquely identifies a VLAN. This is the 12-bit
-      VLAN-ID used in the VLAN Tag header. The range is defined by
-      the referenced specification. This type is in the value set and
-      its semantics equivalent to the VlanId textual convention of
-      the SMIv2.";
-    reference
-      "IEEE Std 802.1Q-2017: Virtual Bridged Local Area Networks.";
-  }
 
 }


### PR DESCRIPTION
Clean PYANG compilation


------------------
ieee802-dot1x.yang
------------------

Pyang Validation
ieee802-dot1x.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
module: ieee802-dot1x
    +--rw nid-group
       +--rw pae-nid-group* [nid]
          +--rw nid                       pae-nid
          +--rw use-eap?                  enumeration
          +--rw unauth-allowed?           enumeration
          +--rw unsecure-allowed?         enumeration
          +--rw unauthenticated-access?   enumeration
          +--rw access-capabilities?      pae-nid-capabilities
          +--ro kmd?                      pae-kmd
  augment /sys:system:
    +--rw pae-system
       +--rw name?                     string
       +--rw system-access-control?    enumeration
       +--rw system-announcements?     enumeration
       +--ro eapol-protocol-version?   uint32
       +--ro mka-version?              uint32
       +--ro pae*                      if:interface-ref
  augment /if:interfaces/if:interface:
    +--rw pae
       +--rw pae-system?                 dot1x:pae-system-ref
       +--rw vp-enable?                  boolean
       +--rw port-capabilities
       |  +--rw supp?                  boolean
       |  +--rw auth?                  boolean
       |  +--rw mka?                   boolean
       |  +--rw macsec?                boolean
       |  +--rw announcements?         boolean
       |  +--rw listener?              boolean
       |  +--rw virtual-ports?         boolean
       |  +--rw in-service-upgrades?   boolean
       +--ro port-name?                  if:interface-ref
       +--ro port-number?                pae-if-index
       +--ro controlled-port-name?       if:interface-ref
       +--ro controlled-port-number?     pae-if-index
       +--ro uncontrolled-port-name?     if:interface-ref
       +--ro uncontrolled-port-number?   pae-if-index
       +--ro common-port-name?           if:interface-ref
       +--ro common-port-number?         pae-if-index
       +--rw port-type?                  enumeration
       +--ro virtual-port
       |  +--ro max?            uint32
       |  +--ro current?        yang:gauge32
       |  +--ro start?          uint32
       |  +--ro peer-address?   ieee:mac-address
       +--rw supplicant
       |  +--rw held-period?     uint16
       |  +--rw retry-max?       uint8
       |  +--ro enabled?         boolean
       |  +--ro authenticate?    boolean
       |  +--ro authenticated?   boolean
       |  +--ro failed?          boolean
       +--rw authenticator
       |  +--rw quiet-period?    uint16
       |  +--rw reauth-period?   uint16
       |  +--rw reauth-enable?   boolean
       |  +--rw retry-max?       uint8
       |  +--ro enabled?         boolean
       |  +--ro authenticate?    boolean
       |  +--ro authenticated?   boolean
       |  +--ro failed?          boolean
       +--rw kay
       |  +--rw enable?               boolean
       |  +--rw actor
       |  |  +--rw priority?   uint8
       |  |  +--ro sci?        sci-list-entry
       |  +--rw key-server
       |  |  +--rw priority?   uint8
       |  |  +--ro sci?        sci-list-entry
       |  +--rw group
       |  |  +--rw join?   boolean
       |  |  +--rw form?   boolean
       |  |  +--rw new?    boolean
       |  +--rw macsec
       |  |  +--rw capable?          boolean
       |  |  +--rw desired?          boolean
       |  |  +--ro protect?          boolean
       |  |  +--ro validate?         boolean
       |  |  +--ro replay-protect?   boolean
       |  +--rw suspend-on-request?   boolean
       |  +--rw suspend-for?          uint8
       |  +--ro suspended-while?      uint8
       |  +--ro active?               boolean
       |  +--ro authenticated?        boolean
       |  +--ro secured?              boolean
       |  +--ro failed?               boolean
       |  +--ro key-number
       |  |  +--ro tx?   mak-kn
       |  |  +--ro rx?   mak-kn
       |  +--ro association-number
       |  |  +--ro tx?   mak-an
       |  |  +--ro rx?   mak-an
       |  +--rw participants* [participant]
       |     +--rw participant    uint32
       |     +--rw cached?        boolean
       |     +--rw active?        boolean
       |     +--rw retain?        boolean
       |     +--rw activate?      enumeration
       |     +--ro peers
       |     |  +--ro live*        sci-list-entry
       |     |  +--ro potential*   sci-list-entry
       |     +--ro ckn?           pae-ckn
       |     +--ro kmd?           pae-kmd
       |     +--ro nid?           pae-nid
       |     +--ro auth-data?     pae-auth-data
       |     +--ro principal?     boolean
       |     +--ro dist-ckn?      pae-ckn
       +--rw logon-nid
       |  +--rw selected?        pae-nid
       |  +--rw pae-nid-group* [nid]
       |  |  +--rw nid                       pae-nid
       |  |  +--rw use-eap?                  enumeration
       |  |  +--rw unauth-allowed?           enumeration
       |  |  +--rw unsecure-allowed?         enumeration
       |  |  +--rw unauthenticated-access?   enumeration
       |  |  +--rw access-capabilities?      pae-nid-capabilities
       |  |  +--ro kmd?                      pae-kmd
       |  +--ro connected?       pae-nid
       |  +--ro requested?       pae-nid
       +--rw announcer
       |  +--rw enable?     boolean
       |  +--rw announce* [announces]
       |     +--rw announces        uint32
       |     +--rw pae-nid-group* [nid]
       |     |  +--rw nid                       pae-nid
       |     |  +--rw use-eap?                  enumeration
       |     |  +--rw unauth-allowed?           enumeration
       |     |  +--rw unsecure-allowed?         enumeration
       |     |  +--rw unauthenticated-access?   enumeration
       |     |  +--rw access-capabilities?      pae-nid-capabilities
       |     |  +--ro kmd?                      pae-kmd
       |     +--ro nid?             pae-nid
       |     +--ro access-status?   pae-access-status
       +--rw listener
       |  +--rw enable?         boolean
       |  +--ro announcement* [announcements]
       |     +--ro announcements             uint32
       |     +--ro nid?                      pae-nid
       |     +--ro kmd?                      pae-kmd
       |     +--ro specific?                 boolean
       |     +--ro access-status?            pae-access-status
       |     +--ro requested-nid?            boolean
       |     +--ro unauthenticated-access?   pae-access-status
       |     +--ro access-capabilities?      pae-nid-capabilities
       |     +--ro cipher-suites* [index]
       |        +--ro index                    uint16
       |        +--ro cipherSuite?             string
       |        +--ro cipherSuiteCapability?   uint32
       +--ro eapol-statistics
       |  +--ro invalid-eapol-frame-rx?       yang:counter32
       |  +--ro eap-length-error-frames?      yang:counter32
       |  +--ro eapol-announcements-rx?       yang:counter32
       |  +--ro eapol-announce-reqs-rx?       yang:counter32
       |  +--ro eapol-port-unavailable?       yang:counter32
       |  +--ro eapol-start-frames-rx?        yang:counter32
       |  +--ro eapol-eap-frames-rx?          yang:counter32
       |  +--ro eapol-logoff-frames-rx?       yang:counter32
       |  +--ro eapol-mk-no-cfn?              yang:counter32
       |  +--ro eapol-mk-invalid-frames-rx?   yang:counter32
       |  +--ro last-eapol-frame-source?      ieee:mac-address
       |  +--ro last-eapol-frame-version?     yang:counter32
       |  +--ro eapol-supp-eap-frames-tx?     yang:counter32
       |  +--ro eapol-logoff-frames-tx?       yang:counter32
       |  +--ro eapol-announcements-tx?       yang:counter32
       |  +--ro eapol-announce-reqs-tx?       yang:counter32
       |  +--ro eapol-start-frames-tx?        yang:counter32
       |  +--ro eapol-auth-eap-frames-tx?     yang:counter32
       |  +--ro eapol-mka-frames-tx?          yang:counter32
       +--rw logon-process
          +--rw logon?                boolean
          +--ro connect?              enumeration
          +--ro port-valid?           boolean
          +--ro session-statistics* [session-id]
             +--ro session-id         pae-session-id
             +--ro user-name?         pae-session-user-name
             +--ro octets-rx?         yang:counter64
             +--ro octets-tx?         yang:counter64
             +--ro frames-rx?         yang:counter64
             +--ro frames-tx?         yang:counter64
             +--ro time?              yang:timeticks
             +--ro terminate-cause?   enumeration

Confdc Output
No warnings or errors

yanglint Validation
warn: Value "iana-if-type:ptm" is not valid for the node "type" (ietf-interfaces:type = 'iana-if-type:ptm').


------------------------
ieee802-dot1q-types.yang
------------------------

Pyang Validation
ieee802-dot1q-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
No warnings or errors

Confdc Output
No warnings or errors

yanglint Validation
No warnings or errors


-------------------------
ieee802-dot1q-bridge.yang
-------------------------

Pyang Validation
ieee802-dot1q-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
module: ieee802-dot1q-bridge
    +--rw bridges
       +--rw bridge* [name]
          +--rw name           dot1qtypes:name-type
          +--rw address        ieee:mac-address
          +--rw bridge-type    identityref
          +--ro ports?         uint16
          +--ro up-time?       yang:zero-based-counter32
          +--ro components?    uint32
          +--rw component* [name]
             +--rw name                     string
             +--rw id?                      uint32
             +--rw type                     identityref
             +--rw address?                 ieee:mac-address
             +--rw traffic-class-enabled?   boolean
             +--ro ports?                   uint16
             +--ro bridge-port*             if:interface-ref
             +--ro capabilities
             |  +--ro extended-filtering?             boolean
             |  +--ro traffic-classes?                boolean
             |  +--ro static-entry-individual-port?   boolean
             |  +--ro ivl-capable?                    boolean
             |  +--ro svl-capable?                    boolean
             |  +--ro hybrid-capable?                 boolean
             |  +--ro configurable-pvid-tagging?      boolean
             |  +--ro local-vlan-capable?             boolean
             +--rw filtering-database
             |  +--rw aging-time?                          uint32
             |  +--ro size?                                yang:gauge32
             |  +--ro static-entries?                      yang:gauge32
             |  +--ro dynamic-entries?                     yang:gauge32
             |  +--ro static-vlan-registration-entries?    yang:gauge32
             |  +--ro dynamic-vlan-registration-entries?   yang:gauge32
             |  +--ro mac-address-registration-entries?    yang:gauge32 {extended-filtering-services}?
             |  +--rw filtering-entry* [database-id vids address]
             |  |  +--rw database-id    uint32
             |  |  +--rw address        ieee:mac-address
             |  |  +--rw vids           dot1qtypes:vid-range-type
             |  |  +--rw entry-type?    enumeration
             |  |  +--rw port-map* [port-ref]
             |  |  |  +--rw port-ref                             port-number-type
             |  |  |  +--rw (map-type)?
             |  |  |     +--:(static-filtering-entries)
             |  |  |     |  +--rw static-filtering-entries
             |  |  |     |     +--rw control-element?         enumeration
             |  |  |     |     +--rw connection-identifier?   port-number-type
             |  |  |     +--:(static-vlan-registration-entries)
             |  |  |     |  +--rw static-vlan-registration-entries
             |  |  |     |     +--rw registrar-admin-control?   enumeration
             |  |  |     |     +--rw vlan-transmitted?          enumeration
             |  |  |     +--:(mac-address-registration-entries)
             |  |  |     |  +--rw mac-address-registration-entries
             |  |  |     |     +--rw control-element?   enumeration
             |  |  |     +--:(dynamic-vlan-registration-entries)
             |  |  |     |  +--rw dynamic-vlan-registration-entries
             |  |  |     |     +--rw control-element?   enumeration
             |  |  |     +--:(dynamic-reservation-entries)
             |  |  |     |  +--rw dynamic-reservation-entries
             |  |  |     |     +--rw control-element?   enumeration
             |  |  |     +--:(dynamic-filtering-entries)
             |  |  |        +--rw dynamic-filtering-entries
             |  |  |           +--rw control-element?   enumeration
             |  |  +--ro status?        enumeration
             |  +--rw vlan-registration-entry* [database-id vids]
             |     +--rw database-id    uint32
             |     +--rw vids           dot1qtypes:vid-range-type
             |     +--rw entry-type?    enumeration
             |     +--rw port-map* [port-ref]
             |        +--rw port-ref                             port-number-type
             |        +--rw (map-type)?
             |           +--:(static-filtering-entries)
             |           |  +--rw static-filtering-entries
             |           |     +--rw control-element?         enumeration
             |           |     +--rw connection-identifier?   port-number-type
             |           +--:(static-vlan-registration-entries)
             |           |  +--rw static-vlan-registration-entries
             |           |     +--rw registrar-admin-control?   enumeration
             |           |     +--rw vlan-transmitted?          enumeration
             |           +--:(mac-address-registration-entries)
             |           |  +--rw mac-address-registration-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-vlan-registration-entries)
             |           |  +--rw dynamic-vlan-registration-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-reservation-entries)
             |           |  +--rw dynamic-reservation-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-filtering-entries)
             |              +--rw dynamic-filtering-entries
             |                 +--rw control-element?   enumeration
             +--rw permanent-database
             |  +--ro size?                               yang:gauge32
             |  +--ro static-entries?                     yang:gauge32
             |  +--ro static-vlan-registration-entries?   yang:gauge32
             |  +--rw filtering-entry* [database-id vids address]
             |     +--rw database-id    uint32
             |     +--rw address        ieee:mac-address
             |     +--rw vids           dot1qtypes:vid-range-type
             |     +--ro status?        enumeration
             |     +--rw port-map* [port-ref]
             |        +--rw port-ref                             port-number-type
             |        +--rw (map-type)?
             |           +--:(static-filtering-entries)
             |           |  +--rw static-filtering-entries
             |           |     +--rw control-element?         enumeration
             |           |     +--rw connection-identifier?   port-number-type
             |           +--:(static-vlan-registration-entries)
             |           |  +--rw static-vlan-registration-entries
             |           |     +--rw registrar-admin-control?   enumeration
             |           |     +--rw vlan-transmitted?          enumeration
             |           +--:(mac-address-registration-entries)
             |           |  +--rw mac-address-registration-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-vlan-registration-entries)
             |           |  +--rw dynamic-vlan-registration-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-reservation-entries)
             |           |  +--rw dynamic-reservation-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-filtering-entries)
             |              +--rw dynamic-filtering-entries
             |                 +--rw control-element?   enumeration
             +--rw bridge-vlan
             |  +--ro version?                   uint16
             |  +--ro max-vids?                  uint16
             |  +--ro override-default-pvid?     boolean
             |  +--ro protocol-template?         dot1qtypes:protocol-frame-format-type {port-and-protocol-based-vlan}?
             |  +--ro max-msti?                  uint16
             |  +--rw vlan* [vid]
             |  |  +--rw vid               dot1qtypes:vlan-index-type
             |  |  +--rw name?             dot1qtypes:name-type
             |  |  +--ro untagged-ports*   if:interface-ref
             |  |  +--ro egress-ports*     if:interface-ref
             |  +--rw protocol-group-database* [db-index] {port-and-protocol-based-vlan}?
             |  |  +--rw db-index             uint16
             |  |  +--rw frame-format-type?   dot1qtypes:protocol-frame-format-type
             |  |  +--rw (frame-format)?
             |  |  |  +--:(ethernet-rfc1042-snap8021H)
             |  |  |  |  +--rw ethertype?           dot1qtypes:ethertype-type
             |  |  |  +--:(snap-other)
             |  |  |  |  +--rw protocol-id?         string
             |  |  |  +--:(llc-other)
             |  |  |     +--rw dsap-ssap-pairs
             |  |  |        +--rw llc-address?   string
             |  |  +--rw group-id?            uint32
             |  +--rw vid-to-fid-allocation* [vids]
             |  |  +--rw vids               dot1qtypes:vid-range-type
             |  |  +--ro fid?               uint32
             |  |  +--ro allocation-type?   enumeration
             |  +--rw fid-to-vid-allocation* [fid]
             |  |  +--rw fid                uint32
             |  |  +--ro allocation-type?   enumeration
             |  |  +--ro vid*               dot1qtypes:vlan-index-type
             |  +--rw vid-to-fid* [vid]
             |     +--rw vid    dot1qtypes:vlan-index-type
             |     +--rw fid?   uint32
             +--rw bridge-mst
                +--rw mstid*                     dot1qtypes:mstid-type
                +--rw fid-to-mstid* [fid]
                |  +--rw fid      uint32
                |  +--rw mstid?   dot1qtypes:mstid-type
                +--rw fid-to-mstid-allocation* [fids]
                   +--rw fids     dot1qtypes:vid-range-type
                   +--rw mstid?   dot1qtypes:mstid-type
  augment /if:interfaces/if:interface:
    +--rw bridge-port
       +--rw component-name?                        string
       +--rw port-type?                             identityref
       +--rw pvid?                                  dot1qtypes:vlan-index-type
       +--rw default-priority?                      dot1qtypes:priority-type
       +--rw priority-regeneration
       |  +--rw priority0?   priority-type
       |  +--rw priority1?   priority-type
       |  +--rw priority2?   priority-type
       |  +--rw priority3?   priority-type
       |  +--rw priority4?   priority-type
       |  +--rw priority5?   priority-type
       |  +--rw priority6?   priority-type
       |  +--rw priority7?   priority-type
       +--rw pcp-selection?                         dot1qtypes:pcp-selection-type
       +--rw pcp-decoding-table
       |  +--rw pcp-decoding-map* [pcp]
       |     +--rw pcp             pcp-selection-type
       |     +--rw priority-map* [priority-code-point]
       |        +--rw priority-code-point    priority-type
       |        +--rw priority?              priority-type
       |        +--rw drop-eligible?         boolean
       +--rw pcp-encoding-table
       |  +--rw pcp-encoding-map* [pcp]
       |     +--rw pcp             pcp-selection-type
       |     +--rw priority-map* [priority dei]
       |        +--rw priority               priority-type
       |        +--rw dei                    boolean
       |        +--rw priority-code-point?   priority-type
       +--rw use-dei?                               boolean
       +--rw drop-encoding?                         boolean
       +--rw service-access-priority-selection?     boolean
       +--rw service-access-priority
       |  +--rw priority0?   priority-type
       |  +--rw priority1?   priority-type
       |  +--rw priority2?   priority-type
       |  +--rw priority3?   priority-type
       |  +--rw priority4?   priority-type
       |  +--rw priority5?   priority-type
       |  +--rw priority6?   priority-type
       |  +--rw priority7?   priority-type
       +--rw traffic-class
       |  +--rw traffic-class-map* [priority]
       |     +--rw priority                   priority-type
       |     +--rw available-traffic-class* [num-traffic-class]
       |        +--rw num-traffic-class    uint8
       |        +--rw traffic-class?       traffic-class-type
       +--rw acceptable-frame?                      enumeration
       +--rw enable-ingress-filtering?              boolean
       +--rw enable-restricted-vlan-registration?   boolean
       +--rw enable-vid-translation-table?          boolean
       +--rw enable-egress-vid-translation-table?   boolean
       +--rw protocol-group-vid-set* [group-id] {port-and-protocol-based-vlan}?
       |  +--rw group-id    uint32
       |  +--rw vid*        dot1qtypes:vlanid
       +--rw admin-point-to-point?                  enumeration
       +--ro protocol-based-vlan-classification?    boolean {port-and-protocol-based-vlan}?
       +--ro max-vid-set-entries?                   uint16 {port-and-protocol-based-vlan}?
       +--ro port-number?                           dot1qtypes:port-number-type
       +--ro address?                               ieee:mac-address
       +--ro capabilities?                          bits
       +--ro type-capabilties?                      bits
       +--ro external?                              boolean
       +--ro oper-point-to-point?                   boolean
       +--ro statistics
       |  +--ro delay-exceeded-discards?          yang:counter64
       |  +--ro mtu-exceeded-discards?            yang:counter64
       |  +--ro frame-rx?                         yang:counter64
       |  +--ro octets-rx?                        yang:counter64
       |  +--ro frame-tx?                         yang:counter64
       |  +--ro octets-tx?                        yang:counter64
       |  +--ro discard-inbound?                  yang:counter64
       |  +--ro forward-outbound?                 yang:counter64
       |  +--ro discard-lack-of-buffers?          yang:counter64
       |  +--ro discard-transit-delay-exceeded?   yang:counter64
       |  +--ro discard-on-error?                 yang:counter64
       |  +--ro discard-on-ingress-filtering?     yang:counter64 {ingress-filtering}?
       +--rw vid-translations* [local-vid]
       |  +--rw local-vid    dot1qtypes:vlanid
       |  +--rw relay-vid?   dot1qtypes:vlanid
       +--rw egress-vid-translations* [relay-vid]
          +--rw relay-vid    dot1qtypes:vlanid
          +--rw local-vid?   dot1qtypes:vlanid

Confdc Output
No warnings or errors

yanglint Validation
No warnings or errors


------------------
ieee802-types.yang
------------------

Pyang Validation
ieee802-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
No warnings or errors

Confdc Output
No warnings or errors

yanglint Validation
No warnings or errors


---------------------
ieee802-dot1q-pb.yang
---------------------

Pyang Validation
ieee802-dot1q-pb.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
module: ieee802-dot1q-pb
  augment /if:interfaces/if:interface/dot1q:bridge-port:
    +--rw svid?                            dot1qtypes:vlanid
    +--rw cvid-registration* [cvid]
    |  +--rw cvid            dot1qtypes:vlanid
    |  +--rw svid?           dot1qtypes:vlanid
    |  +--rw untagged-pep?   boolean
    |  +--rw untagged-cep?   boolean
    +--rw service-priority-regeneration* [svid]
    |  +--rw svid                     dot1qtypes:vlanid
    |  +--rw priority-regeneration
    |     +--rw priority0?   priority-type
    |     +--rw priority1?   priority-type
    |     +--rw priority2?   priority-type
    |     +--rw priority3?   priority-type
    |     +--rw priority4?   priority-type
    |     +--rw priority5?   priority-type
    |     +--rw priority6?   priority-type
    |     +--rw priority7?   priority-type
    +--rw rcap-internal-interface* [external-svid]
       +--rw external-svid              dot1qtypes:vlanid
       +--rw internal-port-number?      dot1qtypes:port-number-type
       +--rw internal-svid?             dot1qtypes:vlanid
       +--rw internal-interface-type?   enumeration

Confdc Output
No warnings or errors

yanglint Validation
No warnings or errors
