### PR TITLE
Introduce initial version of IEEE 802.1Qcu CFM YANG module

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -1,0 +1,2996 @@
+module ieee802-dot1q-cfm {
+
+  namespace "urn:ieee:std:802.1X:yang:ieee802-dot1q-cfm";
+  prefix "dot1q-cfm";
+
+  import ieee802-types { prefix "ieee"; }
+  import ietf-yang-types { prefix "yang"; }
+  import ietf-interfaces { prefix "if"; }
+  import ieee802-dot1q-bridge { prefix "dot1q"; }
+  import ieee802-dot1q-types { prefix "dot1q-types"; }
+
+  organization
+    "Institute of Electrical and Electronics Engineers";
+
+  contact
+  	"WG-URL: http://grouper.ieee.org/groups/802/1/
+    WG-EMail: stds-802-1@ieee.org
+
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+ 	
+    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
+
+  description
+    "Connectivity Fault Management (CFM) comprises capabilities
+  	for detecting, verifying, and isolating connectivity failures
+  	in Virtual Bridged Local Area Networks. These capabilities
+  	can be used in networks operated by multiple independent
+  	organizaitons, each wit restricted management access to each others
+  	equipment.";
+  
+  revision 2017-12-20 {
+    description
+      "Initial creation for Task Group review.";
+    reference
+      "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
+      Virtual Bridged Local Area Networks.";
+  }
+  
+  /* --------------------------------------------------
+   * Type definitions used by 802.1AB -LLDP YANG module
+   * --------------------------------------------------
+   */
+  
+  typedef lldp-chassis-id-subtype {
+  	type enumeration {
+  		enum chassis-component {
+  			value 1;
+  			description
+  				"Represents a chassis identifier based on the value of
+  				entPhysicalAlias object (defined in IETF RFC 2737) for a
+  				chassis component (i.e., an entPhysicalClass value of
+  				chassis(3))";
+  		}
+  		enum interface-alias {
+  			value 2;
+  			description
+  				"Represents a chassis identifier based on the value of
+  				ifAlias object (defined in IETF RFC 2863) for an interface
+  				on the containing chassis.";
+  		}
+  		enum port-component {
+  			value 3;
+  			description
+  				"Represents a chassis identifier based on the value of
+  				entPhysicalAlias object (defined in IETF RFC 2737) for a
+  				port or backplane component (i.e., entPhysicalClass value of
+  				port(10) or backplane(4)), within the containing chassis.";
+  		}
+  		enum mac-address {
+  			value 4;
+  			description
+  				"Represents a chassis identifier based on the value of a
+  				unicast source address (encoded in network byte order and
+  				IEEE 802.3 canonical bit order), of a port on the containing
+  				chassis as defined in IEEE Std 802-2001.";
+  		}
+  		enum network-address {
+  			value 5;
+  			description
+  				"Represents a chassis identifier based on a network address,
+  				associated with a particular chassis.  The encoded address is
+  				actually composed of two fields.  The first field is a
+  				single octet, representing the IANA AddressFamilyNumbers
+  				value for the specific address type, and the second field is
+  				the network address value.";
+  		}
+  		enum interface-name {
+  			value 6;
+  			description
+  				"Represents a chassis identifier based on the value of
+  				ifName object (defined in IETF RFC 2863) for an interface
+  				on the containing chassis.";
+  		}
+  		enum local {
+  			value 7;
+  			description
+  				"Represents a chassis identifier based on a locally defined
+  				value.";
+  		}
+  	}
+  	description
+  		"The source of a chassis identifier.";
+  	reference
+  		"LLDP MIB 20050506";
+  }
+  
+  typedef lldp-chassis-id {
+  	type string {
+  		length "1..255";
+  	}
+  	description
+  		"The format of a chassis identifier string. Objects of this type
+  		are always used with an associated lldp-chassis-is-subtype
+  		object, which identifies the format of the particular
+  		lldp-chassis-id object instance.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      chassis-component, then the octet string identifies
+      a particular instance of the entPhysicalAlias object
+      (defined in IETF RFC 2737) for a chassis component (i.e.,
+      an entPhysicalClass value of chassis(3)).
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of interface-alias, then the octet string identifies
+      a particular instance of the ifAlias object (defined in
+      IETF RFC 2863) for an interface on the containing chassis.
+      If the particular ifAlias object does not contain any values,
+      another chassis identifier type should be used.
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of port-component, then the octet string identifies a
+      particular instance of the entPhysicalAlias object (defined
+      in IETF RFC 2737) for a port or backplane component within
+      the containing chassis.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      mac-address, then this string identifies a particular
+      unicast source address (encoded in network byte order and
+      IEEE 802.3 canonical bit order), of a port on the containing
+      chassis as defined in IEEE Std 802-2001.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      network-address, then this string identifies a particular
+      network address, encoded in network byte order, associated
+      with one or more ports on the containing chassis.  The first
+      octet contains the IANA Address Family Numbers enumeration
+      value for the specific address type, and octets 2 through
+      N contain the network address value in network byte order.
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of interface-name, then the octet string identifies
+      a particular instance of the ifName object (defined in
+      IETF RFC 2863) for an interface on the containing chassis.
+      If the particular ifName object does not contain any values,
+      another chassis identifier type should be used.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      local, then this string identifies a locally assigned
+      Chassis ID.";
+  	reference
+  		"LLDP MIB 20050506";
+  }
+  
+  typedef lldp-port-id-subtype {
+  	type enumeration {
+  		enum interface-alias {
+  			value 1;
+  			description
+  				"Represents a port identifier based on the ifAlias
+  				MIB object, defined in IETF RFC 2863.";
+  		}
+  		enum port-component {
+  			value 2;
+  			description
+  				"Represents a port identifier based on the value of
+  				entPhysicalAlias (defined in IETF RFC 2737) for a port
+  				component (i.e., entPhysicalClass value of port(10)), 
+  				within the containing chassis.";
+  		}
+  		enum mac-address {
+  			value 3;
+  			description
+  				"Represents a port identifier based on a unicast source
+  				address (encoded in network byte order and IEEE 802.3
+  				canonical bit order), which has been detected by the agent
+  				and associated with a particular port (IEEE Std 802-2001).";
+  		}
+  		enum network-address {
+  			value 4;
+  			description
+  				"Represents a port identifier based on a network address,
+  				detected by the agent and associated with a particular 
+  				port.";
+  		}
+  		enum interface-name {
+  			value 5;
+  			description
+  				"Represents a port identifier based on the ifName MIB object,
+  				defined in IETF RFC 2863.";
+  		}
+  		enum agent-circuit-id {
+  			value 6;
+  			description
+  				"Represents a port identifier based on the agent-local
+  				identifier of the circuit (defined in RFC 3046), detected by
+  				the agent and associated with a particular port.";
+  		}
+  		enum local {
+  			value 7;
+  			description
+  				"Represents a port identifier based on a value locally
+  				assigned.";
+  		}
+  	}
+  	description
+  		"The source of a particular type of port identifier used
+  		in the LLDP YANG module.";
+  }
+  
+  typedef lldp-port-id {
+  	type string {
+  		length "8";
+  	}
+  	description
+  		"The format of a port identifier string. Objects of this type
+  		are always used with an associated lldp-port-id-subtype object,
+  		which identifies the format of the particular lldp-port-id
+  		object instance.
+
+      If the associated lldp-port-id-subtype object has a value of
+      interface-alias, then the octet string identifies a
+      particular instance of the ifAlias object (defined in IETF
+      RFC 2863).  If the particular ifAlias object does not contain
+      any values, another port identifier type should be used.
+
+      If the associated lldp-port-id-subtype object has a value of
+      port-component, then the octet string identifies a
+      particular instance of the entPhysicalAlias object (defined
+      in IETF RFC 2737) for a port or backplane component.
+
+      If the associated lldp-port-id-subtype object has a value of
+      mac-address, then this string identifies a particular
+      unicast source address (encoded in network byte order
+      and IEEE 802.3 canonical bit order) associated with the port
+      (IEEE Std 802-2001).
+
+      If the associated lldp-port-id-subtype object has a value of
+      network-address, then this string identifies a network
+      address associated with the port.  The first octet contains
+      the IANA AddressFamilyNumbers enumeration value for the
+      specific address type, and octets 2 through N contain the
+      networkAddress address value in network byte order.
+
+      If the associated lldp-port-id-subtype object has a value of
+      interface-name, then the octet string identifies a
+      particular instance of the ifName object (defined in IETF
+      RFC 2863).  If the particular ifName object does not contain
+      any values, another port identifier type should be used.
+
+      If the associated lldp-port-id-subtype object has a value of
+      agent-circuit-id, then this string identifies a agent-local
+      identifier of the circuit (defined in RFC 3046).
+
+      If the associated lldp-port-id-subtype object has a value of
+      local, then this string identifies a locally assigned port ID.";
+  }
+  
+  /* -----------------------------------------------------
+   * Type definitions used by RFC 2579 SNMP v2 YANG module
+   * -----------------------------------------------------
+   */
+  
+  identity type-of-transport-domain {
+  	description
+  		"Represents the transport service domain type.";
+  }
+  
+  identity yang-tdomain {
+  	base type-of-transport-domain;
+  	description
+  		"Base identity for a YANG transport service domain.";
+  }
+  
+  typedef transport-service-domain {
+  	// Refer to RFC 2579. This is an OBJECT Identifier
+  	// Not sure what to do here!
+  	type identityref {
+  		base type-of-transport-domain;
+  	}
+  	description
+  		"Denotes a kind of transport service";
+  	reference
+  		"RFC2579 - Textual Conventions for SMIv2";
+  }
+  
+  typedef transport-service-address {
+  	type string {
+  		length "1..255";
+  	}
+  	description
+  		"Denotes a transport service address";
+  }
+
+  /* ----------------------------------------------
+   * Type definitions used by 802.1Qcx YANG module
+   * ----------------------------------------------
+   */
+  
+  typedef bridge-ref {
+  	type leafref {
+  		path "/dot1q:bridges/dot1q:bridge/dot1q:name";
+  	}
+  	description
+  		"This type is used by data models that need to reference
+  		a configured Bridge.";
+  }
+  
+  typedef component-ref {
+  	type leafref {
+  		path "/dot1q:bridges/dot1q:bridge/dot1q:component/dot1q:name";
+  	}
+  	description
+  		"This type is used by data models that need to reference
+  		a configured Bridge.";
+  }
+  
+  typedef md-name-format-type {
+  	type enumeration {
+  		enum ieee-reserved-0 {
+  			value 0;
+  			description
+  				"Reserved for definition by IEEE 802.1 recommend to not
+  				use zero unless absolutely needed.";
+  		}
+  		enum none {
+  			value 1;
+  			description
+  				"No format specified, usually because there is not a 
+  				Maintenance Domain Name. In this case, a zero length
+  				OCTET string for the Domain name field is acceptable.";
+  		}
+  		enum dns-like-name {
+  			value 2;
+  			description
+  				"Domain name like string, globally unique text string 
+  				derived from a DNS name.";
+  		}
+  		enum mac-address-and-uint {
+  			value 3;
+  			description
+  				"MAC address plus 2-octet (unsigned) integer.";
+  		}
+  		enum char-string {
+  			value 4;
+  			description
+  				"RFC2579 DisplayString, except that the character codes
+  				0-31 (decimal) are not used.";
+  		}
+  		enum ieee-reserved-5-31-64-255 {
+  			value 5;
+  			description
+  				"Reserved for definition by IEEE 802.1. Can be [5..31] and
+  				[64..255].";
+  		}
+  		enum itu-reserved-32-63 {
+  			value 6;
+  			description
+  				"Reserved for definition by ITU-T Y.1731. Values range from
+  				[32..63].";
+  		}
+  	}
+  	description
+  		"A value that represents a type (and thereby the format)
+  		of a md-name.";
+  }
+  
+  typedef md-name-type {
+  	type string {
+  		length "1..43";
+  	}
+  	description
+  		"The Maintenance Domain name type";
+  }
+  
+  typedef ma-name-format-type {
+  	type enumeration {
+  		enum ieee-reserved-0 {
+  			value 0;
+  			description
+  				"Reserved for definition by IEEE 802.1. Recommend not to use
+  				zero unless absolutely needed.";
+  		}
+  		enum primary-vid {
+  			value 1;
+  			description
+  				"Primary VLAN ID. 12 bits represented in a 2-octet integer.";
+  		}
+  		enum char-string {
+  			value 2;
+  			description
+  				"RFC2579 DisplayString, except that the character codes
+  				0-31 (decimal) are not used. (1..45) octets.";
+  		}
+  		enum unsigned-int16 {
+  			value 3;
+  			description
+  				"2-octet integer/big endian.";
+  		}
+  		enum rfc2865-vpn-id {
+  			value 4;
+  			description
+  				"RFC2685 VPN ID. 3 octet VPN authority Organizationally
+  				Unique Identifier followed by 4 octet VPN index identifying
+  				VPN according to the OUI.";
+  		}
+  		enum icc-format {
+  			value 32;
+  			description
+  				"ICC-based format as specified in ITU-T Y.1731.";
+  		}
+  		enum ieee-reserved-5-31-64-255 {
+  			value 5;
+  			description
+  				"Reserved for definition by IEEE 802.1. Values can be [5..31]
+  				and [64..255].";
+  		}
+  		enum itu-reserved-33-63 {
+  			value 6;
+  			description
+  				"Reserved for definition by ITU-T Y.1731. Values range from
+  				[33..63].";
+  		}
+  	}
+  	description
+  		"A value that represents a type (and thereby the format)
+  		of a ma-name.";
+  }
+  
+  typedef ma-name-type {
+  	type string {
+  		length "1..45";
+  	}
+  	description
+  		"The Maintenance Association name type";
+  }
+  
+  typedef mhf-creation-type {
+  	type enumeration {
+  		enum mhf-none {
+  			value 1;
+  			description
+  				"No MHFs can be created for designated VID(s) or ISID.";
+  		}
+  		enum mhf-default {
+  			value 2;
+  			description
+  				"MHFs can be created for designated VID(s) or ISID on any
+  				Bridge Port through which the VID(s) or ISID can pass, where:
+  				  i) There are no lower active MD levels; or
+  				 ii) There is a MEP at the next lower active MD level on 
+  				     the port.";
+  		}
+  		enum mhf-explicit {
+  			value 3;
+  			description
+  				"MHFs can be created for designated VID(s) or ISID only
+  				on Bridge Ports through which the VID(s) or ISID can pass, 
+  				and onlyh if there is a MEP at the next lower active 
+  				MD level on the port.";
+  		}
+  		enum mhf-defer {
+  			value 4;
+  			description
+  				"In the Maintenance Association only, the control of MHF
+  				creation is deferred to the corresponding variable in
+  				the enclosing Maintenance Domain.";
+  		}
+  	}
+  	description
+  		"Indicates if the Management Entity can create MHFs.";
+  }
+  
+  typedef mp-direction-type {
+  	type enumeration {
+  		enum down {
+  			value 1;
+  			description
+  				"Down maintenance point, where CFM protocol messages
+  				are dispatched away from the MAC Relay entity.";
+  		}
+  		enum up {
+  			value 2;
+  			description
+  				"Up maintenance point, where CFM protocol messages 
+  				are dispatched towards the MAC Relay entity.";
+  		}
+  	}
+  	description
+  		"Indicates the direction in which the Maintenance
+  		association (MEP or MIP) faces on the Bridge Port.";
+  }
+  
+  typedef service-selector-type {
+  	type enumeration {
+  		enum ieee-reserved-0 {
+  			value 0;
+  			description
+  				"Reserved for definition by IEEE 802.1 recommend to not
+  				use zero unless absolutely needed.";
+  		}
+  		enum vlan-id {
+  			value 1;
+  			description
+  				"12-bit identifier found in a VLAN tag.";
+  		}
+  		enum isid {
+  			value 2;
+  			description
+  				"24-bit identifier found in an I-TAG.";
+  		}
+  		enum tesid {
+  			value 3;
+  			description 
+  				"32-bit identifier";
+  		}
+  		enum segid {
+  			value 4;
+  			description
+  				"32-bit identifier";
+  		}
+  		enum path-tesid {
+  			value 5;
+  			description
+  				"32-bit identifier";
+  		}
+  		enum group-isid {
+  			value 6;
+  			description
+  				"24 bit identifier";
+  		}
+  		enum ieee-reserved {
+  			value 7;
+  			description
+  				"Reserved for definition by IEEE 802.1";
+  		}
+  	}
+  	description
+  		"A value that represents a type (and thereby the format)
+  		of a service-selector-value.";
+  }
+  
+  typedef service-selector-value {
+  	type uint32 {
+  		range "1..4294967295";
+  	}
+  	description
+  		"An integer that uniquely identifies a generic MAC Service,
+  		or none. Examples of service selectors are a VLAN-ID
+  		(IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
+  		
+  		An service-selector-value value is always interpreted
+  		within the context of an service-selector-type value.
+  		Every usage of the service-selector-value textual
+  		convention is required to specify the
+  		service-selector-type object that provides the context.
+  		
+  		The value of an service-selector-value object must
+  		always be consistent with the value of the associated
+  		service-selector-type object. Attempts to set an
+  		service-selector-value object to a value inconsistent
+  		with the associated service-selector-type must fail
+  		with an inconsistent-value error.";
+  }
+  
+  typedef service-selector-value-or-none {
+  	type uint32 {
+  		range "0 | 1..4294967295";
+  	}
+  	description
+  		"An integer that uniquely identifies a generic MAC Service,
+  		or none. Examples of service selectors are a VLAN-ID
+  		(IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
+  		
+  		An service-selector-value value is always interpreted
+  		within the context of an service-selector-type value.
+  		Every usage of the service-selector-value textual
+  		convention is required to specify the
+  		service-selector-type object that provides the context.
+  		
+  		The value of an service-selector-value object must
+  		always be consistent with the value of the associated
+  		service-selector-type object. Attempts to set an
+  		service-selector-value object to a value inconsistent
+  		with the associated service-selector-type must fail
+  		with an inconsistent-value error.
+  		
+  		The special value of zero is used to indicate that no
+  		service selector is present or used. This can be used in
+  		any situation where an object or a table entry MUST either
+  		refer to a specific service, or not make a selection.";
+  }
+  
+  typedef mep-id-type {
+  	type uint32 {
+  		range "1..8191";
+  	}
+  	description
+  		"Maintenance association End Point Identifier, which is
+  		unique over a given Maintenance Association.";
+  }
+  
+  typedef mep-id-or-zero-type {
+  	type uint32 {
+  		range "0 | 1..8191";
+  	}
+  	description
+  		"Maintenance association End Point Identifier, which is
+  		unique over a given Maintenance Association.
+  		
+  		The special value 0 is allowed to indicate a special case when
+  		there is no MEPID configured.";
+  }
+  
+  typedef md-level-type {
+  	type uint32 {
+  		range "0..7";
+  	}
+  	description
+  		"Integer identifying the Maintenance Domain Level (MD Level).
+  		Higher numbers correspond to higher Maintenance Domains,
+  		those with the greatest physical reach, with the highest
+  		values for customers' CFM PDUs. Lower numbers correspond
+  		to lower Maintenance Domains, those with more limited
+  		physical reach, with the lowest values for CFM PDUs
+  		protecting single bridges or physical links.";
+  }
+  
+  typedef md-level-or-none-type {
+  	type int32 {
+  		range "-1 | 0..7";
+  	}
+  	description
+  		"Integer identifying the Maintenance Domain Level (MD Level).
+  		Higher numbers correspond to higher Maintenance Domains,
+  		those with the greatest physical reach, with the highest
+  		values for customers CFM packets. Lower numbers correspond
+  		to lower Maintenance Domains, those with more limited
+  		physical reach, with the lowest values for CFM PDUs
+  		protecting single bridges or physical links.
+  		The value (-1) is reserved to indicate that no MA Level has
+  		been assigned.";
+  }
+  
+  typedef component-identifier-type {
+  	type uint32 {
+  		range "1..4294967295";
+  	}
+  	description
+  		"The component identifier is used to distinguish between the
+  		multiple virtual Bridge instances within a PB or PBB. Each
+  		virtual Bridge instance is called a component. In simple
+  		situations where there is only a single component the default
+  		value is 1. The component is identified by a component
+  		identifier unique within the BEB and by a MAC address unique
+  		within the PBBN. Each component is associated with a Backbone
+  		Edge Bridge (BEB) Configuration managed object.";
+  }
+  
+  typedef port-status-tlv-value {
+  	type enumeration {
+  		enum no-port-state-tlv {
+  			value 0;
+  			description
+  				"Indicates either that no CCM has been received or that
+  				no port status TLV was present in the last CCM received.";
+  		}
+  		enum blocked {
+  			value 1;
+  			description
+  				"Ordinary data cannot pass freely through the port on
+  				which the remote MEP resides.";
+  		}
+  		enum up {
+  			value 2;
+  			description
+  				"Ordinaty data can pass freely through the port on which
+  				the remote MEP resides.";
+  		}
+  	}
+  	description
+  		"An enumerated value from he Port Status TLV from the last CCM
+  		received from the last MEP. It indicates the ability of the
+  		Bridge Port on which the transmitting MEP resides to pass
+  		ordinary data, regardless of the status of the MAC.";
+  }
+  
+  typedef interface-status-tlv-value {
+  	type enumeration {
+  		enum is-no-interface-status-tlv {
+  			value 0;
+  			description
+  				"Indicates either that no CCM has been received or that
+  				no interface status TLV was present in the last CCM
+  				received.";
+  		}
+  		enum is-up {
+  			value 1;
+  			description
+  				"The interface is ready to pass packets.";
+  		}
+  		enum is-down {
+  			value 2;
+  			description
+  				"The interface can not pass packets.";
+  		}
+  		enum is-testing {
+  			value 3;
+  			description
+  				"The interface is in same test mode.";
+  		}
+  		enum is-unknown {
+  			value 4;
+  			description
+  				"The interface status cannot be determined for some
+  				reason.";
+  		}
+  		enum is-dormant {
+  			value 5;
+  			description
+  				"The interface is not in a state to pass packets but is in
+  				a pending state, waiting for some extrnal event.";
+  		}
+  		enum is-not-present {
+  			value 6;
+  			description
+  				"Some component of the interface is mssing.";
+  		}
+  		enum is-lower-layer-down {
+  			value 7;
+  			description
+  				"The interface is down due to state of the lower layer
+  				interface.";
+  		}
+  	}
+  	description
+  		"An enumerated value from the Interface Status TLV from the
+  		last CCM received from the last MEP. It indicates the status
+  		of the Interface within which the MEP transmitting the CCM
+  		is configured, or the next lower Interface in the Interface
+  		Stack, if the MEP is not configured within an Interface.";
+  }
+  
+  typedef highest-defect-priority-type {
+  	type enumeration {
+  		enum none {
+  			value 0;
+  			description
+  				"No defects since Fault Notificaiton Generator state
+  				machine reset.";
+  		}
+  		enum def-rdi-ccm {
+  			value 1;
+  			description
+  				"The last CCM received by this MEP from some remote MEP
+  				contained the RDI bit set.";
+  		}
+  		enum def-mac-status {
+  			value 2;
+  			description
+  				"The last CCM received by this MEP from some remote MEP
+  				indicating that the transmitting MEP's associated MAC is
+  				reporting an error status via the Port Status TLV or
+  				Interface Status TLV is set.";
+  		}
+  		enum def-remote-ccm {
+  			value 3;
+  			description
+  				"This MEP is not receiving CCMs from some other MEP in its
+  				configured list.";
+  		}
+  		enum def-error-ccm {
+  			value 4;
+  			description
+  				"This MEP is receiving invalid CCMs.";
+  		}
+  		enum def-xcon-ccm {
+  			value 5;
+  			description
+  				"This MEP is receiving CCMs that could be from some other 
+  				MA.";
+  		}
+  	}
+  	description
+  		"An enumerated value, equal to the contents of the variable
+  		highestDefect (20.35.9 and Table 20-1), indicating the
+  		highest-priority defect that has been present since the MEP
+  		Fault Notification Generator State Machine was last in the
+  		FNG_RESET state.";
+  }
+  
+  typedef lowest-alarm-priority-type {
+  	type enumeration {
+  		enum all-def {
+  			value 1;
+  			description
+  				"Includes def-rid-ccm, def-mac-status, def-remote-ccm,
+  				def-error-ccm, and def-xcon-ccm.";
+  		}
+  		enum mac-remote-error-xcon {
+  			value 2;
+  			description
+  				"Only includes def-mac-status, def-remote-ccm, def-error-ccm,
+  				and def-xcon-ccm.";
+  		}
+  		enum remote-error-xcon {
+  			value 3;
+  			description
+  				"Includes def-remote-ccm, def-error-ccm, and def-xcon-ccm.";
+  		}
+  		enum error-xcon {
+  			value 4;
+  			description
+  				"Includes def-error-ccm and def-xcon-ccm.";
+  		}
+  		enum xcon {
+  			value 5;
+  			description
+  				"Only def-xcon-ccm";
+  		}
+  		enum no-xcon {
+  			value 6;
+  			description
+  				"No defects def-xcon or lower are to be reported.";
+  		}
+  	}
+  	description
+  		"An integer value specifying the lowest priority defect
+  		that is allowed to generate a Fault Alarm (20.9.5).";
+  }
+  
+  typedef sender-id-permission-type {
+  	type enumeration {
+  		enum send-id-none {
+  			value 1;
+  			description 
+  				"The Sender ID TLV is not to be sent.";
+  		}
+  		enum send-id-chassis {
+  			value 2;
+  			description
+  				"The Chassis ID Length, Chassis ID Subtype, and Chassis ID
+  				fields of te Sender ID TLV are to be sent.";
+  		}
+  		enum send-id-manage {
+  			value 3;
+  			description
+  				"The Management Address Length and Management Address
+  				of the Sender ID TLV are to be sent.";
+  		}
+  		enum send-id-chassis-manage {
+  			value 4;
+  			description
+  				"The Chassis ID Length, Chassis ID Subtype, Chassis ID, 
+  				Managment Address Length and Managemetn Address fields are
+  				all to be sent.";
+  		}
+  		enum send-id-defer {
+  			value 5;
+  			description
+  				"The content of the Sender ID TLV are determined by the
+  				corresponding Maintenance Domain variable.";
+  		}
+  	}
+  	description
+  		"Indicates what, if anything, is to be included in the Sender
+  		ID TLV transmitted in CCMs, LBMs, LTMs, and LTRs.";
+  }
+  
+  typedef ccm-interval-type {
+  	type enumeration {
+  		enum inteval-invalid {
+  			value 0;
+  			description
+  				"No CCMs are sent.";
+  		}
+  		enum interval-300hz {
+  			value 1;
+  			description
+  				"CCMs are sent every 3 1/3 milliseconds (300Hz).";
+  		}
+  		enum interval-10ms {
+  			value 2;
+  			description
+  				"CCMs are sent every 10 milliseconds.";
+  		}
+  		enum interval-100ms {
+  			value 3;
+  			description
+  				"CCMs are sent every 100 milliseconds.";
+  		}
+  		enum interval-1sec {
+  			value 4;
+  			description
+  				"CCMs are sent every second.";
+  		}
+  		enum interval-10sec {
+  			value 5;
+  			description
+  				"CCMs are sent every 10 seconds.";
+  		}
+  		enum interval-1min {
+  			value 6;
+  			description
+  				"CCMs are sent every minute.";
+  		}
+  		enum interval-10min {
+  			value 7;
+  			description
+  				"CCMs are sent every 10 minutes.";
+  		}
+  	}
+  	description
+  		"Indicates the interval at which CCMs are sent by a MEP.";
+  }
+  
+  typedef fng-state-type {
+  	type enumeration {
+  		enum fng-reset {
+  			value 1;
+  			description
+  				"No defect has been present since the mep-fng-reset-time
+  				timer expired, or since the state machine was last reset.";
+  		}
+  		enum fng-defect {
+  			value 2;
+  			description
+  				"A defect is present, but not for a long enough time to be
+  				reported.";
+  		}
+  		enum fng-report-defect {
+  			value 3;
+  			description
+  				"A momentary state during which the defect is reported by sending a
+  				fault-alarm notifcation, if that action is enabled.";
+  		}
+  		enum fng-defect-reported {
+  			value 4;
+  			description
+  				"A defect is present, and some defect has been reported.";
+  		}
+  		enum fng-defect-clearing {
+  			value 5;
+  			description
+  				"No defect is present, but the mep-fng-reset-time timer
+  				has not yet expired.";
+  		}
+  	}
+  	description
+  		"Indicates the diferent states of the MEP Fault Notification
+  		Generator State Machine.";
+  }
+  
+  typedef relay-action-field-value {
+  	type enumeration {
+  		enum relay-hit {
+  			value 1;
+  			description
+  				"The LTM reached a Maintenance Point whose MAC address
+  				matches the target address.";
+  		}
+  		enum relay-fdb {
+  			value 2;
+  			description
+  				"The Egress Port was determiend by consulting the Filtering
+  				Database.";
+  		}
+  		enum relay-mpdb {
+  			value 3;
+  			description
+  				"The Egress Port was determined by consulting the MIP CCM
+  				Database.";
+  		}
+  	}
+  	description
+  		"Possible values the Relay action field can take.";
+  }
+  
+  typedef ingress-action-field-value {
+  	type enumeration {
+  		enum ingress-no-tlv {
+  			value 0;
+  			description
+  				"Indicates that no Reply Ingress TLV was returned in the LTM.";
+  		}
+  		enum ingress-ok {
+  			value 1;
+  			description
+  				"The target data frame would be passed through to the MAC 
+  				Relay Entity.";
+  		}
+  		enum ingress-down {
+  			value 2;
+  			description
+  				"The Bridge Ports MAC_Operational paramter is false.";
+  		}
+  		enum ingress-blocked {
+  			value 3;
+  			description
+  				"The target data frame woujld not be forarded if received on
+  				this Port due to active topology enforcement.";
+  		}
+  		enum ingress-vid {
+  			value 4;
+  			description
+  				"The ingress port is not in the member set of the LTMs VID,
+  				and ingress filtering is enabled, so the target data frame
+  				would be filtered by ingress filtering.";
+  		}
+  	}
+  	description
+  		"Possible values returned in the ingress action field.";
+  }
+  
+  typedef egress-action-field-value {
+  	type enumeration {
+  		enum egress-no-tlv {
+  			value 0;
+  			description
+  				"Indicates that no Reply Egress TLV was returned in the LTM.";
+  		}
+  		enum egress-okay {
+  			value 1;
+  			description
+  				"The targeted data frame would be forwarded.";
+  		}
+  		enum egress-down {
+  			value 2;
+  			description
+  				"The Egress Port can be identified, but that Bridge Port
+  				MAC_Operational parameter is false.";
+  		}
+  		enum egress-blocked {
+  			value 3;
+  			description
+  				"The Egress Port can be identified, but the data frame would
+  				not pass through the Egress Port due to active topology 
+  				management (i.e., the Bridge Port is not in the 
+  				Forwardin state.";
+  		}
+  		enum egress-vid {
+  			value 4;
+  			description
+  				"The Egress Port can be identifid, but the Bridge Port is not
+  				in the LTMs VIDs member set, so would be filtered by
+  				egress filtering.";
+  		}
+  	}
+  	description
+  		"Possible values returned in the egress action field.";
+  }
+  
+  typedef remote-mep-state-type {
+  	type enumeration {
+  		enum rmep-idle {
+  			value 1;
+  			description
+  				"Momentary state during reset.";
+  		}
+  		enum rmep-start {
+  			value 2;
+  			description
+  				"The timer has not expired since the state machine
+  				was reset, and no valid CCM has yet been received.";
+  		}
+  		enum rmep-failed {
+  			value 3;
+  			description
+  				"The timer has expired, both since the state machine was
+  				reset, and since a valid CCM was received.";
+  		}
+  		enum rmep-ok {
+  			value 4;
+  			description
+  				"The timer has not expired since a valid CCM was received.";
+  		}
+  	}
+  	description
+  		"Operational state of the remote MEP state machine. This
+  		state machine monitors the reception of valid CCMs from a
+  		remote MEP with a specific MEPID. It uses a timer that
+  		expires in 3.5 times the length of time indicated by the
+  		ma-ccm-interval object.";
+  }
+  
+  typedef mep-defects-type {
+  	type bits {
+  		bit def-rdi-ccm {
+  			position 0;
+  			description
+  				"A remote MEP reported that RDI bit in its last CCM.";
+  		}
+  		bit def-mac-status {
+  			position 1;
+  			description
+  				"Either some remote MEP is reporting its Interface Status
+  				TLV as not isUp, or all remote MEPs are reporting a Port 
+  				Status TLV that contains some value other than psUp.";
+  		}
+  		bit def-remote-ccm {
+  			position 2;
+  			description
+  				"The MEP is not receiving valid VCMs from at least one of
+  				the remote MEPs.";
+  		}
+  		bit def-error-ccm {
+  			position 3;
+  			description
+  				"The MEP has received at least one invalid CCM whose CCM
+  				Interval has not yet timed out.";
+  		}
+  		bit def-xcon-ccm {
+  			position 4;
+  			description
+  				"The MEP has received at last one CCM from either another 
+  				MAID or a lower MD level whose CCm Interval has not yet 
+  				timed out.";
+  		}
+  	}
+  	description
+  		"A MEP can detect and report a number of defects, and multiple
+  		defects can be present at the same time.";
+  }
+  
+  typedef config-errors {
+  	type bits {
+  		bit cfm-leaf {
+  			position 0;
+  			description
+  				"MA x is associated with a specific VID list, one or more 
+  				of the VIDs in MA x can pass through the Bridge Port,
+  				no Down MEP is configured on any Bridge Port for MA x,
+  				and some other MA y, at a higher MD Level than MA x, and
+  				associated with at least one of the VID(s) also in MA x,
+  				does have a MEP configured on the Bridge Port.";
+  		}
+  		bit conflicting-vids {
+  			position 1;
+  			description
+  				"MA x is associated with a specific VID list, an Up MEP is
+  				configured on MA x on the Bridge Port, and some other MA y,
+  				associated with at least one of the VID(s) also in MA x,
+  				also has an Up MEP configured on some Bridge Port.";
+  		}
+  		bit excessive-levels {
+  			position 2;
+  			description
+  				"The number of different MD Levels at which MIPs are to be
+  				created on this port exceeds the Bridge's capabilities.";
+  		}
+  		bit overlapped-levels {
+  			position 3;
+  			description
+  				"A MEP is created for one VID at one MD Level, but a MEP is
+  				configured on another VID at that MD Level or higher,
+  				exceeding the Bridges capabilities.";
+  		}
+  	}
+  	description
+  		"While making the MIP creation evaluation described in
+  		22.2.3, the management entity can encounter errors in
+  		the configuration.";
+  }
+  
+  typedef mep-tx-ltm-flags-type {
+  	type bits {
+  		bit use-fdb-only {
+  			position 0;
+  			description
+  				"Use FDB only";
+  		}
+  	}
+  	description
+  		"The flags field for LTMs transmitted by the MEP.";
+  }
+  
+  typedef fault-alarm-adress-type {
+  	type enumeration {
+  		enum address {
+  			value 1;
+  			description
+  				"Indicates that a Network address tow hich Fault Alarms
+  				are to be transmitted should be used.";
+  		}
+  		enum not-specified {
+  			value 2;
+  			description
+  				"Indicates not specified. In the case of a MA, then the
+  				selection used by the MD should be used.";
+  		}
+  		enum not-transmitted {
+  			value 3;
+  			description
+  				"Indicates that Fault alarms are not to be transmitted.";
+  		}
+  	}
+  	description
+			"The Fault Alarm adress indicators.";
+  }
+
+
+  /* ---------------------------------------------------
+   * Configuration objects used by 802.1Qcx YANG module
+   * ---------------------------------------------------
+   */
+  
+  container cfm {
+  	description
+  		"Connectivity Fault Management configuration and operational
+  		information.";
+  	
+  	container cfm-stacks {
+  		description 
+  			"he CFM Stack contains information about the Maintenance
+    		Points configured on a particular Bridge Port (or
+    		aggregated port). It contains all CFM Stack specific related
+    		configuration and operational data.";
+  		leaf bridge {
+  			type bridge-ref;
+  			description
+  				"A Bridge on which the CFM Stack is associated with.";
+  		}
+  		list cfm-stack {
+    		key "bridge-port type-of-service-selector service-selector-or-none md-level direction";
+    		description
+    			"The CFM Stack contains information about the Maintenance
+      		Points configured on a particular Bridge Port (or
+      		aggregated port). It contains all CFM Stack specific related
+      		configuration and operational data.
+    			
+    			Upon a restart of the system, the system SHALL, if necessary,
+    			change the value of this variable, and rearrange the
+    			cfm-stack, so that it indexes the entry in the
+    			interface table with the same value of interface-ref that it
+    			indexed before the system restart. If no such entry exists,
+    			then the system SHALL delete all entries in the
+    			cfm-stack with the interface index.";  		
+    		leaf bridge-port {
+      		type if:interface-ref;
+      		description
+      			"An interface on which maintenance points might be 
+      			configured. This object represents the Bridge Port or 
+      			aggregated port on which MEPs or MHFs might be 
+      			configured.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2a";
+      	}
+      	leaf type-of-service-selector {
+      		type service-selector-type;
+      		description
+      			"Type of the service selector identifier.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2d, 22.1.7";
+      	}
+      	leaf service-selector-or-none {
+      		type service-selector-value-or-none;
+      		description
+      			"Service Selector identifier to which the MP is attached,
+      			or 0, if none.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2d, 22.1.7";
+      	}  	
+      	leaf md-level {
+      		type md-level-type;
+      		description
+      			"The MD level of the maintenance point";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2b";
+      	}
+      	leaf direction {
+      		type mp-direction-type;
+      		description
+      			"The direction in which the maintenance point faces on the 
+      			Bridge Port.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2c";  		
+      	}
+      	leaf maintenance-domain-index {
+      		type uint32;
+      		config false;
+      		description
+      			"The Maintenance Domain reference to which the Maintenance
+      			Points Maintenance Assocaition is associated. If none,
+      			then 0.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.3b";
+      	}
+      	leaf maintenance-association-index {
+      		type uint32;
+      		config false;
+      		description
+      			"The Maintenance Association reference to which the 
+      			Maintenance Point is associated. If none, then 0.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.3c";
+      	}
+      	leaf mep-id {
+      		type mep-id-or-zero-type;
+      		config false;
+      		description
+      			"The MEP identifier is a MEP is configured. Otherwise is 0.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.3d";
+      	}
+      	leaf mac-address {
+      		type ieee:mac-address;
+      		config false;
+      		description
+      			"The MAC address of the maintenance point.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.2.1.3e";
+      	}
+    	}	 // cfm-stack
+  	} // cfm-stacks
+  	
+  	container default-md-levels {
+  		description
+  			"There is a single Default MD Level managed object per Bridge
+  			Component. It controls MIP Half Function (MHF) creation for
+  			VIDs or I-SIDs of I- or B-components that are not contained in
+  			the list of VIDs attached to any specific Maintenance 
+  			Association managed object, and the transmission of the Sender
+  			ID TLV by those MHFs.";
+  		leaf bridge {
+  			type bridge-ref;
+  			description
+  				"A Bridge on which the Default MD Level object is associated
+  				with.";
+  		}
+  		list default-md-level {
+    		key "component-id primary-selector-type primary-selector";
+    		description
+    			"For each bridge component, the Default MD Level Managed 
+    			Object controls MHF creation for VIDs that are not attached
+    			to a specific Maintenance Association Managed Object, and
+    			Sender ID TLV transmission by those MHFs.
+    			
+    			For each Bridge Port, and for each VLAN ID whose data can
+    			pass through that Bridge Port, an entry in this table is
+    			used by the algorithm in subclause 22.2.3 only if there is no
+    			entry in the Maintenance Association table defining an MA
+    			for the same VLAN ID and MD Level as this table's entry, and
+    			on which MA an Up MEP is defined. If there exists such an
+    			MA, that MA's objects are used by the algorithm in
+    			subclause 22.2.3 in place of this table entrys objects.
+    			
+    			The agent maintains the value of md-status to indicate
+    			whether this entry is overridden by an MA. When first
+    			initialized, the agent creates this table automatically with
+    			entries for all VLAN IDs, with the default values specified
+    			for each object. After this initialization, the writable
+    			objects in this table need to be persistent upon reboot or
+    			restart of a device.";
+    		leaf component-id {
+    			type component-identifier-type;
+    			description
+    				"The Bridge component within the system to which the
+    				information in this entry applies. If the system is not a
+    				Bridge, or if only one component is present in the Bridge,
+    				then this variable (index) MUST be equal to 1.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 12.3l";
+    		}
+    		leaf primary-selector-type {
+    			type service-selector-type;
+    			description
+    				"Type of the Primary Service Selector identifier.";
+    		}
+    		leaf primary-selector {
+    			type service-selector-value;
+    			description
+    				"Primary Service Selector identifier of a Service Instance
+    				with no MA configured.";
+    		}
+    		leaf-list selectors {
+      		type service-selector-value;
+      		description
+      			"A list of VIDs associated with any MHF on the VID, always
+      			including that VID, or the Backbone-SID of the B-component
+      			or VIP-SID of the I-component associated with any MHF on
+      			the I-SID. The first VID is the MAs Primary VID.
+      			
+      			List is empty if no VID specified.";
+      		reference
+      			"IEEE 802.1Q-2017 Clause 12.14.3.1.3a";
+      	}
+    		leaf md-status {
+    			type boolean;
+    			description
+    				"State of this Default MD Level table entry. True if there is
+    				no entry in the Maintenance Association table defining an MA
+    				for the same VLAN ID and MD Level as this tables entry, and
+    				on which MA an Up MEP is defined, else false.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 12.14.3.1.3b";
+    		}
+    		leaf md-level {
+    			type md-level-or-none-type;
+    			default -1;
+    			description
+    				"A value indicating the MD Level at which MHFs are to be
+    				created, and Sender ID TLV transmission by those MHFs is to
+    				be controlled, for the VLAN to which this entry's objects
+    				apply.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 12.14.3.1.3c, 12.14.3.2.2b";
+    		}
+    		leaf mhf-creation {
+    			type mhf-creation-type;
+    			default "mhf-defer";
+    			description
+    				"A value indicating if the Management entity can create MHFs
+    				(MIP Half Function) for this VID at this MD Level. If this
+    				object has the value mhf-defer, MHF creation for this VLAN
+    				is controlled by md-mhf-creation. The value of this variable
+    				is meaningless if the values of md-status is false.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 12.14.3.1.3d";
+    			
+    		}
+    		leaf id-permission {
+    			type sender-id-permission-type;
+    			default "send-id-defer";
+    			description
+    				"Enumerated value indicating what, if anything, is to be
+    				included in the Sender ID TLV transmitted by MHFs
+    				created by the Default Maintenance Domain. If this object
+    				has the value send-if-deferr, Sender ID TLV transmission 
+    				for this VLAN is controlled by md-id-permission-type. The
+    				value of this variable is meaningless if the values of
+    				md-status is false.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 12.14.3.1.3e, 12.14.3.2.2a";
+    		}
+    	} // default-md-level
+  	} // default-md-levels
+  	
+  	container config-errors {
+  		description
+  			"The Configuration Error List managed object is a list of
+  			{identifier, port} pairs configured in error together with
+  			the identity of the configuration error.";
+  		leaf bridge {
+  			type bridge-ref;
+  			description
+  				"A Bridge on which the Configuraton Error is associated
+  				with.";
+  		}
+  		list config-error {
+  			key "type-of-selector selector bridge-port";
+  			description
+  				"The CFM Configuration Error List table provides a list of
+  				Interfaces and VIDs that are incorrectly configured.";
+  			leaf type-of-selector {
+  				type service-selector-type;
+    			description
+    				"Type of the Primary Service Selector identifier.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 12.14.4.1.2a";
+  			}
+  			leaf selector {
+  				type service-selector-value;
+    			description
+    				"The Service Selector Identifier of the Service with 
+    				interfaces in error.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 12.14.4.1.2a";
+  			}
+  			leaf bridge-port {
+  				type if:interface-ref;
+  				description
+  					"The interface index of the interface (i.e., Bridge 
+  					Port).
+  					
+  					Upon a restart of the system, the system SHALL, if 
+  					necessary, change the value of this variable so that it
+  					indexes the entry in the interface table with the same
+  					value of the index that it indexed before the system
+  					restart. If no such entry exists, then the system SHALL
+  					delete any entries in config-error-list indexed by that
+  					interface-ref.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.4.1.2b";
+  			}
+  			leaf error-type {
+  				type config-errors;
+  				config false;
+  				description
+  					"vector of Boolean error conditions from 22.2.4.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.4.1.3b";
+  			}
+  		} // config-error
+  	} // config-errors
+    
+  	container maintenance-domains {
+  		description
+  			"A Maintenance Domain object is required in order to create an
+  			MA with a Maintenance Association Identifier (MAID) that
+  			includes that Maintenance Domains Name. From this Maintenance
+  			Domain managed object, all Maintenance Association managed
+  			objects associated with that Maintenance Domain managed object
+  			can be accessed, and thus controlled.";
+  		leaf bridge {
+  			type bridge-ref;
+  			description
+  				"A Bridge on which the given list of MDs is associated
+  				with.";
+  		}
+  		list maintenance-domain {
+    		key "name-format name";
+    		description
+    			"Contains the Maintenance Domain configuration and 
+    			operational data. A Maintenance Domain is the network or the
+    			part of the network for which faults in connectivity can be
+    			managed. The boundary of a Maintenance Domain is defined by
+    			a set of Domain Service Access Points (DoSAPs), each of 
+    			which can become a point of connectivity to a service 
+    			instance.";
+    		leaf name-format {
+    			type md-name-format-type;
+    			//default "char-string";
+    			description
+    				"The type (or format) of the Maintenance Domain name.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 21.6.5.1";
+    		}
+    		leaf name {
+    			type md-name-type;
+    			//default "DEFAULT";
+    			description
+    				"The Maintenance Domain name. Each Maintenance Domain has a
+    				unique name among all those used or available to a service
+    				provider or operator. It facilitates easy idenification
+    				of administrative responsibility for each Maintenance
+    				Domain.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 3.122, 21.6.5.3";
+    		}
+    		leaf md-index {
+    			type uint32;
+    			description
+    				"The index to the Maintenance Domain list.";
+    		}
+    		leaf md-level {
+    			type md-level-type;
+    			default 0;
+    			description
+    				"The Maintenance Domain level.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3b";
+    		}
+    		leaf mhf-creation {
+    			type mhf-creation-type;
+    			default mhf-none;
+    			description
+    				"Value indicating whether the management entity can
+    				create MHFs (MIP Half Function) for this Maintenance
+    				Domain. Since there is no encompassing Maintenance
+    				Domain, the vlaue mhf-defer is not allowed.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
+    		}
+    		leaf id-permission {
+    			type sender-id-permission-type;
+    			description
+    				"Value indicating what, if anything, is to be included in
+    				the Sender ID TLV transmitted by Maintenance Points
+    				configured in this Maintenance Domain. Since there is no
+    				encompassing Maintenance Domain, the value send-id-defer
+    				is not allowed.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3d";
+    		}
+    		leaf fault-alarm-address {
+    			type fault-alarm-adress-type;
+    			default "not-transmitted";
+    			description
+    				"A value indicating whether Fault Alarms are to be 
+    				transmitted or not. The default is not transmit.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3e";
+    		}
+    		
+    		list maintenance-association {
+    			key "name name-format";
+    			description
+    				"Provides configuration and operational data for the
+    				Maintenance Associations. A Maintenance Association is a 
+    				set of MEPs, each configured with the same MAID and MD 
+    				level, established to verify the integrity of a single
+    				service instance. A Maintenance Association can be thought
+    				of as a full mesh of Maintenance Entities among a set of
+    				MEPs so configured.";
+    			leaf name {
+    				type ma-name-type;
+    				description
+    					"The Short Maintenance Association name. The type/format
+    					is determiend by the value of ma-name-format. This name
+    					must be unique within a maintenance domain.";
+    				reference
+    					"IEEE 802.1Q-2017 Clause 21.6.5.6";
+    			}
+    			leaf name-format {
+    				type ma-name-format-type;
+    				description
+    					"The type (format) of the Maintenance Association name.";
+    				reference
+    					"IEEE 802.1Q-2017 Clause 21.6.5.4";
+    			}
+    			leaf ma-index {
+    				type uint32;
+    				description 
+    					"Key of the Maintenance Association list of entries.";
+    			}
+    			leaf md-reference {
+    				type uint32;
+    				description
+    					"An index reference to the Maintenance Domain that this
+    					Maintenance Association belongs to.";
+    				reference
+    					"IEEE 802.1Q-2017 Clause 12.14.5.3.2a";
+    			}
+    			leaf mhf-creation {
+      			type mhf-creation-type;
+      			default mhf-defer;
+      			description
+      				"Value indicating whether the management entity can
+      				create MHFs (MIP Half Function) for this Maintenance
+      				Domain. Since there is no encompassing Maintenance
+      				Domain, the vlaue mhf-defer is not allowed.";
+      			reference
+      				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
+      		}
+    			leaf id-permission {
+      			type sender-id-permission-type;
+      			default send-id-defer;
+      			description
+      				"Value indicating what, if anything, is to be included
+      				in the Sender ID TLV transmitted by Maintenance Points
+      				configured in this Maintenance Domain. Since there is no
+      				encompassing Maintenance Domain, the value send-id-defer
+      				is not allowed.";
+      			reference
+      				"IEEE 802.1Q-2017 Clause 12.14.6.1.3d";
+      		}
+    			leaf ccm-interval {
+    				type ccm-interval-type;
+    				description
+    					"The interval between CCM transmissions to be used by all
+    					MEPs in the Maintenance Association.";
+    				reference
+    					"IEEE 802.1Q-2017 Clause 12.14.6.1.3e";
+    			}
+    			leaf-list selectors {
+    	  		type service-selector-value;
+    	  		description
+    	  			"The list of VIDs, I-SID, or the TE-SID monitored by 
+    	  			this MA, or 0, if the MA is not attached to a VID, or
+    	  			I-SID, or TE-SID. In the case of a list of VIDs, the 
+    	  			first VID in the list is the MAs Primary VID (default 
+    	  			none). The specification of I-SID is allowed only in
+    	  			the case of I- or B- components. The TE-SID is allowed
+    	  			only in the case that PBB-TE is supported.";
+    	  		reference
+    	  			"IEEE 802.1Q-2017 Clause 12.14.5.3.2c, 12.14.6.1.3b";
+    	  	}
+    			leaf fault-alarm-address {
+      			type fault-alarm-adress-type;
+      			default "not-specified";
+      			description
+      				"A value indicating whether Fault Alarms are to be 
+      				transmitted or not. The default is not specified, 
+      				which implies that the disposition of the fault-alarm
+      				used by the MD should be used.";
+      			reference
+      				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3e";
+      		}
+    			
+    			list maintenance-association-component {
+    				key ma-component-id;
+    				description
+    					"This is the part of the complete MA table that is
+    					variable across the Bridges in a Maintenance Domain, or
+    					across the components of a single Bridge.";
+    				leaf ma-component-id {
+    					type component-identifier-type;
+    					description
+    						"The Bridge component within the system to which the
+    						information applies. If the system is not a Bridge, or
+    						if only one component is present in the Bridge, then
+    						this variable (index) MUST be equal to 1";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.3l";
+    				}
+    				leaf primary-selector-type {
+    					type service-selector-type;
+    					description
+    						"Type of the Service Selector identifiers. In Services
+    						instances made of multiple Service Selector
+    						identifiers, ensures that the type of the Service 
+    						selector identifiers is the same.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
+    				}
+    				leaf primary-selector-or-none {
+    					type service-selector-value-or-none;
+    	    		description
+    	    			"Service Selector identifier to which the MP is 
+    	    			attached, or 0, if none.";
+    	    		reference
+    	    			"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
+    				}
+    				leaf mhf-creation {
+        			type mhf-creation-type;
+        			default mhf-defer;
+        			description
+        				"Value indicating whether the management entity can
+        				create MHFs (MIP Half Function) for this Maintenance
+        				Domain. Since there is no encompassing Maintenance
+        				Domain, the vlaue mhf-defer is not allowed.";
+        			reference
+        				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
+        		}
+    				leaf id-permission {
+    					type sender-id-permission-type;
+    	  			default "send-id-defer";
+    	  			description
+    	  				"Enumerated value indicating what, if anything, is to
+    	  				be included in the Sender ID TLV (21.5.3) transmitted
+    	  				by MPs configured in this MA.";
+    	  			reference
+    	  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3d";
+    				}
+    				leaf number-of-vids {
+    					type uint32;
+    					description
+    						"The number of VIDs associated with the MA.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
+    				}
+    				leaf-list selectors {
+      	  		type service-selector-value;
+      	  		description
+      	  			"The list of VIDs, I-SID, or the TE-SID monitored by 
+      	  			this MA, or 0, if the MA is not attached to a VID, or
+      	  			I-SID, or TE-SID. In the case of a list of VIDs, the 
+      	  			first VID in the list is the MAs Primary VID (default 
+      	  			none). The specification of I-SID is allowed only in
+      	  			the case of I- or B- components. The TE-SID is allowed
+      	  			only in the case that PBB-TE is supported.";
+      	  		reference
+      	  			"IEEE 802.1Q-2017 Clause 12.14.5.3.2c, 12.14.6.1.3b";
+      	  	}
+    			} // maintenance-association-component
+    			
+    			list mep {
+    				key "mep-id";
+    				description 
+    					"A list of Maintenance association End Points (MEPs). A
+    					MEP is an actively managed CFM entity, associated with a 
+    					specific DoSAP of a service instance, which can generate
+    					and receive CFM PDUs and track any responses. It is an 
+    					end point of a single Maintenance Association (MA) and is
+    					an end point of a separate Maintenance Entity for each of
+    					the other MEPs in the same MA.";
+    				leaf mep-id {
+    					type mep-id-type;
+    					description
+    						"Integer that is unique among all the MEPs in the same
+    						Maintenance Association.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+    				}
+    				leaf ma-reference {
+    					type uint32;
+    					description
+    						"An index reference to the particular Maintenance
+    						Association that this MEP belongs to.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
+    				}
+    				leaf bridge-port {
+    					type if:interface-ref;
+    					description
+    						"The interface index of the interface (i.e., Bridge 
+    						Port) to which the MEP is attached.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+    				}
+    				leaf mep-direction {
+    					type mp-direction-type;
+    					description
+    						"The direction in which the MEP faces on the Bridge
+    						Port. Example, up or down.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
+    				}
+    				leaf mep-primary-vid {
+    					type uint32 {
+    						range "0..16777215";
+    					}
+    					default 0;
+    					description
+    						"An integer indicating the Primary VID of the MEP. It
+    						is always one of the VIDs assigned to the MEPs MA. A
+    						value of 0 indicates that either the Primary VID is
+    						that of the MEPs MA, or that the MEPs MA is associated
+    						with no VID.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
+    				}
+    				leaf mep-admin-state {
+    					type boolean;
+    					default "false";
+    					description
+    						"The administrative state of the MEP. TRUE indicates
+    						that the MEP is to functional normally, and FALSE
+    						indicates that it is to cease functioning.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
+    				}
+    				leaf mep-fng-state {
+    					type fng-state-type;
+    					default "fng-reset";
+    					config false;
+    					description
+    						"The current state of teh MEP Fault Notification 
+    						Generator state machine.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
+    				}
+    				leaf mep-ccm-enabled {
+    					type boolean;
+    					default "false";
+    					description
+    						"Indicates whether the MEP can generate CCMs. If TRUE,
+    						the MEP will generate CCM PDUs.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
+    				}
+    				leaf mep-ccm-ltm-priority {
+    					type dot1q-types:priority-type;
+    					description
+    						"The priority value for CCMs and LTMs transmitted by
+    						the MEP. The default value is the highest priority 
+    						allowed to pass through the Bridge Port for any of the
+    						MEPs VID(s).";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+    				}
+    				leaf mep-mac-address {
+    					type ieee:mac-address;
+    					description
+    						"The MAC address of the MEP.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
+    				}
+    				leaf fault-alarm-address {
+        			type fault-alarm-adress-type;
+        			default "not-specified";
+        			description
+        				"A value indicating whether Fault Alarms are to be 
+        				transmitted or not. The default is not specified, 
+        				which implies that the disposition of the fault-alarm
+        				used by the MD should be used.";
+        			reference
+        				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
+        		}
+    				leaf mep-lowest-priority-defect {
+    					type lowest-alarm-priority-type;
+    					default "mac-remote-error-xcon";
+    					description
+    						"The lowest priority defect that is allowed to generate
+    						fault alarms.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
+    				}
+    				leaf mep-fng-alarm-time {
+    					type yang:zero-based-counter32 {
+    						range "250..1000";
+    					}
+    					units deciseconds;
+    					default 250;
+    					description
+      					"The time that defect must be present before a Fault
+      					Alarm is issued.";
+      				reference
+      					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
+    				}
+    				leaf mep-fng-reset-time {
+      				type yang:zero-based-counter32 {
+      					range "250..1000";  					
+      				}
+      				units deciseconds;
+      				default 1000;
+      				description
+      					"The time that defects must be absent before resetting
+      					a Fault Alarm.";
+      				reference
+      					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
+      			}
+    				leaf mep-highest-priority-defect {
+    					type highest-defect-priority-type;
+    					config false;
+    					description
+    						"The highest priority defect that has been present
+    						sicne the MEPs Fault Notification Generator state
+    						machine was last in the FNG_RESET state.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
+    				}
+    				leaf mep-defects {
+    					type mep-defects-type;
+    					config false;
+    					description
+    						"Vector of boolean error conditions";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
+    						20.23.3, 20.35.5, 20.35.6, 20.35.7";
+    				}
+    				leaf mep-error-ccm-last-failure {
+    					type string {
+    						length "1..1522";
+    					}
+    					config false;
+    					description
+    						"The last received CCM that triggered a def-error-ccm
+    						fault.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
+    				}
+    				leaf mep-xcon-ccm-last-failure {
+    					type string {
+    						length "1..1522";
+    					}
+    					config false;
+    					description
+    						"The last received CCM that triggered a def-xcon-ccm
+    						fault.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
+    				}
+    				leaf mep-next-lbm-trans-id {
+    					type uint32;
+    					config false;
+    					description
+    						"Next sequence number identifier to be sent in a
+    						Loopback message. This sequence number can be zero
+    						since it can wrap around.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3x, 20.28.2";
+    				}
+    				leaf mep-ltm-next-seq-number {
+    					type uint32;
+    					config false;
+    					description
+    						"Next transaction identifier to be sent in a LinkTrace
+    						message.This sequence number can be zero since it
+    						can wrap around.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ab, 20.41.1";
+    				}
+    				leaf-list active-rmeps {
+    					type mep-id-type;
+    					description
+    						"A list indicating which of the remote MEPs in the
+    						same MA are active. By default, all configured
+    						remote MEPs in the same MA are active.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+    				}
+    				leaf mep-transmit-lbm-status {
+    					type boolean;
+    					default "false";
+    					description
+    						"A Boolean flag set to TRUE by the MEP Loopback
+    						Initiator state machine or YANG network configuration
+    						manager to indicate that another LBM is being 
+    						transmitted. Reset to FALSE by the MEP Loopback
+    						initiator state machine.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 20.32, Figure 20-11";
+    				}
+    				leaf mep-transmit-lbm-dest-mac-address {
+    					type ieee:mac-address;
+    					description
+    						"The target MAC Address field to be transmitted.
+    						A unicast destination MAC address. This address
+    						is used if node mep-transmit-lbm-dest-is-mep-id
+    						is FALSE.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+    				}
+    				leaf mep-transmit-lbm-dest-mep-id {
+    					type mep-id-or-zero-type;
+    					description
+    						"The identifier of a remote MEP in the same MA to
+    						which the LBM is to be sent. This address
+    						is used if node mep-transmit-lbm-dest-is-mep-id
+    						is TRUE.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+    				}
+    				leaf mep-transmit-lbm-dest-is-mep-id {
+    					type boolean;
+    					description
+    						"TRUE indicates that MEP ID of the target MEP is used
+    						for Loopback transmissions. FALSE indicates that
+    						unicast destination MAC address of the target MEP is
+    						used for Loopback transmissions.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+    				}
+    				leaf mep-transmit-lbm-messages {
+    					type uint32 {
+    						range "1..1024";
+    					}
+    					default 1;
+    					description
+    						"The number of Loopback messages to be transmitted.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2c";
+    				}
+    				leaf mep-transmit-lbm-data-tlv {
+    					type string;
+    					description
+    						"An arbitraty amoun tof data to be included in the
+    						Data TLV, if the Data TLV is selected to be sent. The
+    						intent is to be able to fill the frame carrying the
+    						CFM PDU to its maximum length.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
+    				}
+    				leaf mep-transmit-lbm-vlan-priority {
+    					type dot1q-types:priority-type;
+    					description
+    						"Priority. 3 bit value to be used in the VLAN tag, if
+    						present in the transmitted frame. The default value
+    						should be the CCM priority.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+    				}
+    				leaf mep-transmit-lbm-vlan-drop-eligible {
+    					type boolean;
+    					default "false";
+    					description
+    						"Drop eligible bit value to be used in the VLAN tag, if
+    						present in the transmitted frame";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+    				}
+    				leaf mep-transmit-lbm-result-ok {
+    					type boolean;
+    					default "true";
+    					config false;
+    					description
+    						"Indicates the result of the operation:
+    						   TRUE - The LBM will be (or has been) sent.
+    						   FALSE - The LBM will not be sent.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.3a";
+    				}
+    				leaf mep-transmit-lbm-seq-number {
+    					type uint32;
+    					description
+    						"The Loopback transaction identifier
+    						(mep-next-lbm-trans-id) of the first LBM (to be) sent.
+    						The value returned is undefined if 
+    						mep-transmit-lbm-result-ok is FALSE.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.3.3b";
+    				}
+    				leaf mep-transmit-ltm-status {
+    					type boolean;
+    					default "true";
+    					config false;
+    					description
+    						"A Boolean flag set to TRUE by the Bridge Port to 
+    						indicate that another LTM may be transmitted. Reset to
+    						FALSE by the MEP Linktrace initiator state machine.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 20.49, Figure 20-17";
+    				}
+    				leaf mep-transmit-ltm-flags {
+    					type mep-tx-ltm-flags-type;
+    					default use-fdb-only;
+    					description
+    						"The flags field for the LTMs transmitted by the MEP.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2b, 20.42.1";
+    					
+    				}
+    				leaf mep-transmit-ltm-target-mac-address {
+    					type ieee:mac-address;
+    					description
+    						"The target MAC address field to be transmitted. A
+    						unicast MAC address. This address will be used if the
+    						value of mep-transmit-ltm-target-is-mep-id is FALSE.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+    				}
+    				leaf mep-transmit-ltm-target-mep-id {
+    					type mep-id-or-zero-type;
+    					description
+    						"The target MAC address field to be transmitted. The
+    						MEP identifier of another MEP in teh same MA. This
+    						address will be used if the value of 
+    						mep-transmit-ltm-target-is-mep-id is TRUE.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+    				}
+    				leaf mep-transmit-ltm-target-is-mep-id {
+    					type boolean;
+    					default "false";
+    					description
+    						"TRUE indicates taht MEP id of the target MEP is used
+    						for Linktrace transmission. FALSE indicates that
+    						unicast destination MAC address of the target MEP is
+    						used for LinkTrace transmission.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+    				}
+    				leaf mep-transmit-ltm-ttl {
+    					type uint32 {
+    						range "0..255";
+    					}
+    					default 64;
+    					description
+    						"The LTM TTL field. Indicates the number of hops 
+    						remaining to the LTM. Decremented by 1 by each
+    						Linktrace Responder that handles the LTM. The value
+    						returned in the LTR is one less than that received in
+    						the LTM. If the LTM TTL is 0 or 1, the LTM is not
+    						forwarded to the next hop, and if 0, no LTR is 
+    						generated.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2d, 21.8.4";
+    				}
+    				leaf mep-transmit-ltm-result {
+    					type boolean;
+    					default "true";
+    					config false;
+    					description
+    						"Indicates the result of the operation:
+    						   TRUE - The Linktrace message will be (or has been) 
+    						          sent.
+    						   FALSE - The Linktrace message will not be sent.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.4.3a";
+    				}
+    				leaf mep-transmit-ltm-seq-number {
+    					type uint32;
+    					config false;
+    					description
+    						"The LTM transaction identifier 
+    						(mep-ltm-next-seq-number) of the LTM sent. The value
+    						returned is undefined if mep-transmit-ltm-result is 
+    						FALSE.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.4.3b";
+    				}
+    				leaf mep-transmit-ltm-egress-identifier {
+    					type string {
+    						length "8";
+    					}
+    					config false;
+    					description
+    						"Identifies the MEP Linktrace Initiator that is 
+    						originating, or the Linktrace Responder that is
+    						forwarding, this LTM.
+    						
+    						The low-order six octets contain a 48-bit IEEE MAC
+    						address unique to the system in which the MEP Linktrace
+    						Initiator or Linktrace Responder resides. The 
+    						high-order two octets contain a value sufficient to 
+    						uniquely identify the MEP Linktrace Initiator or 
+    						Linktrace Responder within that system.
+    						
+    						For most Bridges, the address of any MAC attached to
+    						the Bridge will suffice for the low-order six octets,
+    						and 0 for the high-order octets. In some situations,
+    						e.g., if multiple virtual Bridges utilizing emulated
+    						LANs are implemented in a single physical system, the
+    						high-order two octets can be used to differentiate
+    						among the transmitting entities.
+    						
+    						The value returned is undefined if 
+    						mep-transmit-ltm-result is FALSE.";
+    					reference
+    						"IEEE 802.1Q-2017 Clause 12.14.7.4.3c";  					
+    				}
+    				
+    				list linktrace-reply {
+    					key "ltr-seq-number ltr-receive-order";
+    					description
+    						"This table extends the MEP table and contains a list
+    						of Linktrace replies received by a specific MEP in
+    						response to a linktrace message.";
+    					leaf ltr-seq-number {
+    						type uint32 {
+    							range "0..4294967295";
+    						}
+    						description
+    							"Transaction identifier returned by a previous
+    							transmit linktrace message command, indicating which
+    							LTMs response is going to be returned.";
+    						reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.5.2b";
+    					}
+    					leaf ltr-receive-order {
+    						type uint32 {
+    							range "1..4294967295";
+    						}
+    						description
+    							"An index to distinguish among multiple LTRs with the
+    							same LTR Transaction Identifier field value. 
+    							Assigned sequentially from 1, in the order that the 
+    							Linktrace Initiator received the LTRs.";
+    					}
+    					leaf ltr-ttl {
+    						type uint32 {
+    							range "0..255";
+    						}
+    						config false;
+    						description
+    							"TTL field value for a returned LTR.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5, 20.41.2.2";
+    					}
+    					leaf ltr-forwarded {
+    						type boolean;
+    						config false;
+    						description
+    							"Indicates if a LTM was forwarded by the responding
+    							MP, as returned in the FwdYes flag of the flags 
+    							field.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3c, 20.41.2.1";
+    					}  					
+    					leaf ltr-terminal-mep {
+    						type boolean;
+    						config false;
+    						description
+    							"A Boolean value stating whether the forwarded LTM
+    							reached a MEP enclosing its MA, as returned in the
+    							Terminal MEP flag of the Flags field";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3d, 20.41.2.1";
+    					}
+    					leaf ltr-last-egress-identifier {
+    						type string {
+    							length "8";
+    						}
+    						config false;
+    						description
+    							"An octet field holding the Last Egress Identifier
+    							returned in the LTR Egress Identifier TLV of the LTR.
+    							The Last Egress Identifier identifies the MEP
+    							Linktrace Initiator that originated, or the Linktrace Responder
+    							that forwarded, the LTM to which this LTR is the
+    							response. This is the same value as the Egress
+    							Identifier TLV of that LTM.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3e, 20.41.2.3";
+    					}  					
+    					leaf ltr-next-egress-identifier {
+    						type string {
+    							length "8";
+    						}
+    						config false;
+    						description
+    							"An octet field holding the Next Egress Identifier
+    							returned in the LTR Egress Identifier TLV of the LTR.
+    							The Next Egress Identifier Identifies the Linktrace
+    							Responder that transmitted this LTR, and can forward
+    							the LTM to the next hop. This is the same value as
+    							the Egress Identifier TLV of the forwarded LTM, if
+    							any. If the FwdYes bit of the Flags field is false, 
+    							the contents of this field are undefined, i.e., any
+    							value can be transmitted, and the field is ignored by the
+    							receiver.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3f, 20.41.2.4";
+    					}  					
+    					leaf ltr-relay {
+    						type relay-action-field-value;
+    						config false;
+    						description
+    							"Value returned in teh Relay Action field.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
+    					}  					
+    					leaf ltr-chassis-id-subtype {
+    						type lldp-chassis-id-subtype;
+    						config false;
+    						description
+    							"Specifies the format of the Chassis ID returned
+    							in the Sender ID TLV of the LTR, if any. This value
+    							is meaningless if the ltr-chassis-id has a length
+    							of 0.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3h, 21.5.3.2";
+    					}  					
+    					leaf ltr-chassis-id {
+    						type lldp-chassis-id;
+    						config false;
+    						description
+    							"The Chassis ID returned in the Sender ID TLV of the
+    							LTR, if any. The format of this object is determined
+    							by the value of the ltr-chassis-id-subtype object.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3i, 21.5.3.2";
+    					}  					
+    					leaf ltr-man-address-domain {
+    						type transport-service-domain;
+    						config false;
+    						description
+    							"The transport-service-domain that identifies the
+    							type and format of the related mep-db-man-address
+    							object, used to access the YANG agent of the system
+    							transmitting the LTR. Received in the LTR Sender ID
+    							TLV from that system.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.5,
+    							21.9.6";
+    					}  					
+    					leaf ltr-man-address {
+    						type transport-service-address;
+    						config false;
+    						description
+    							"The transport-service-address that can be used to
+    							access the YANG	agent of the system transmitting the
+    							CCM, received in the CCM Sender ID TLV from that
+    							system.
+    							
+    							If the related object ltr-man-address-domain
+    							contains the value zeroDotZero, this object
+    							ltr-man-address MUST have a zero-length OCTET STRING
+    							as a value.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.7,
+    							21.9.6";
+    					}  					
+    					leaf ltr-ingress {
+    						type ingress-action-field-value;
+    						config false;
+    						description
+    							"The value returned in the Ingress Action Field of
+    							the LTM. The value ingress-no-tlv indicates that no
+    							Reply Ingress TLV was returned in the LTM.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3k, 20.41.2.6";
+    					}  					
+    					leaf ltr-ingress-mac {
+    						type ieee:mac-address;
+    						config false;
+    						description
+    							"MAC address returned in the ingress MAC address
+    							field. If the ltr-ingress object contains the value 
+    							ingress-no-tlv, then the contents of this object are
+    							meaningless.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3l, 20.41.2.7";
+    					}  					
+    					leaf ltr-ingress-port-id-subtype {
+    						type lldp-port-id-subtype;
+    						config false;
+    						description
+    							"Ingress Port ID. The format of this object is 
+    							determined by the value of the 
+    							ltr-ingress-port-id-subtype object. If the
+    							ltr-ingress object contains the value ingress-no-tlv, then the 
+    							contents of this object are meaningless.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3n, 20.41.2.9";
+    					}  					
+    					leaf ltr-egress {
+    						type egress-action-field-value;
+    						config false;
+    						description
+    							"The value returned in the Egress Action Field of the
+    							LTM. The value egress-no-tlv indicates that no Reply
+    							Egress TLV was returned in the LTM.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3o, 20.41.2.10";
+    					}  					
+    					leaf ltr-egress-mac {
+    						type ieee:mac-address;
+    						config false;
+    						description
+    							"MAC address returned in the egress MAC address field.
+    							If the ltr-egress object contains the value
+    							egress-no-tlv, then the contents of this object are
+    							meaningless.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3p, 20.41.2.11";
+    					}  					
+    					leaf ltr-egress-port-id-subtype {
+    						type lldp-port-id-subtype;
+    						config false;
+    						description
+    							"Format of the egress Port ID. If the ltr-egress
+    							object contains the value egress-no-tlv, then the
+    							contents of this object are meaningless.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3q, 20.41.2.12";
+    					}  					
+    					leaf ltr-egress-port-id {
+    						type lldp-port-id;
+    						config false;
+    						description
+    							"Egress Port ID. The format of this object is
+    							determined by the value of the
+    							ltr-egress-port-id-subtype object. If the ltr-egress
+    							object contains the value egress-no-tlv, then the
+    							contents of this object are meaningless.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3r, 20.41.2.13";
+    					}  					
+    					leaf ltr-organization-specific-tlv {
+    						type string {
+    							length "0 | 4..1500";
+    						}
+    						config false;
+    						description
+    							"All Organization specific TLVs returned in the LTR,
+    							if any. Includes all octets including and following
+    							the TLV Length field of each TLV, concatenated
+    							together.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3s, 21.5.2";
+    					}
+    				} // linktrace-reply
+    				
+    				list mep-db {
+    					key rmep-id;
+    					description
+    						"";
+    					leaf rmep-id {
+    						type mep-id-type;
+    						description
+    							"Maintenance association Endpoint Identifier of a
+    							remote MEP whose information from the MEP Database is
+    							to be returned.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.2b";  						
+    					}
+    					leaf rmep-state {
+    						type remote-mep-state-type;
+    						config false;
+    						description 
+    							"The operational state of the remote MEP  state
+    							machine";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3b, 20.20";
+    					}
+    					leaf rmep-failed-ok-time {
+    						type yang:zero-based-counter32;
+    						units seconds;
+    						config false;
+    						description
+    							"The time (SysUpTime) at which the Remote MEP state
+    							machine last entered either the RMEP_FAILED or
+    							RMEP_OK state";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
+    					}
+    					leaf mep-db-mac-address {
+    						type ieee:mac-address;
+    						config false;
+    						description
+    							"The MAC address of the remote MEP.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
+    					}
+    					leaf mep-db-rdi {
+    						type boolean;
+    						config false;
+    						description
+    							"State of the RDI bit in the last received CCM
+    							(true for RDI=1), or false if none has been 
+    							received.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
+    					}
+    					leaf mep-db-port-status-tlv {
+    						type port-status-tlv-value;
+    						default "no-port-state-tlv";
+    						config false;
+    						description
+    							"An enumerated value of the Port status TLV received
+    							in the last CCM from the remote MEP or the default
+    							value no-port-state-tlv indicating either no CCM has
+    							been received, or that no port status TLV was
+    							received in the last CCM.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
+    					}
+    					leaf mep-db-interface-status-tlv {
+    						type interface-status-tlv-value;
+    						default "is-no-interface-status-tlv";
+    						config false;
+    						description
+    							"An enumerated value of the Interface status TLV
+    							received in the last CCM from the remote MEP or the
+    							default value is-no-interface-status-tlv indicating
+    							either no CCM has been received, or that no interface
+    							status TLV was received in the last CCM.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
+    					}
+    					leaf mep-db-chassis-id-subtype {
+    						type lldp-chassis-id-subtype;
+    						config false;
+    						description
+    							"This object specifies the format of the Chassis ID
+    							received in the last CCM.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
+    					}
+    					leaf mep-db-chassis-id {
+    						type lldp-chassis-id;
+    						config false;
+    						description
+    							"The Chassis ID. The format of this object is
+    							determined by the value of the ltr-chassis-id-subtype
+    							object.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
+    					}
+    					leaf mep-db-man-address-domain {
+    						type transport-service-domain;
+    						config false;
+    						description
+    							"The transport-service-domain that identifies the
+    							type and format of the related mep-db-man-address
+    							object, used to access the YANG agent of the system
+    							transmitting the CCM. Received in the CCM Sender ID
+    							TLV from that system.
+    							
+    							The value zeroDotZero (from RFC2578) indicates no
+    							management address was present in the LTR, in which
+    							case the related mep-db-man-address object MUST have
+    							a zero-length OCTET STRING as a value.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
+    							21.6.7";
+    					}
+    					leaf mep-db-man-address {
+    						type transport-service-address;
+    						config false;
+    						description
+    							"The transport-service-address that can be used to 
+    							access the YANG agent of the system transmitting the
+    							CCM, received in the CCM Sender ID TLV from that
+    							system. If the related mep-db-man-address-domain 
+    							object contains the value zeroDotZero, this object
+    							mep-db-man-address MUST have a zero-length OCTET
+    							STRING as a value.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
+    							21.6.7";
+    					}
+    					leaf mep-db-rmep-is-active {
+    						type boolean;
+    						description
+    							"A Boolean value statign if the remote MEP is 
+    							active.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+    					}
+    				} // mep-db
+    				
+    				container stats {
+    					config false;
+    					description
+    						"Contains the counters associated with the MEP.";
+    					leaf mep-ccm-sequence-errors {
+    						type yang:counter64;
+    						description
+    							"The total number of out-of-sequence CCMs received
+    							from all remote MEPs.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
+    					}
+    					leaf mep-sent-ccms {
+    						type yang:counter64;
+    						description
+    							"Total number of CCMs transmitted";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3w, 20.10.2";
+    					}
+    					leaf mep-lbr-in {
+    						type yang:counter64;
+    						description
+    							"Total number of valid, in-order Loopback Replies
+    							received.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3y, 20.31.1";
+    					}
+    					leaf mep-lbr-in-out-of-order {
+    						type yang:counter64;
+    						description
+    							"The total number of valid, out-of-order
+    							Loopback Replies received";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3z, 20.31.1";
+    					}
+    					leaf mep-lbr-bad-msdu {
+    						type yang:counter64;
+    						description
+    							"The total number of LBRs receivd whose
+    							mac_service_data_unit did not match (except for the
+    							OpCode) that of the corresponding LBM.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3aa, 20.2.3";
+    					}
+    					leaf mep-unexpected-ltr-in {
+    						type yang:counter64;
+    						description
+    							"The total number of unexpected LTRs received.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ac, 20.44.1";
+    					}
+    					leaf mep-lbr-out {
+    						type yang:counter64;
+    						description
+    							"Total number of Loopback Replies transmitted.";
+    						reference
+    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ad, 20.28.2";
+    					}
+    				} // stats
+    			} // mep
+    		} // maintenance-association
+  		} // maintenance-domain
+  	} // maintenance-domains
+  	
+  } // cfm
+  
+  
+  /* ------------------------
+   *  Remote Procedure Calls
+   * ------------------------
+   */
+  rpc transmit-loopback-message {
+  	description
+  		"To signal to the MEP to transmit some number of LBMs.";
+  	input {
+  		leaf md-index {
+  			type uint32;
+  			description
+  				"The index to the Maintenance Domain list.";
+  			reference
+  				"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
+  		}
+  		leaf ma-index {
+  			type uint32;
+  			description
+  				"The index to the Maintenance Association list.";
+  			reference
+  				"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
+  		}
+  		leaf mep-id {
+  			type mep-id-type;
+				description
+					"Integer that is unique among all the MEPs in the same
+					Maintenance Association.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
+  		}
+  		leaf mep-transmit-lbm-dest-mac-address {
+				type ieee:mac-address;
+				description
+					"The target MAC Address field to be transmitted.
+					A unicast destination MAC address. This address
+					is used if node mep-transmit-lbm-dest-is-mep-id
+					is FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+			}
+			leaf mep-transmit-lbm-dest-mep-id {
+				type mep-id-or-zero-type;
+				description
+					"The identifier of a remote MEP in the same MA to
+					which the LBM is to be sent. This address
+					is used if node mep-transmit-lbm-dest-is-mep-id
+					is TRUE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+			}
+			leaf mep-transmit-lbm-dest-is-mep-id {
+				type boolean;
+				description
+					"TRUE indicates that MEP ID of the target MEP is used
+					for Loopback transmissions. FALSE indicates that
+					unicast destination MAC address of the target MEP is
+					used for Loopback transmissions.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+			}
+			leaf mep-transmit-lbm-messages {
+				type uint32 {
+					range "1..1024";
+				}
+				default 1;
+				description
+					"The number of Loopback messages to be transmitted.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2c";
+			}
+			leaf mep-transmit-lbm-data-tlv {
+				type string;
+				description
+					"An arbitraty amount of data to be included in the
+					Data TLV, if the Data TLV is selected to be sent. The
+					intent is to be able to fill the frame carrying the
+					CFM PDU to its maximum length.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
+			}
+			leaf mep-transmit-lbm-vlan-priority {
+				type dot1q-types:priority-type;
+				description
+					"Priority. 3 bit value to be used in the VLAN tag, if
+					present in the transmitted frame. The default value
+					should be the CCM priority.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+			}
+			leaf mep-transmit-lbm-vlan-drop-eligible {
+				type boolean;
+				default "false";
+				description
+					"Drop eligible bit value to be used in the VLAN tag, if
+					present in the transmitted frame";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+			}
+  	} // input
+  	output {
+  		leaf mep-transmit-lbm-result-ok {
+				type boolean;
+				default "true";
+				description
+					"Indicates the result of the operation:
+					   TRUE - The LBM will be (or has been) sent.
+					   FALSE - The LBM will not be sent.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.3a";
+			}
+			leaf mep-transmit-lbm-seq-number {
+				type uint32;
+				description
+					"The Loopback transaction identifier
+					(mep-next-lbm-trans-id) of the first LBM (to be) sent.
+					The value returned is undefined if 
+					mep-transmit-lbm-result-ok is FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.3b";
+			}  		
+  	} // output
+  } // transmit-loopback-message
+  	
+	rpc transmit-linktrace-message {
+		description
+			"To signal to the MEP to transmit an LTM and to create an LTM
+			entry in the MEPs Linktrace Database.";
+		input {
+			leaf md-index {
+  			type uint32;
+  			description
+  				"The index to the Maintenance Domain list.";
+  			reference
+  				"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
+  		}
+  		leaf ma-index {
+  			type uint32;
+  			description
+  				"The index to the Maintenance Association list.";
+  			reference
+  				"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
+  		}
+  		leaf mep-id {
+  			type mep-id-type;
+				description
+					"Integer that is unique among all the MEPs in the same
+					Maintenance Association.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
+  		}
+  		leaf mep-transmit-ltm-flags {
+				type mep-tx-ltm-flags-type;
+				default use-fdb-only;
+				description
+					"The flags field for the LTMs transmitted by the MEP.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2b, 20.42.1";
+				
+			}
+			leaf mep-transmit-ltm-target-mac-address {
+				type ieee:mac-address;
+				description
+					"The target MAC address field to be transmitted. A
+					unicast MAC address. This address will be used if the
+					value of mep-transmit-ltm-target-is-mep-id is FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+			}
+			leaf mep-transmit-ltm-target-mep-id {
+				type mep-id-or-zero-type;
+				description
+					"The target MAC address field to be transmitted. The
+					MEP identifier of another MEP in teh same MA. This
+					address will be used if the value of 
+					mep-transmit-ltm-target-is-mep-id is TRUE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+			}
+			leaf mep-transmit-ltm-target-is-mep-id {
+				type boolean;
+				default "false";
+				description
+					"TRUE indicates taht MEP id of the target MEP is used
+					for Linktrace transmission. FALSE indicates that
+					unicast destination MAC address of the target MEP is
+					used for LinkTrace transmission.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+			}
+			leaf mep-transmit-ltm-ttl {
+				type uint32 {
+					range "0..255";
+				}
+				default 64;
+				description
+					"The LTM TTL field. Indicates the number of hops 
+					remaining to the LTM. Decremented by 1 by each
+					Linktrace Responder that handles the LTM. The value
+					returned in the LTR is one less than that received in
+					the LTM. If the LTM TTL is 0 or 1, the LTM is not
+					forwarded to the next hop, and if 0, no LTR is 
+					generated.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2d, 21.8.4";
+			}  			
+		} // input
+		output {
+			leaf mep-transmit-ltm-result {
+				type boolean;
+				default "true";
+				description
+					"Indicates the result of the operation:
+					   TRUE - The Linktrace message will be (or has been) 
+					          sent.
+					   FALS - The Linktrace message will not be sent.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.3a";
+			}
+			leaf mep-transmit-ltm-seq-number {
+				type uint32;
+				description
+					"The LTM transaction identifier 
+					(mep-ltm-next-seq-number) of the LTM sent. The value
+					returned is undefined if mep-transmit-ltm-result is 
+					FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.3b";
+			}
+			leaf mep-transmit-ltm-egress-identifier {
+				type string {
+					length "8";
+				}
+				description
+					"Identifies the MEP Linktrace Initiator that is 
+					originating, or the Linktrace Responder that is
+					forwarding, this LTM.
+					
+					The low-order six octets contain a 48-bit IEEE MAC
+					address unique to the system in which the MEP Linktrace
+					Initiator or Linktrace Responder resides. The 
+					high-order two octets contain a value sufficient to 
+					uniquely identify the MEP Linktrace Initiator or 
+					Linktrace Responder within that system.
+					
+					For most Bridges, the address of any MAC attached to
+					the Bridge will suffice for the low-order six octets,
+					and 0 for the high-order octets. In some situations,
+					e.g., if multiple virtual Bridges utilizing emulated
+					LANs are implemented in a single physical system, the
+					high-order two octets can be used to differentiate
+					among the transmitting entities.
+					
+					The value returned is undefined if 
+					mep-transmit-ltm-result is FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.3c";  					
+			}
+		} // output
+	} // transmit- linktrace-message
+	
+	/* ---------------
+	 *  Notifications
+	 * ---------------
+   */
+	
+	notification mep-fault-alarm {
+		description
+			"To alert the Manager to the existence of a fault in a monitored
+			MA by issuing a Fault Alarm.";
+		leaf md-name {
+			type leafref {
+				path "/cfm/maintenance-domains/maintenance-domain/name";
+			}
+			description
+				"The Maintenance Domain name. Each Maintenance Domain has a
+				unique name among all those used or available to a service
+				provider or operator. It facilitates easy idenification
+				of administrative responsibility for each Maintenance
+				Domain.";
+			reference
+				"IEEE 802.1Q-2017 Clause 3.122, 21.6.5.3";
+		}
+		leaf md-name-format {
+			type leafref {
+				path "/cfm/maintenance-domains/maintenance-domain"+
+			       "/name-format";
+			}
+			description
+				"The type (or format) of the Maintenance Domain name.";
+			reference
+				"IEEE 802.1Q-2017 Clause 21.6.5.1";
+		}
+		leaf ma-name {
+			type leafref {
+				path "/cfm/maintenance-domains/maintenance-domain"+
+			       "/maintenance-association/name";
+			}
+			description
+				"The Short Maintenance Association name. The type/format
+				is determiend by the value of ma-name-format. This name
+				must be unique within a maintenance domain.";
+			reference
+				"IEEE 802.1Q-2017 Clause 21.6.5.6";
+		}
+		leaf ma-name-format {
+			type leafref {
+				path "/cfm/maintenance-domains/maintenance-domain"+
+			       "/maintenance-association/name-format";
+			}
+			description
+				"The type (format) of the Maintenance Association name.";
+			reference
+				"IEEE 802.1Q-2017 Clause 21.6.5.4";
+		}
+		leaf mep-id {
+			type leafref {
+				path "/cfm/maintenance-domains/maintenance-domain"+
+			       "/maintenance-association/mep/mep-id";
+			}
+			description
+				"Integer that is unique among all the MEPs in the same
+				Maintenance Association.";
+			reference
+				"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+		}
+		leaf mep-priority-defect {
+			type leafref {
+				path "/cfm/maintenance-domains/maintenance-domain"+
+			       "/maintenance-association/mep"+
+						 "/mep-highest-priority-defect";
+			}
+			description
+				"The highest priority defect that has been present
+				sicne the MEPs Fault Notification Generator state
+				machine was last in the FNG_RESET state.";
+		}
+	} // mep-fault-alarm
+  	
+} // ieee802-dot1q-cfm


### PR DESCRIPTION
Clean PYANG

----------------------
**ieee802-dot1q-cfm.yang**
----------------------

Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw cfm-stacks
       |  +--rw bridge?      bridge-ref
       |  +--rw cfm-stack* [bridge-port type-of-service-selector service-selector-or-none md-level direction]
       |     +--rw bridge-port                      if:interface-ref
       |     +--rw type-of-service-selector         service-selector-type
       |     +--rw service-selector-or-none         service-selector-value-or-none
       |     +--rw md-level                         md-level-type
       |     +--rw direction                        mp-direction-type
       |     +--ro maintenance-domain-index?        uint32
       |     +--ro maintenance-association-index?   uint32
       |     +--ro mep-id?                          mep-id-or-zero-type
       |     +--ro mac-address?                     ieee:mac-address
       +--rw default-md-levels
       |  +--rw bridge?             bridge-ref
       |  +--rw default-md-level* [component-id primary-selector-type primary-selector]
       |     +--rw component-id             component-identifier-type
       |     +--rw primary-selector-type    service-selector-type
       |     +--rw primary-selector         service-selector-value
       |     +--rw selectors*               service-selector-value
       |     +--rw md-status?               boolean
       |     +--rw md-level?                md-level-or-none-type
       |     +--rw mhf-creation?            mhf-creation-type
       |     +--rw id-permission?           sender-id-permission-type
       +--rw config-errors
       |  +--rw bridge?         bridge-ref
       |  +--rw config-error* [type-of-selector selector bridge-port]
       |     +--rw type-of-selector    service-selector-type
       |     +--rw selector            service-selector-value
       |     +--rw bridge-port         if:interface-ref
       |     +--ro error-type?         config-errors
       +--rw maintenance-domains
          +--rw bridge?               bridge-ref
          +--rw maintenance-domain* [name-format name]
             +--rw name-format                md-name-format-type
             +--rw name                       md-name-type
             +--rw md-index?                  uint32
             +--rw md-level?                  md-level-type
             +--rw mhf-creation?              mhf-creation-type
             +--rw id-permission?             sender-id-permission-type
             +--rw fault-alarm-address?       fault-alarm-adress-type
             +--rw maintenance-association* [name name-format]
                +--rw name                                 ma-name-type
                +--rw name-format                          ma-name-format-type
                +--rw ma-index?                            uint32
                +--rw md-reference?                        uint32
                +--rw mhf-creation?                        mhf-creation-type
                +--rw id-permission?                       sender-id-permission-type
                +--rw ccm-interval?                        ccm-interval-type
                +--rw selectors*                           service-selector-value
                +--rw fault-alarm-address?                 fault-alarm-adress-type
                +--rw maintenance-association-component* [ma-component-id]
                |  +--rw ma-component-id             component-identifier-type
                |  +--rw primary-selector-type?      service-selector-type
                |  +--rw primary-selector-or-none?   service-selector-value-or-none
                |  +--rw mhf-creation?               mhf-creation-type
                |  +--rw id-permission?              sender-id-permission-type
                |  +--rw number-of-vids?             uint32
                |  +--rw selectors*                  service-selector-value
                +--rw mep* [mep-id]
                   +--rw mep-id                                 mep-id-type
                   +--rw ma-reference?                          uint32
                   +--rw bridge-port?                           if:interface-ref
                   +--rw mep-direction?                         mp-direction-type
                   +--rw mep-primary-vid?                       uint32
                   +--rw mep-admin-state?                       boolean
                   +--ro mep-fng-state?                         fng-state-type
                   +--rw mep-ccm-enabled?                       boolean
                   +--rw mep-ccm-ltm-priority?                  dot1q-types:priority-type
                   +--rw mep-mac-address?                       ieee:mac-address
                   +--rw fault-alarm-address?                   fault-alarm-adress-type
                   +--rw mep-lowest-priority-defect?            lowest-alarm-priority-type
                   +--rw mep-fng-alarm-time?                    yang:zero-based-counter32
                   +--rw mep-fng-reset-time?                    yang:zero-based-counter32
                   +--ro mep-highest-priority-defect?           highest-defect-priority-type
                   +--ro mep-defects?                           mep-defects-type
                   +--ro mep-error-ccm-last-failure?            string
                   +--ro mep-xcon-ccm-last-failure?             string
                   +--ro mep-next-lbm-trans-id?                 uint32
                   +--ro mep-ltm-next-seq-number?               uint32
                   +--rw active-rmeps*                          mep-id-type
                   +--rw mep-transmit-lbm-status?               boolean
                   +--rw mep-transmit-lbm-dest-mac-address?     ieee:mac-address
                   +--rw mep-transmit-lbm-dest-mep-id?          mep-id-or-zero-type
                   +--rw mep-transmit-lbm-dest-is-mep-id?       boolean
                   +--rw mep-transmit-lbm-messages?             uint32
                   +--rw mep-transmit-lbm-data-tlv?             string
                   +--rw mep-transmit-lbm-vlan-priority?        dot1q-types:priority-type
                   +--rw mep-transmit-lbm-vlan-drop-eligible?   boolean
                   +--ro mep-transmit-lbm-result-ok?            boolean
                   +--rw mep-transmit-lbm-seq-number?           uint32
                   +--ro mep-transmit-ltm-status?               boolean
                   +--rw mep-transmit-ltm-flags?                mep-tx-ltm-flags-type
                   +--rw mep-transmit-ltm-target-mac-address?   ieee:mac-address
                   +--rw mep-transmit-ltm-target-mep-id?        mep-id-or-zero-type
                   +--rw mep-transmit-ltm-target-is-mep-id?     boolean
                   +--rw mep-transmit-ltm-ttl?                  uint32
                   +--ro mep-transmit-ltm-result?               boolean
                   +--ro mep-transmit-ltm-seq-number?           uint32
                   +--ro mep-transmit-ltm-egress-identifier?    string
                   +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
                   |  +--rw ltr-seq-number                   uint32
                   |  +--rw ltr-receive-order                uint32
                   |  +--ro ltr-ttl?                         uint32
                   |  +--ro ltr-forwarded?                   boolean
                   |  +--ro ltr-terminal-mep?                boolean
                   |  +--ro ltr-last-egress-identifier?      string
                   |  +--ro ltr-next-egress-identifier?      string
                   |  +--ro ltr-relay?                       relay-action-field-value
                   |  +--ro ltr-chassis-id-subtype?          lldp-chassis-id-subtype
                   |  +--ro ltr-chassis-id?                  lldp-chassis-id
                   |  +--ro ltr-man-address-domain?          transport-service-domain
                   |  +--ro ltr-man-address?                 transport-service-address
                   |  +--ro ltr-ingress?                     ingress-action-field-value
                   |  +--ro ltr-ingress-mac?                 ieee:mac-address
                   |  +--ro ltr-ingress-port-id-subtype?     lldp-port-id-subtype
                   |  +--ro ltr-egress?                      egress-action-field-value
                   |  +--ro ltr-egress-mac?                  ieee:mac-address
                   |  +--ro ltr-egress-port-id-subtype?      lldp-port-id-subtype
                   |  +--ro ltr-egress-port-id?              lldp-port-id
                   |  +--ro ltr-organization-specific-tlv?   string
                   +--rw mep-db* [rmep-id]
                   |  +--rw rmep-id                        mep-id-type
                   |  +--ro rmep-state?                    remote-mep-state-type
                   |  +--ro rmep-failed-ok-time?           yang:zero-based-counter32
                   |  +--ro mep-db-mac-address?            ieee:mac-address
                   |  +--ro mep-db-rdi?                    boolean
                   |  +--ro mep-db-port-status-tlv?        port-status-tlv-value
                   |  +--ro mep-db-interface-status-tlv?   interface-status-tlv-value
                   |  +--ro mep-db-chassis-id-subtype?     lldp-chassis-id-subtype
                   |  +--ro mep-db-chassis-id?             lldp-chassis-id
                   |  +--ro mep-db-man-address-domain?     transport-service-domain
                   |  +--ro mep-db-man-address?            transport-service-address
                   |  +--rw mep-db-rmep-is-active?         boolean
                   +--ro stats
                      +--ro mep-ccm-sequence-errors?   yang:counter64
                      +--ro mep-sent-ccms?             yang:counter64
                      +--ro mep-lbr-in?                yang:counter64
                      +--ro mep-lbr-in-out-of-order?   yang:counter64
                      +--ro mep-lbr-bad-msdu?          yang:counter64
                      +--ro mep-unexpected-ltr-in?     yang:counter64
                      +--ro mep-lbr-out?               yang:counter64

  rpcs:
    +---x transmit-loopback-message
    |  +---w input
    |  |  +---w md-index?                              uint32
    |  |  +---w ma-index?                              uint32
    |  |  +---w mep-id?                                mep-id-type
    |  |  +---w mep-transmit-lbm-dest-mac-address?     ieee:mac-address
    |  |  +---w mep-transmit-lbm-dest-mep-id?          mep-id-or-zero-type
    |  |  +---w mep-transmit-lbm-dest-is-mep-id?       boolean
    |  |  +---w mep-transmit-lbm-messages?             uint32
    |  |  +---w mep-transmit-lbm-data-tlv?             string
    |  |  +---w mep-transmit-lbm-vlan-priority?        dot1q-types:priority-type
    |  |  +---w mep-transmit-lbm-vlan-drop-eligible?   boolean
    |  +--ro output
    |     +--ro mep-transmit-lbm-result-ok?    boolean
    |     +--ro mep-transmit-lbm-seq-number?   uint32
    +---x transmit-linktrace-message
       +---w input
       |  +---w md-index?                              uint32
       |  +---w ma-index?                              uint32
       |  +---w mep-id?                                mep-id-type
       |  +---w mep-transmit-ltm-flags?                mep-tx-ltm-flags-type
       |  +---w mep-transmit-ltm-target-mac-address?   ieee:mac-address
       |  +---w mep-transmit-ltm-target-mep-id?        mep-id-or-zero-type
       |  +---w mep-transmit-ltm-target-is-mep-id?     boolean
       |  +---w mep-transmit-ltm-ttl?                  uint32
       +--ro output
          +--ro mep-transmit-ltm-result?              boolean
          +--ro mep-transmit-ltm-seq-number?          uint32
          +--ro mep-transmit-ltm-egress-identifier?   string

  notifications:
    +---n mep-fault-alarm
       +--ro md-name?               -> /cfm/maintenance-domains/maintenance-domain/name
       +--ro md-name-format?        -> /cfm/maintenance-domains/maintenance-domain/name-format
       +--ro ma-name?               -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name
       +--ro ma-name-format?        -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name-format
       +--ro mep-id?                -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/mep/mep-id
       +--ro mep-priority-defect?   -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/mep/mep-highest-priority-defect

Confdc Output
No warnings or errors

yanglint Validation
No warnings or errors

