### PR TITLE
Fixed MEP table placement structure in CFM YANG module

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -1637,29 +1637,6 @@ module ieee802-dot1q-cfm {
     				reference
     					"IEEE 802.1Q-2017 Clause 12.14.5.3.2a";
     			}
-    			leaf mhf-creation {
-      			type mhf-creation-type;
-      			default mhf-defer;
-      			description
-      				"Value indicating whether the management entity can
-      				create MHFs (MIP Half Function) for this Maintenance
-      				Domain. Since there is no encompassing Maintenance
-      				Domain, the vlaue mhf-defer is not allowed.";
-      			reference
-      				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
-      		}
-    			leaf id-permission {
-      			type sender-id-permission-type;
-      			default send-id-defer;
-      			description
-      				"Value indicating what, if anything, is to be included
-      				in the Sender ID TLV transmitted by Maintenance Points
-      				configured in this Maintenance Domain. Since there is no
-      				encompassing Maintenance Domain, the value send-id-defer
-      				is not allowed.";
-      			reference
-      				"IEEE 802.1Q-2017 Clause 12.14.6.1.3d";
-      		}
     			leaf ccm-interval {
     				type ccm-interval-type;
     				description
@@ -1668,19 +1645,6 @@ module ieee802-dot1q-cfm {
     				reference
     					"IEEE 802.1Q-2017 Clause 12.14.6.1.3e";
     			}
-    			leaf-list selectors {
-    	  		type service-selector-value;
-    	  		description
-    	  			"The list of VIDs, I-SID, or the TE-SID monitored by 
-    	  			this MA, or 0, if the MA is not attached to a VID, or
-    	  			I-SID, or TE-SID. In the case of a list of VIDs, the 
-    	  			first VID in the list is the MAs Primary VID (default 
-    	  			none). The specification of I-SID is allowed only in
-    	  			the case of I- or B- components. The TE-SID is allowed
-    	  			only in the case that PBB-TE is supported.";
-    	  		reference
-    	  			"IEEE 802.1Q-2017 Clause 12.14.5.3.2c, 12.14.6.1.3b";
-    	  	}
     			leaf fault-alarm-address {
       			type fault-alarm-adress-type;
       			default "not-specified";
@@ -1768,890 +1732,894 @@ module ieee802-dot1q-cfm {
       	  		reference
       	  			"IEEE 802.1Q-2017 Clause 12.14.5.3.2c, 12.14.6.1.3b";
       	  	}
-    			} // maintenance-association-component
-    			
-    			list mep {
-    				key "mep-id";
-    				description 
-    					"A list of Maintenance association End Points (MEPs). A
-    					MEP is an actively managed CFM entity, associated with a 
-    					specific DoSAP of a service instance, which can generate
-    					and receive CFM PDUs and track any responses. It is an 
-    					end point of a single Maintenance Association (MA) and is
-    					an end point of a separate Maintenance Entity for each of
-    					the other MEPs in the same MA.";
-    				leaf mep-id {
-    					type mep-id-type;
-    					description
-    						"Integer that is unique among all the MEPs in the same
-    						Maintenance Association.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
-    				}
-    				leaf ma-reference {
-    					type uint32;
-    					description
-    						"An index reference to the particular Maintenance
-    						Association that this MEP belongs to.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
-    				}
-    				leaf bridge-port {
-    					type if:interface-ref;
-    					description
-    						"The interface index of the interface (i.e., Bridge 
-    						Port) to which the MEP is attached.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
-    				}
-    				leaf mep-direction {
-    					type mp-direction-type;
-    					description
-    						"The direction in which the MEP faces on the Bridge
-    						Port. Example, up or down.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
-    				}
-    				leaf mep-primary-vid {
-    					type uint32 {
-    						range "0..16777215";
-    					}
-    					default 0;
-    					description
-    						"An integer indicating the Primary VID of the MEP. It
-    						is always one of the VIDs assigned to the MEPs MA. A
-    						value of 0 indicates that either the Primary VID is
-    						that of the MEPs MA, or that the MEPs MA is associated
-    						with no VID.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
-    				}
-    				leaf mep-admin-state {
-    					type boolean;
-    					default "false";
-    					description
-    						"The administrative state of the MEP. TRUE indicates
-    						that the MEP is to functional normally, and FALSE
-    						indicates that it is to cease functioning.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
-    				}
-    				leaf mep-fng-state {
-    					type fng-state-type;
-    					default "fng-reset";
-    					config false;
-    					description
-    						"The current state of teh MEP Fault Notification 
-    						Generator state machine.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
-    				}
-    				leaf mep-ccm-enabled {
-    					type boolean;
-    					default "false";
-    					description
-    						"Indicates whether the MEP can generate CCMs. If TRUE,
-    						the MEP will generate CCM PDUs.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
-    				}
-    				leaf mep-ccm-ltm-priority {
-    					type dot1q-types:priority-type;
-    					description
-    						"The priority value for CCMs and LTMs transmitted by
-    						the MEP. The default value is the highest priority 
-    						allowed to pass through the Bridge Port for any of the
-    						MEPs VID(s).";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
-    				}
-    				leaf mep-mac-address {
-    					type ieee:mac-address;
-    					description
-    						"The MAC address of the MEP.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
-    				}
-    				leaf fault-alarm-address {
-        			type fault-alarm-adress-type;
-        			default "not-specified";
-        			description
-        				"A value indicating whether Fault Alarms are to be 
-        				transmitted or not. The default is not specified, 
-        				which implies that the disposition of the fault-alarm
-        				used by the MD should be used.";
-        			reference
-        				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
-        		}
-    				leaf mep-lowest-priority-defect {
-    					type lowest-alarm-priority-type;
-    					default "mac-remote-error-xcon";
-    					description
-    						"The lowest priority defect that is allowed to generate
-    						fault alarms.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
-    				}
-    				leaf mep-fng-alarm-time {
-    					type yang:zero-based-counter32 {
-    						range "250..1000";
-    					}
-    					units deciseconds;
-    					default 250;
-    					description
-      					"The time that defect must be present before a Fault
-      					Alarm is issued.";
-      				reference
-      					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
-    				}
-    				leaf mep-fng-reset-time {
-      				type yang:zero-based-counter32 {
-      					range "250..1000";  					
+    				
+    				list mep {
+      				key "mep-id";
+      				description 
+      					"A list of Maintenance association End Points (MEPs). A
+      					MEP is an actively managed CFM entity, associated with
+      					a specific DoSAP of a service instance, which can
+      					generate and receive CFM PDUs and track any responses.
+      					It is an end point of a single Maintenance Association
+      					(MA) and is an end point of a separate Maintenance
+      					Entity for each of the other MEPs in the same MA.";
+      				leaf mep-id {
+      					type mep-id-type;
+      					description
+      						"Integer that is unique among all the MEPs in the
+      						same Maintenance Association.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
       				}
-      				units deciseconds;
-      				default 1000;
-      				description
-      					"The time that defects must be absent before resetting
-      					a Fault Alarm.";
-      				reference
-      					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
-      			}
-    				leaf mep-highest-priority-defect {
-    					type highest-defect-priority-type;
-    					config false;
-    					description
-    						"The highest priority defect that has been present
-    						sicne the MEPs Fault Notification Generator state
-    						machine was last in the FNG_RESET state.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
-    				}
-    				leaf mep-defects {
-    					type mep-defects-type;
-    					config false;
-    					description
-    						"Vector of boolean error conditions";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
-    						20.23.3, 20.35.5, 20.35.6, 20.35.7";
-    				}
-    				leaf mep-error-ccm-last-failure {
-    					type string {
-    						length "1..1522";
-    					}
-    					config false;
-    					description
-    						"The last received CCM that triggered a def-error-ccm
-    						fault.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
-    				}
-    				leaf mep-xcon-ccm-last-failure {
-    					type string {
-    						length "1..1522";
-    					}
-    					config false;
-    					description
-    						"The last received CCM that triggered a def-xcon-ccm
-    						fault.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
-    				}
-    				leaf mep-next-lbm-trans-id {
-    					type uint32;
-    					config false;
-    					description
-    						"Next sequence number identifier to be sent in a
-    						Loopback message. This sequence number can be zero
-    						since it can wrap around.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3x, 20.28.2";
-    				}
-    				leaf mep-ltm-next-seq-number {
-    					type uint32;
-    					config false;
-    					description
-    						"Next transaction identifier to be sent in a LinkTrace
-    						message.This sequence number can be zero since it
-    						can wrap around.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ab, 20.41.1";
-    				}
-    				leaf-list active-rmeps {
-    					type mep-id-type;
-    					description
-    						"A list indicating which of the remote MEPs in the
-    						same MA are active. By default, all configured
-    						remote MEPs in the same MA are active.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
-    				}
-    				leaf mep-transmit-lbm-status {
-    					type boolean;
-    					default "false";
-    					description
-    						"A Boolean flag set to TRUE by the MEP Loopback
-    						Initiator state machine or YANG network configuration
-    						manager to indicate that another LBM is being 
-    						transmitted. Reset to FALSE by the MEP Loopback
-    						initiator state machine.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 20.32, Figure 20-11";
-    				}
-    				leaf mep-transmit-lbm-dest-mac-address {
-    					type ieee:mac-address;
-    					description
-    						"The target MAC Address field to be transmitted.
-    						A unicast destination MAC address. This address
-    						is used if node mep-transmit-lbm-dest-is-mep-id
-    						is FALSE.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
-    				}
-    				leaf mep-transmit-lbm-dest-mep-id {
-    					type mep-id-or-zero-type;
-    					description
-    						"The identifier of a remote MEP in the same MA to
-    						which the LBM is to be sent. This address
-    						is used if node mep-transmit-lbm-dest-is-mep-id
-    						is TRUE.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
-    				}
-    				leaf mep-transmit-lbm-dest-is-mep-id {
-    					type boolean;
-    					description
-    						"TRUE indicates that MEP ID of the target MEP is used
-    						for Loopback transmissions. FALSE indicates that
-    						unicast destination MAC address of the target MEP is
-    						used for Loopback transmissions.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
-    				}
-    				leaf mep-transmit-lbm-messages {
-    					type uint32 {
-    						range "1..1024";
-    					}
-    					default 1;
-    					description
-    						"The number of Loopback messages to be transmitted.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2c";
-    				}
-    				leaf mep-transmit-lbm-data-tlv {
-    					type string;
-    					description
-    						"An arbitraty amoun tof data to be included in the
-    						Data TLV, if the Data TLV is selected to be sent. The
-    						intent is to be able to fill the frame carrying the
-    						CFM PDU to its maximum length.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
-    				}
-    				leaf mep-transmit-lbm-vlan-priority {
-    					type dot1q-types:priority-type;
-    					description
-    						"Priority. 3 bit value to be used in the VLAN tag, if
-    						present in the transmitted frame. The default value
-    						should be the CCM priority.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
-    				}
-    				leaf mep-transmit-lbm-vlan-drop-eligible {
-    					type boolean;
-    					default "false";
-    					description
-    						"Drop eligible bit value to be used in the VLAN tag, if
-    						present in the transmitted frame";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
-    				}
-    				leaf mep-transmit-lbm-result-ok {
-    					type boolean;
-    					default "true";
-    					config false;
-    					description
-    						"Indicates the result of the operation:
-    						   TRUE - The LBM will be (or has been) sent.
-    						   FALSE - The LBM will not be sent.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.3a";
-    				}
-    				leaf mep-transmit-lbm-seq-number {
-    					type uint32;
-    					description
-    						"The Loopback transaction identifier
-    						(mep-next-lbm-trans-id) of the first LBM (to be) sent.
-    						The value returned is undefined if 
-    						mep-transmit-lbm-result-ok is FALSE.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.3.3b";
-    				}
-    				leaf mep-transmit-ltm-status {
-    					type boolean;
-    					default "true";
-    					config false;
-    					description
-    						"A Boolean flag set to TRUE by the Bridge Port to 
-    						indicate that another LTM may be transmitted. Reset to
-    						FALSE by the MEP Linktrace initiator state machine.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 20.49, Figure 20-17";
-    				}
-    				leaf mep-transmit-ltm-flags {
-    					type mep-tx-ltm-flags-type;
-    					default use-fdb-only;
-    					description
-    						"The flags field for the LTMs transmitted by the MEP.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2b, 20.42.1";
-    					
-    				}
-    				leaf mep-transmit-ltm-target-mac-address {
-    					type ieee:mac-address;
-    					description
-    						"The target MAC address field to be transmitted. A
-    						unicast MAC address. This address will be used if the
-    						value of mep-transmit-ltm-target-is-mep-id is FALSE.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
-    				}
-    				leaf mep-transmit-ltm-target-mep-id {
-    					type mep-id-or-zero-type;
-    					description
-    						"The target MAC address field to be transmitted. The
-    						MEP identifier of another MEP in teh same MA. This
-    						address will be used if the value of 
-    						mep-transmit-ltm-target-is-mep-id is TRUE.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
-    				}
-    				leaf mep-transmit-ltm-target-is-mep-id {
-    					type boolean;
-    					default "false";
-    					description
-    						"TRUE indicates taht MEP id of the target MEP is used
-    						for Linktrace transmission. FALSE indicates that
-    						unicast destination MAC address of the target MEP is
-    						used for LinkTrace transmission.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
-    				}
-    				leaf mep-transmit-ltm-ttl {
-    					type uint32 {
-    						range "0..255";
-    					}
-    					default 64;
-    					description
-    						"The LTM TTL field. Indicates the number of hops 
-    						remaining to the LTM. Decremented by 1 by each
-    						Linktrace Responder that handles the LTM. The value
-    						returned in the LTR is one less than that received in
-    						the LTM. If the LTM TTL is 0 or 1, the LTM is not
-    						forwarded to the next hop, and if 0, no LTR is 
-    						generated.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.4.2d, 21.8.4";
-    				}
-    				leaf mep-transmit-ltm-result {
-    					type boolean;
-    					default "true";
-    					config false;
-    					description
-    						"Indicates the result of the operation:
-    						   TRUE - The Linktrace message will be (or has been) 
-    						          sent.
-    						   FALSE - The Linktrace message will not be sent.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.4.3a";
-    				}
-    				leaf mep-transmit-ltm-seq-number {
-    					type uint32;
-    					config false;
-    					description
-    						"The LTM transaction identifier 
-    						(mep-ltm-next-seq-number) of the LTM sent. The value
-    						returned is undefined if mep-transmit-ltm-result is 
-    						FALSE.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.4.3b";
-    				}
-    				leaf mep-transmit-ltm-egress-identifier {
-    					type string {
-    						length "8";
-    					}
-    					config false;
-    					description
-    						"Identifies the MEP Linktrace Initiator that is 
-    						originating, or the Linktrace Responder that is
-    						forwarding, this LTM.
-    						
-    						The low-order six octets contain a 48-bit IEEE MAC
-    						address unique to the system in which the MEP Linktrace
-    						Initiator or Linktrace Responder resides. The 
-    						high-order two octets contain a value sufficient to 
-    						uniquely identify the MEP Linktrace Initiator or 
-    						Linktrace Responder within that system.
-    						
-    						For most Bridges, the address of any MAC attached to
-    						the Bridge will suffice for the low-order six octets,
-    						and 0 for the high-order octets. In some situations,
-    						e.g., if multiple virtual Bridges utilizing emulated
-    						LANs are implemented in a single physical system, the
-    						high-order two octets can be used to differentiate
-    						among the transmitting entities.
-    						
-    						The value returned is undefined if 
-    						mep-transmit-ltm-result is FALSE.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.7.4.3c";  					
-    				}
-    				
-    				list linktrace-reply {
-    					key "ltr-seq-number ltr-receive-order";
-    					description
-    						"This table extends the MEP table and contains a list
-    						of Linktrace replies received by a specific MEP in
-    						response to a linktrace message.";
-    					leaf ltr-seq-number {
-    						type uint32 {
-    							range "0..4294967295";
-    						}
-    						description
-    							"Transaction identifier returned by a previous
-    							transmit linktrace message command, indicating which
-    							LTMs response is going to be returned.";
-    						reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.5.2b";
-    					}
-    					leaf ltr-receive-order {
-    						type uint32 {
-    							range "1..4294967295";
-    						}
-    						description
-    							"An index to distinguish among multiple LTRs with the
-    							same LTR Transaction Identifier field value. 
-    							Assigned sequentially from 1, in the order that the 
-    							Linktrace Initiator received the LTRs.";
-    					}
-    					leaf ltr-ttl {
-    						type uint32 {
-    							range "0..255";
-    						}
-    						config false;
-    						description
-    							"TTL field value for a returned LTR.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5, 20.41.2.2";
-    					}
-    					leaf ltr-forwarded {
-    						type boolean;
-    						config false;
-    						description
-    							"Indicates if a LTM was forwarded by the responding
-    							MP, as returned in the FwdYes flag of the flags 
-    							field.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3c, 20.41.2.1";
-    					}  					
-    					leaf ltr-terminal-mep {
-    						type boolean;
-    						config false;
-    						description
-    							"A Boolean value stating whether the forwarded LTM
-    							reached a MEP enclosing its MA, as returned in the
-    							Terminal MEP flag of the Flags field";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3d, 20.41.2.1";
-    					}
-    					leaf ltr-last-egress-identifier {
-    						type string {
-    							length "8";
-    						}
-    						config false;
-    						description
-    							"An octet field holding the Last Egress Identifier
-    							returned in the LTR Egress Identifier TLV of the LTR.
-    							The Last Egress Identifier identifies the MEP
-    							Linktrace Initiator that originated, or the Linktrace Responder
-    							that forwarded, the LTM to which this LTR is the
-    							response. This is the same value as the Egress
-    							Identifier TLV of that LTM.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3e, 20.41.2.3";
-    					}  					
-    					leaf ltr-next-egress-identifier {
-    						type string {
-    							length "8";
-    						}
-    						config false;
-    						description
-    							"An octet field holding the Next Egress Identifier
-    							returned in the LTR Egress Identifier TLV of the LTR.
-    							The Next Egress Identifier Identifies the Linktrace
-    							Responder that transmitted this LTR, and can forward
-    							the LTM to the next hop. This is the same value as
-    							the Egress Identifier TLV of the forwarded LTM, if
-    							any. If the FwdYes bit of the Flags field is false, 
-    							the contents of this field are undefined, i.e., any
-    							value can be transmitted, and the field is ignored by the
-    							receiver.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3f, 20.41.2.4";
-    					}  					
-    					leaf ltr-relay {
-    						type relay-action-field-value;
-    						config false;
-    						description
-    							"Value returned in teh Relay Action field.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
-    					}  					
-    					leaf ltr-chassis-id-subtype {
-    						type lldp-chassis-id-subtype;
-    						config false;
-    						description
-    							"Specifies the format of the Chassis ID returned
-    							in the Sender ID TLV of the LTR, if any. This value
-    							is meaningless if the ltr-chassis-id has a length
-    							of 0.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3h, 21.5.3.2";
-    					}  					
-    					leaf ltr-chassis-id {
-    						type lldp-chassis-id;
-    						config false;
-    						description
-    							"The Chassis ID returned in the Sender ID TLV of the
-    							LTR, if any. The format of this object is determined
-    							by the value of the ltr-chassis-id-subtype object.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3i, 21.5.3.2";
-    					}  					
-    					leaf ltr-man-address-domain {
-    						type transport-service-domain;
-    						config false;
-    						description
-    							"The transport-service-domain that identifies the
-    							type and format of the related mep-db-man-address
-    							object, used to access the YANG agent of the system
-    							transmitting the LTR. Received in the LTR Sender ID
-    							TLV from that system.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.5,
-    							21.9.6";
-    					}  					
-    					leaf ltr-man-address {
-    						type transport-service-address;
-    						config false;
-    						description
-    							"The transport-service-address that can be used to
-    							access the YANG	agent of the system transmitting the
-    							CCM, received in the CCM Sender ID TLV from that
-    							system.
-    							
-    							If the related object ltr-man-address-domain
-    							contains the value zeroDotZero, this object
-    							ltr-man-address MUST have a zero-length OCTET STRING
-    							as a value.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.7,
-    							21.9.6";
-    					}  					
-    					leaf ltr-ingress {
-    						type ingress-action-field-value;
-    						config false;
-    						description
-    							"The value returned in the Ingress Action Field of
-    							the LTM. The value ingress-no-tlv indicates that no
-    							Reply Ingress TLV was returned in the LTM.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3k, 20.41.2.6";
-    					}  					
-    					leaf ltr-ingress-mac {
-    						type ieee:mac-address;
-    						config false;
-    						description
-    							"MAC address returned in the ingress MAC address
-    							field. If the ltr-ingress object contains the value 
-    							ingress-no-tlv, then the contents of this object are
-    							meaningless.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3l, 20.41.2.7";
-    					}  					
-    					leaf ltr-ingress-port-id-subtype {
-    						type lldp-port-id-subtype;
-    						config false;
-    						description
-    							"Ingress Port ID. The format of this object is 
-    							determined by the value of the 
-    							ltr-ingress-port-id-subtype object. If the
-    							ltr-ingress object contains the value ingress-no-tlv, then the 
-    							contents of this object are meaningless.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3n, 20.41.2.9";
-    					}  					
-    					leaf ltr-egress {
-    						type egress-action-field-value;
-    						config false;
-    						description
-    							"The value returned in the Egress Action Field of the
-    							LTM. The value egress-no-tlv indicates that no Reply
-    							Egress TLV was returned in the LTM.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3o, 20.41.2.10";
-    					}  					
-    					leaf ltr-egress-mac {
-    						type ieee:mac-address;
-    						config false;
-    						description
-    							"MAC address returned in the egress MAC address field.
-    							If the ltr-egress object contains the value
-    							egress-no-tlv, then the contents of this object are
-    							meaningless.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3p, 20.41.2.11";
-    					}  					
-    					leaf ltr-egress-port-id-subtype {
-    						type lldp-port-id-subtype;
-    						config false;
-    						description
-    							"Format of the egress Port ID. If the ltr-egress
-    							object contains the value egress-no-tlv, then the
-    							contents of this object are meaningless.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3q, 20.41.2.12";
-    					}  					
-    					leaf ltr-egress-port-id {
-    						type lldp-port-id;
-    						config false;
-    						description
-    							"Egress Port ID. The format of this object is
-    							determined by the value of the
-    							ltr-egress-port-id-subtype object. If the ltr-egress
-    							object contains the value egress-no-tlv, then the
-    							contents of this object are meaningless.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3r, 20.41.2.13";
-    					}  					
-    					leaf ltr-organization-specific-tlv {
-    						type string {
-    							length "0 | 4..1500";
-    						}
-    						config false;
-    						description
-    							"All Organization specific TLVs returned in the LTR,
-    							if any. Includes all octets including and following
-    							the TLV Length field of each TLV, concatenated
-    							together.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.5.3s, 21.5.2";
-    					}
-    				} // linktrace-reply
-    				
-    				list mep-db {
-    					key rmep-id;
-    					description
-    						"";
-    					leaf rmep-id {
-    						type mep-id-type;
-    						description
-    							"Maintenance association Endpoint Identifier of a
-    							remote MEP whose information from the MEP Database is
-    							to be returned.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.2b";  						
-    					}
-    					leaf rmep-state {
-    						type remote-mep-state-type;
-    						config false;
-    						description 
-    							"The operational state of the remote MEP  state
-    							machine";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3b, 20.20";
-    					}
-    					leaf rmep-failed-ok-time {
-    						type yang:zero-based-counter32;
-    						units seconds;
-    						config false;
-    						description
-    							"The time (SysUpTime) at which the Remote MEP state
-    							machine last entered either the RMEP_FAILED or
-    							RMEP_OK state";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
-    					}
-    					leaf mep-db-mac-address {
-    						type ieee:mac-address;
-    						config false;
-    						description
-    							"The MAC address of the remote MEP.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
-    					}
-    					leaf mep-db-rdi {
-    						type boolean;
-    						config false;
-    						description
-    							"State of the RDI bit in the last received CCM
-    							(true for RDI=1), or false if none has been 
-    							received.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
-    					}
-    					leaf mep-db-port-status-tlv {
-    						type port-status-tlv-value;
-    						default "no-port-state-tlv";
-    						config false;
-    						description
-    							"An enumerated value of the Port status TLV received
-    							in the last CCM from the remote MEP or the default
-    							value no-port-state-tlv indicating either no CCM has
-    							been received, or that no port status TLV was
-    							received in the last CCM.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
-    					}
-    					leaf mep-db-interface-status-tlv {
-    						type interface-status-tlv-value;
-    						default "is-no-interface-status-tlv";
-    						config false;
-    						description
-    							"An enumerated value of the Interface status TLV
-    							received in the last CCM from the remote MEP or the
-    							default value is-no-interface-status-tlv indicating
-    							either no CCM has been received, or that no interface
-    							status TLV was received in the last CCM.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
-    					}
-    					leaf mep-db-chassis-id-subtype {
-    						type lldp-chassis-id-subtype;
-    						config false;
-    						description
-    							"This object specifies the format of the Chassis ID
-    							received in the last CCM.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
-    					}
-    					leaf mep-db-chassis-id {
-    						type lldp-chassis-id;
-    						config false;
-    						description
-    							"The Chassis ID. The format of this object is
-    							determined by the value of the ltr-chassis-id-subtype
-    							object.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
-    					}
-    					leaf mep-db-man-address-domain {
-    						type transport-service-domain;
-    						config false;
-    						description
-    							"The transport-service-domain that identifies the
-    							type and format of the related mep-db-man-address
-    							object, used to access the YANG agent of the system
-    							transmitting the CCM. Received in the CCM Sender ID
-    							TLV from that system.
-    							
-    							The value zeroDotZero (from RFC2578) indicates no
-    							management address was present in the LTR, in which
-    							case the related mep-db-man-address object MUST have
-    							a zero-length OCTET STRING as a value.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
-    							21.6.7";
-    					}
-    					leaf mep-db-man-address {
-    						type transport-service-address;
-    						config false;
-    						description
-    							"The transport-service-address that can be used to 
-    							access the YANG agent of the system transmitting the
-    							CCM, received in the CCM Sender ID TLV from that
-    							system. If the related mep-db-man-address-domain 
-    							object contains the value zeroDotZero, this object
-    							mep-db-man-address MUST have a zero-length OCTET
-    							STRING as a value.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
-    							21.6.7";
-    					}
-    					leaf mep-db-rmep-is-active {
-    						type boolean;
-    						description
-    							"A Boolean value statign if the remote MEP is 
-    							active.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
-    					}
-    				} // mep-db
-    				
-    				container stats {
-    					config false;
-    					description
-    						"Contains the counters associated with the MEP.";
-    					leaf mep-ccm-sequence-errors {
-    						type yang:counter64;
-    						description
-    							"The total number of out-of-sequence CCMs received
-    							from all remote MEPs.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
-    					}
-    					leaf mep-sent-ccms {
-    						type yang:counter64;
-    						description
-    							"Total number of CCMs transmitted";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3w, 20.10.2";
-    					}
-    					leaf mep-lbr-in {
-    						type yang:counter64;
-    						description
-    							"Total number of valid, in-order Loopback Replies
-    							received.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3y, 20.31.1";
-    					}
-    					leaf mep-lbr-in-out-of-order {
-    						type yang:counter64;
-    						description
-    							"The total number of valid, out-of-order
-    							Loopback Replies received";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3z, 20.31.1";
-    					}
-    					leaf mep-lbr-bad-msdu {
-    						type yang:counter64;
-    						description
-    							"The total number of LBRs receivd whose
-    							mac_service_data_unit did not match (except for the
-    							OpCode) that of the corresponding LBM.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3aa, 20.2.3";
-    					}
-    					leaf mep-unexpected-ltr-in {
-    						type yang:counter64;
-    						description
-    							"The total number of unexpected LTRs received.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ac, 20.44.1";
-    					}
-    					leaf mep-lbr-out {
-    						type yang:counter64;
-    						description
-    							"Total number of Loopback Replies transmitted.";
-    						reference
-    							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ad, 20.28.2";
-    					}
-    				} // stats
-    			} // mep
+      				leaf ma-reference {
+      					type uint32;
+      					description
+      						"An index reference to the particular Maintenance
+      						Association that this MEP belongs to.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
+      				}
+      				leaf bridge-port {
+      					type if:interface-ref;
+      					description
+      						"The interface index of the interface (i.e., Bridge 
+      						Port) to which the MEP is attached.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+      				}
+      				leaf mep-direction {
+      					type mp-direction-type;
+      					description
+      						"The direction in which the MEP faces on the Bridge
+      						Port. Example, up or down.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
+      				}
+      				leaf mep-primary-vid {
+      					type uint32 {
+      						range "0..16777215";
+      					}
+      					default 0;
+      					description
+      						"An integer indicating the Primary VID of the MEP. It
+      						is always one of the VIDs assigned to the MEPs MA. A
+      						value of 0 indicates that either the Primary VID is
+      						that of the MEPs MA, or that the MEPs MA is 
+      						associated with no VID.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
+      				}
+      				leaf mep-admin-state {
+      					type boolean;
+      					default "false";
+      					description
+      						"The administrative state of the MEP. TRUE indicates
+      						that the MEP is to functional normally, and FALSE
+      						indicates that it is to cease functioning.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
+      				}
+      				leaf mep-fng-state {
+      					type fng-state-type;
+      					default "fng-reset";
+      					config false;
+      					description
+      						"The current state of the MEP Fault Notification 
+      						Generator state machine.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
+      				}
+      				leaf mep-ccm-enabled {
+      					type boolean;
+      					default "false";
+      					description
+      						"Indicates whether the MEP can generate CCMs. If 
+      						TRUE, the MEP will generate CCM PDUs.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
+      				}
+      				leaf mep-ccm-ltm-priority {
+      					type dot1q-types:priority-type;
+      					description
+      						"The priority value for CCMs and LTMs transmitted by
+      						the MEP. The default value is the highest priority 
+      						allowed to pass through the Bridge Port for any of
+      						the MEPs VID(s).";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+      				}
+      				leaf mep-mac-address {
+      					type ieee:mac-address;
+      					description
+      						"The MAC address of the MEP.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
+      				}
+      				leaf fault-alarm-address {
+          			type fault-alarm-adress-type;
+          			default "not-specified";
+          			description
+          				"A value indicating whether Fault Alarms are to be 
+          				transmitted or not. The default is not specified, 
+          				which implies that the disposition of the fault-alarm
+          				used by the MD should be used.";
+          			reference
+          				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
+          		}
+      				leaf mep-lowest-priority-defect {
+      					type lowest-alarm-priority-type;
+      					default "mac-remote-error-xcon";
+      					description
+      						"The lowest priority defect that is allowed to
+      						generate fault alarms.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
+      				}
+      				leaf mep-fng-alarm-time {
+      					type yang:zero-based-counter32 {
+      						range "250..1000";
+      					}
+      					units deciseconds;
+      					default 250;
+      					description
+        					"The time that defect must be present before a Fault
+        					Alarm is issued.";
+        				reference
+        					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
+      				}
+      				leaf mep-fng-reset-time {
+        				type yang:zero-based-counter32 {
+        					range "250..1000";  					
+        				}
+        				units deciseconds;
+        				default 1000;
+        				description
+        					"The time that defects must be absent before 
+        					resetting a Fault Alarm.";
+        				reference
+        					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
+        			}
+      				leaf mep-highest-priority-defect {
+      					type highest-defect-priority-type;
+      					config false;
+      					description
+      						"The highest priority defect that has been present
+      						sicne the MEPs Fault Notification Generator state
+      						machine was last in the FNG_RESET state.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
+      				}
+      				leaf mep-defects {
+      					type mep-defects-type;
+      					config false;
+      					description
+      						"Vector of boolean error conditions";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
+      						20.23.3, 20.35.5, 20.35.6, 20.35.7";
+      				}
+      				leaf mep-error-ccm-last-failure {
+      					type string {
+      						length "1..1522";
+      					}
+      					config false;
+      					description
+      						"The last received CCM that triggered a def-error-ccm
+      						fault.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
+      				}
+      				leaf mep-xcon-ccm-last-failure {
+      					type string {
+      						length "1..1522";
+      					}
+      					config false;
+      					description
+      						"The last received CCM that triggered a def-xcon-ccm
+      						fault.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
+      				}
+      				leaf mep-next-lbm-trans-id {
+      					type uint32;
+      					config false;
+      					description
+      						"Next sequence number identifier to be sent in a
+      						Loopback message. This sequence number can be zero
+      						since it can wrap around.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3x, 20.28.2";
+      				}
+      				leaf mep-ltm-next-seq-number {
+      					type uint32;
+      					config false;
+      					description
+      						"Next transaction identifier to be sent in a 
+      						LinkTrace message.This sequence number can be zero
+      						since it can wrap around.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ab, 20.41.1";
+      				}
+      				leaf-list active-rmeps {
+      					type mep-id-type;
+      					description
+      						"A list indicating which of the remote MEPs in the
+      						same MA are active. By default, all configured
+      						remote MEPs in the same MA are active.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+      				}
+      				leaf mep-transmit-lbm-status {
+      					type boolean;
+      					default "false";
+      					description
+      						"A Boolean flag set to TRUE by the MEP Loopback
+      						Initiator state machine or YANG network configuration
+      						manager to indicate that another LBM is being 
+      						transmitted. Reset to FALSE by the MEP Loopback
+      						initiator state machine.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 20.32, Figure 20-11";
+      				}
+      				leaf mep-transmit-lbm-dest-mac-address {
+      					type ieee:mac-address;
+      					description
+      						"The target MAC Address field to be transmitted.
+      						A unicast destination MAC address. This address
+      						is used if node mep-transmit-lbm-dest-is-mep-id
+      						is FALSE.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+      				}
+      				leaf mep-transmit-lbm-dest-mep-id {
+      					type mep-id-or-zero-type;
+      					description
+      						"The identifier of a remote MEP in the same MA to
+      						which the LBM is to be sent. This address
+      						is used if node mep-transmit-lbm-dest-is-mep-id
+      						is TRUE.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+      				}
+      				leaf mep-transmit-lbm-dest-is-mep-id {
+      					type boolean;
+      					description
+      						"TRUE indicates that MEP ID of the target MEP is used
+      						for Loopback transmissions. FALSE indicates that
+      						unicast destination MAC address of the target MEP is
+      						used for Loopback transmissions.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+      				}
+      				leaf mep-transmit-lbm-messages {
+      					type uint32 {
+      						range "1..1024";
+      					}
+      					default 1;
+      					description
+      						"The number of Loopback messages to be transmitted.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2c";
+      				}
+      				leaf mep-transmit-lbm-data-tlv {
+      					type string;
+      					description
+      						"An arbitraty amoun tof data to be included in the
+      						Data TLV, if the Data TLV is selected to be sent. The
+      						intent is to be able to fill the frame carrying the
+      						CFM PDU to its maximum length.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
+      				}
+      				leaf mep-transmit-lbm-vlan-priority {
+      					type dot1q-types:priority-type;
+      					description
+      						"Priority. 3 bit value to be used in the VLAN tag, if
+      						present in the transmitted frame. The default value
+      						should be the CCM priority.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+      				}
+      				leaf mep-transmit-lbm-vlan-drop-eligible {
+      					type boolean;
+      					default "false";
+      					description
+      						"Drop eligible bit value to be used in the VLAN tag,
+      						if present in the transmitted frame";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+      				}
+      				leaf mep-transmit-lbm-result-ok {
+      					type boolean;
+      					default "true";
+      					config false;
+      					description
+      						"Indicates the result of the operation:
+      						   TRUE - The LBM will be (or has been) sent.
+      						   FALSE - The LBM will not be sent.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.3a";
+      				}
+      				leaf mep-transmit-lbm-seq-number {
+      					type uint32;
+      					description
+      						"The Loopback transaction identifier
+      						(mep-next-lbm-trans-id) of the first LBM (to be) 
+      						sent. The value returned is undefined if 
+      						mep-transmit-lbm-result-ok is FALSE.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.3.3b";
+      				}
+      				leaf mep-transmit-ltm-status {
+      					type boolean;
+      					default "true";
+      					config false;
+      					description
+      						"A Boolean flag set to TRUE by the Bridge Port to 
+      						indicate that another LTM may be transmitted. Reset
+      						to FALSE by the MEP Linktrace initiator state 
+      						machine.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 20.49, Figure 20-17";
+      				}
+      				leaf mep-transmit-ltm-flags {
+      					type mep-tx-ltm-flags-type;
+      					default use-fdb-only;
+      					description
+      						"The flags field for the LTMs transmitted by the 
+      						MEP.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2b, 20.42.1";
+      					
+      				}
+      				leaf mep-transmit-ltm-target-mac-address {
+      					type ieee:mac-address;
+      					description
+      						"The target MAC address field to be transmitted. A
+      						unicast MAC address. This address will be used if the
+      						value of mep-transmit-ltm-target-is-mep-id is FALSE.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+      				}
+      				leaf mep-transmit-ltm-target-mep-id {
+      					type mep-id-or-zero-type;
+      					description
+      						"The target MAC address field to be transmitted. The
+      						MEP identifier of another MEP in teh same MA. This
+      						address will be used if the value of 
+      						mep-transmit-ltm-target-is-mep-id is TRUE.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+      				}
+      				leaf mep-transmit-ltm-target-is-mep-id {
+      					type boolean;
+      					default "false";
+      					description
+      						"TRUE indicates taht MEP id of the target MEP is used
+      						for Linktrace transmission. FALSE indicates that
+      						unicast destination MAC address of the target MEP is
+      						used for LinkTrace transmission.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+      				}
+      				leaf mep-transmit-ltm-ttl {
+      					type uint32 {
+      						range "0..255";
+      					}
+      					default 64;
+      					description
+      						"The LTM TTL field. Indicates the number of hops 
+      						remaining to the LTM. Decremented by 1 by each
+      						Linktrace Responder that handles the LTM. The value
+      						returned in the LTR is one less than that received in
+      						the LTM. If the LTM TTL is 0 or 1, the LTM is not
+      						forwarded to the next hop, and if 0, no LTR is 
+      						generated.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2d, 21.8.4";
+      				}
+      				leaf mep-transmit-ltm-result {
+      					type boolean;
+      					default "true";
+      					config false;
+      					description
+      						"Indicates the result of the operation:
+      						   TRUE - The Linktrace message will be (or has been) 
+      						          sent.
+      						   FALSE - The Linktrace message will not be sent.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.4.3a";
+      				}
+      				leaf mep-transmit-ltm-seq-number {
+      					type uint32;
+      					config false;
+      					description
+      						"The LTM transaction identifier 
+      						(mep-ltm-next-seq-number) of the LTM sent. The value
+      						returned is undefined if mep-transmit-ltm-result is 
+      						FALSE.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.4.3b";
+      				}
+      				leaf mep-transmit-ltm-egress-identifier {
+      					type string {
+      						length "8";
+      					}
+      					config false;
+      					description
+      						"Identifies the MEP Linktrace Initiator that is 
+      						originating, or the Linktrace Responder that is
+      						forwarding, this LTM.
+      						
+      						The low-order six octets contain a 48-bit IEEE MAC
+      						address unique to the system in which the MEP 
+      						Linktrace Initiator or Linktrace Responder resides.
+      						The high-order two octets contain a value sufficient
+      						to uniquely identify the MEP Linktrace Initiator or 
+      						Linktrace Responder within that system.
+      						
+      						For most Bridges, the address of any MAC attached to
+      						the Bridge will suffice for the low-order six octets,
+      						and 0 for the high-order octets. In some situations,
+      						e.g., if multiple virtual Bridges utilizing emulated
+      						LANs are implemented in a single physical system, the
+      						high-order two octets can be used to differentiate
+      						among the transmitting entities.
+      						
+      						The value returned is undefined if 
+      						mep-transmit-ltm-result is FALSE.";
+      					reference
+      						"IEEE 802.1Q-2017 Clause 12.14.7.4.3c";  					
+      				}
+      				
+      				list linktrace-reply {
+      					key "ltr-seq-number ltr-receive-order";
+      					description
+      						"This table extends the MEP table and contains a list
+      						of Linktrace replies received by a specific MEP in
+      						response to a linktrace message.";
+      					leaf ltr-seq-number {
+      						type uint32 {
+      							range "0..4294967295";
+      						}
+      						description
+      							"Transaction identifier returned by a previous
+      							transmit linktrace message command, indicating
+      							which LTMs response is going to be returned.";
+      						reference
+        						"IEEE 802.1Q-2017 Clause 12.14.7.5.2b";
+      					}
+      					leaf ltr-receive-order {
+      						type uint32 {
+      							range "1..4294967295";
+      						}
+      						description
+      							"An index to distinguish among multiple LTRs with
+      							the same LTR Transaction Identifier field value. 
+      							Assigned sequentially from 1, in the order that the 
+      							Linktrace Initiator received the LTRs.";
+      					}
+      					leaf ltr-ttl {
+      						type uint32 {
+      							range "0..255";
+      						}
+      						config false;
+      						description
+      							"TTL field value for a returned LTR.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5, 20.41.2.2";
+      					}
+      					leaf ltr-forwarded {
+      						type boolean;
+      						config false;
+      						description
+      							"Indicates if a LTM was forwarded by the responding
+      							MP, as returned in the FwdYes flag of the flags 
+      							field.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3c, 20.41.2.1";
+      					}  					
+      					leaf ltr-terminal-mep {
+      						type boolean;
+      						config false;
+      						description
+      							"A Boolean value stating whether the forwarded LTM
+      							reached a MEP enclosing its MA, as returned in the
+      							Terminal MEP flag of the Flags field";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3d, 20.41.2.1";
+      					}
+      					leaf ltr-last-egress-identifier {
+      						type string {
+      							length "8";
+      						}
+      						config false;
+      						description
+      							"An octet field holding the Last Egress Identifier
+      							returned in the LTR Egress Identifier TLV of the
+      							LTR. The Last Egress Identifier identifies the MEP
+      							Linktrace Initiator that originated, or the 
+      							Linktrace Responder that forwarded, the LTM to
+      							which this LTR is the response. This is the same
+      							value as the Egress Identifier TLV of that LTM.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3e, 20.41.2.3";
+      					}  					
+      					leaf ltr-next-egress-identifier {
+      						type string {
+      							length "8";
+      						}
+      						config false;
+      						description
+      							"An octet field holding the Next Egress Identifier
+      							returned in the LTR Egress Identifier TLV of the 
+      							LTR. The Next Egress Identifier Identifies the
+      							Linktrace Responder that transmitted this LTR, and
+      							can forward the LTM to the next hop. This is the
+      							same value as the Egress Identifier TLV of the
+      							forwarded LTM, if any. If the FwdYes bit of the
+      							Flags field is false, the contents of this field
+      							are undefined, i.e., any value can be transmitted,
+      							and the field is ignored by the receiver.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3f, 20.41.2.4";
+      					}  					
+      					leaf ltr-relay {
+      						type relay-action-field-value;
+      						config false;
+      						description
+      							"Value returned in teh Relay Action field.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
+      					}  					
+      					leaf ltr-chassis-id-subtype {
+      						type lldp-chassis-id-subtype;
+      						config false;
+      						description
+      							"Specifies the format of the Chassis ID returned
+      							in the Sender ID TLV of the LTR, if any. This value
+      							is meaningless if the ltr-chassis-id has a length
+      							of 0.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3h, 21.5.3.2";
+      					}  					
+      					leaf ltr-chassis-id {
+      						type lldp-chassis-id;
+      						config false;
+      						description
+      							"The Chassis ID returned in the Sender ID TLV of 
+      							the LTR, if any. The format of this object is
+      							determined by the value of the 
+      							ltr-chassis-id-subtype object.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3i, 21.5.3.2";
+      					}  					
+      					leaf ltr-man-address-domain {
+      						type transport-service-domain;
+      						config false;
+      						description
+      							"The transport-service-domain that identifies the
+      							type and format of the related mep-db-man-address
+      							object, used to access the YANG agent of the system
+      							transmitting the LTR. Received in the LTR Sender ID
+      							TLV from that system.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.5,
+      							21.9.6";
+      					}  					
+      					leaf ltr-man-address {
+      						type transport-service-address;
+      						config false;
+      						description
+      							"The transport-service-address that can be used to
+      							access the YANG	agent of the system transmitting
+      							the CCM, received in the CCM Sender ID TLV from
+      							that system.
+      							
+      							If the related object ltr-man-address-domain
+      							contains the value zeroDotZero, this object
+      							ltr-man-address MUST have a zero-length OCTET 
+      							STRING as a value.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.7,
+      							21.9.6";
+      					}  					
+      					leaf ltr-ingress {
+      						type ingress-action-field-value;
+      						config false;
+      						description
+      							"The value returned in the Ingress Action Field of
+      							the LTM. The value ingress-no-tlv indicates that no
+      							Reply Ingress TLV was returned in the LTM.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3k, 20.41.2.6";
+      					}  					
+      					leaf ltr-ingress-mac {
+      						type ieee:mac-address;
+      						config false;
+      						description
+      							"MAC address returned in the ingress MAC address
+      							field. If the ltr-ingress object contains the value 
+      							ingress-no-tlv, then the contents of this object
+      							are meaningless.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3l, 20.41.2.7";
+      					}  					
+      					leaf ltr-ingress-port-id-subtype {
+      						type lldp-port-id-subtype;
+      						config false;
+      						description
+      							"Ingress Port ID. The format of this object is 
+      							determined by the value of the 
+      							ltr-ingress-port-id-subtype object. If the
+      							ltr-ingress object contains the value 
+      							ingress-no-tlv, then the contents of this object
+      							are meaningless.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3n, 20.41.2.9";
+      					}  					
+      					leaf ltr-egress {
+      						type egress-action-field-value;
+      						config false;
+      						description
+      							"The value returned in the Egress Action Field of
+      							the LTM. The value egress-no-tlv indicates that 
+      							no Reply Egress TLV was returned in the LTM.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3o, 20.41.2.10";
+      					}  					
+      					leaf ltr-egress-mac {
+      						type ieee:mac-address;
+      						config false;
+      						description
+      							"MAC address returned in the egress MAC address
+      							field. If the ltr-egress object contains the value
+      							egress-no-tlv, then the contents of this object are
+      							meaningless.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3p, 20.41.2.11";
+      					}  					
+      					leaf ltr-egress-port-id-subtype {
+      						type lldp-port-id-subtype;
+      						config false;
+      						description
+      							"Format of the egress Port ID. If the ltr-egress
+      							object contains the value egress-no-tlv, then the
+      							contents of this object are meaningless.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3q, 20.41.2.12";
+      					}  					
+      					leaf ltr-egress-port-id {
+      						type lldp-port-id;
+      						config false;
+      						description
+      							"Egress Port ID. The format of this object is
+      							determined by the value of the
+      							ltr-egress-port-id-subtype object. If the 
+      							ltr-egress object contains the value egress-no-tlv,
+      							then the contents of this object are meaningless.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3r, 20.41.2.13";
+      					}  					
+      					leaf ltr-organization-specific-tlv {
+      						type string {
+      							length "0 | 4..1500";
+      						}
+      						config false;
+      						description
+      							"All Organization specific TLVs returned in the 
+      							LTR, if any. Includes all octets including and
+      							following the TLV Length field of each TLV, 
+      							concatenated together.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3s, 21.5.2";
+      					}
+      				} // linktrace-reply
+      				
+      				list mep-db {
+      					key rmep-id;
+      					description
+      						"";
+      					leaf rmep-id {
+      						type mep-id-type;
+      						description
+      							"Maintenance association Endpoint Identifier of a
+      							remote MEP whose information from the MEP Database
+      							is to be returned.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.2b";  						
+      					}
+      					leaf rmep-state {
+      						type remote-mep-state-type;
+      						config false;
+      						description 
+      							"The operational state of the remote MEP  state
+      							machine";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3b, 20.20";
+      					}
+      					leaf rmep-failed-ok-time {
+      						type yang:zero-based-counter32;
+      						units seconds;
+      						config false;
+      						description
+      							"The time (SysUpTime) at which the Remote MEP state
+      							machine last entered either the RMEP_FAILED or
+      							RMEP_OK state";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
+      					}
+      					leaf mep-db-mac-address {
+      						type ieee:mac-address;
+      						config false;
+      						description
+      							"The MAC address of the remote MEP.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
+      					}
+      					leaf mep-db-rdi {
+      						type boolean;
+      						config false;
+      						description
+      							"State of the RDI bit in the last received CCM
+      							(true for RDI=1), or false if none has been 
+      							received.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
+      					}
+      					leaf mep-db-port-status-tlv {
+      						type port-status-tlv-value;
+      						default "no-port-state-tlv";
+      						config false;
+      						description
+      							"An enumerated value of the Port status TLV 
+      							received in the last CCM from the remote MEP or 
+      							the default value no-port-state-tlv indicating
+      							either no CCM has been received, or that no port
+      							status TLV was received in the last CCM.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
+      					}
+      					leaf mep-db-interface-status-tlv {
+      						type interface-status-tlv-value;
+      						default "is-no-interface-status-tlv";
+      						config false;
+      						description
+      							"An enumerated value of the Interface status TLV
+      							received in the last CCM from the remote MEP or the
+      							default value is-no-interface-status-tlv indicating
+      							either no CCM has been received, or that no 
+      							interface status TLV was received in the last 
+      							CCM.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
+      					}
+      					leaf mep-db-chassis-id-subtype {
+      						type lldp-chassis-id-subtype;
+      						config false;
+      						description
+      							"This object specifies the format of the Chassis ID
+      							received in the last CCM.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
+      					}
+      					leaf mep-db-chassis-id {
+      						type lldp-chassis-id;
+      						config false;
+      						description
+      							"The Chassis ID. The format of this object is
+      							determined by the value of the 
+      							ltr-chassis-id-subtype object.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
+      					}
+      					leaf mep-db-man-address-domain {
+      						type transport-service-domain;
+      						config false;
+      						description
+      							"The transport-service-domain that identifies the
+      							type and format of the related mep-db-man-address
+      							object, used to access the YANG agent of the system
+      							transmitting the CCM. Received in the CCM Sender ID
+      							TLV from that system.
+      							
+      							The value zeroDotZero (from RFC2578) indicates no
+      							management address was present in the LTR, in which
+      							case the related mep-db-man-address object MUST
+      							have a zero-length OCTET STRING as a value.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
+      							21.6.7";
+      					}
+      					leaf mep-db-man-address {
+      						type transport-service-address;
+      						config false;
+      						description
+      							"The transport-service-address that can be used to 
+      							access the YANG agent of the system transmitting
+      							the CCM, received in the CCM Sender ID TLV from
+      							that system. If the related 
+      							mep-db-man-address-domain object contains the 
+      							value zeroDotZero, this object mep-db-man-address
+      							MUST have a zero-length OCTET STRING as a value.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
+      							21.6.7";
+      					}
+      					leaf mep-db-rmep-is-active {
+      						type boolean;
+      						description
+      							"A Boolean value statign if the remote MEP is 
+      							active.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+      					}
+      				} // mep-db
+      				
+      				container stats {
+      					config false;
+      					description
+      						"Contains the counters associated with the MEP.";
+      					leaf mep-ccm-sequence-errors {
+      						type yang:counter64;
+      						description
+      							"The total number of out-of-sequence CCMs received
+      							from all remote MEPs.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
+      					}
+      					leaf mep-sent-ccms {
+      						type yang:counter64;
+      						description
+      							"Total number of CCMs transmitted";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3w, 20.10.2";
+      					}
+      					leaf mep-lbr-in {
+      						type yang:counter64;
+      						description
+      							"Total number of valid, in-order Loopback Replies
+      							received.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3y, 20.31.1";
+      					}
+      					leaf mep-lbr-in-out-of-order {
+      						type yang:counter64;
+      						description
+      							"The total number of valid, out-of-order
+      							Loopback Replies received";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3z, 20.31.1";
+      					}
+      					leaf mep-lbr-bad-msdu {
+      						type yang:counter64;
+      						description
+      							"The total number of LBRs receivd whose
+      							mac_service_data_unit did not match (except for the
+      							OpCode) that of the corresponding LBM.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3aa, 20.2.3";
+      					}
+      					leaf mep-unexpected-ltr-in {
+      						type yang:counter64;
+      						description
+      							"The total number of unexpected LTRs received.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ac, 20.44.1";
+      					}
+      					leaf mep-lbr-out {
+      						type yang:counter64;
+      						description
+      							"Total number of Loopback Replies transmitted.";
+      						reference
+      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ad, 20.28.2";
+      					}
+      				} // stats
+      			} // mep
+    			} // maintenance-association-component
     		} // maintenance-association
   		} // maintenance-domain
   	} // maintenance-domains
-  	
   } // cfm
   
   
@@ -2972,7 +2940,8 @@ module ieee802-dot1q-cfm {
 		leaf mep-id {
 			type leafref {
 				path "/cfm/maintenance-domains/maintenance-domain"+
-			       "/maintenance-association/mep/mep-id";
+			       "/maintenance-association"+
+						 "/maintenance-association-component/mep/mep-id";
 			}
 			description
 				"Integer that is unique among all the MEPs in the same
@@ -2983,7 +2952,8 @@ module ieee802-dot1q-cfm {
 		leaf mep-priority-defect {
 			type leafref {
 				path "/cfm/maintenance-domains/maintenance-domain"+
-			       "/maintenance-association/mep"+
+			       "/maintenance-association"+
+			       "/maintenance-association-component/mep"+
 						 "/mep-highest-priority-defect";
 			}
 			description


### PR DESCRIPTION
**Clean Compile**


----------------------
ieee802-dot1q-cfm.yang
----------------------

Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw cfm-stacks
       |  +--rw bridge?      bridge-ref
       |  +--rw cfm-stack* [bridge-port type-of-service-selector service-selector-or-none md-level direction]
       |     +--rw bridge-port                      if:interface-ref
       |     +--rw type-of-service-selector         service-selector-type
       |     +--rw service-selector-or-none         service-selector-value-or-none
       |     +--rw md-level                         md-level-type
       |     +--rw direction                        mp-direction-type
       |     +--ro maintenance-domain-index?        uint32
       |     +--ro maintenance-association-index?   uint32
       |     +--ro mep-id?                          mep-id-or-zero-type
       |     +--ro mac-address?                     ieee:mac-address
       +--rw default-md-levels
       |  +--rw bridge?             bridge-ref
       |  +--rw default-md-level* [component-id primary-selector-type primary-selector]
       |     +--rw component-id             component-identifier-type
       |     +--rw primary-selector-type    service-selector-type
       |     +--rw primary-selector         service-selector-value
       |     +--rw selectors*               service-selector-value
       |     +--rw md-status?               boolean
       |     +--rw md-level?                md-level-or-none-type
       |     +--rw mhf-creation?            mhf-creation-type
       |     +--rw id-permission?           sender-id-permission-type
       +--rw config-errors
       |  +--rw bridge?         bridge-ref
       |  +--rw config-error* [type-of-selector selector bridge-port]
       |     +--rw type-of-selector    service-selector-type
       |     +--rw selector            service-selector-value
       |     +--rw bridge-port         if:interface-ref
       |     +--ro error-type?         config-errors
       +--rw maintenance-domains
          +--rw bridge?               bridge-ref
          +--rw maintenance-domain* [name-format name]
             +--rw name-format                md-name-format-type
             +--rw name                       md-name-type
             +--rw md-index?                  uint32
             +--rw md-level?                  md-level-type
             +--rw mhf-creation?              mhf-creation-type
             +--rw id-permission?             sender-id-permission-type
             +--rw fault-alarm-address?       fault-alarm-adress-type
             +--rw maintenance-association* [name name-format]
                +--rw name                                 ma-name-type
                +--rw name-format                          ma-name-format-type
                +--rw ma-index?                            uint32
                +--rw md-reference?                        uint32
                +--rw ccm-interval?                        ccm-interval-type
                +--rw fault-alarm-address?                 fault-alarm-adress-type
                +--rw maintenance-association-component* [ma-component-id]
                   +--rw ma-component-id             component-identifier-type
                   +--rw primary-selector-type?      service-selector-type
                   +--rw primary-selector-or-none?   service-selector-value-or-none
                   +--rw mhf-creation?               mhf-creation-type
                   +--rw id-permission?              sender-id-permission-type
                   +--rw number-of-vids?             uint32
                   +--rw selectors*                  service-selector-value
                   +--rw mep* [mep-id]
                      +--rw mep-id                                 mep-id-type
                      +--rw ma-reference?                          uint32
                      +--rw bridge-port?                           if:interface-ref
                      +--rw mep-direction?                         mp-direction-type
                      +--rw mep-primary-vid?                       uint32
                      +--rw mep-admin-state?                       boolean
                      +--ro mep-fng-state?                         fng-state-type
                      +--rw mep-ccm-enabled?                       boolean
                      +--rw mep-ccm-ltm-priority?                  dot1q-types:priority-type
                      +--rw mep-mac-address?                       ieee:mac-address
                      +--rw fault-alarm-address?                   fault-alarm-adress-type
                      +--rw mep-lowest-priority-defect?            lowest-alarm-priority-type
                      +--rw mep-fng-alarm-time?                    yang:zero-based-counter32
                      +--rw mep-fng-reset-time?                    yang:zero-based-counter32
                      +--ro mep-highest-priority-defect?           highest-defect-priority-type
                      +--ro mep-defects?                           mep-defects-type
                      +--ro mep-error-ccm-last-failure?            string
                      +--ro mep-xcon-ccm-last-failure?             string
                      +--ro mep-next-lbm-trans-id?                 uint32
                      +--ro mep-ltm-next-seq-number?               uint32
                      +--rw active-rmeps*                          mep-id-type
                      +--rw mep-transmit-lbm-status?               boolean
                      +--rw mep-transmit-lbm-dest-mac-address?     ieee:mac-address
                      +--rw mep-transmit-lbm-dest-mep-id?          mep-id-or-zero-type
                      +--rw mep-transmit-lbm-dest-is-mep-id?       boolean
                      +--rw mep-transmit-lbm-messages?             uint32
                      +--rw mep-transmit-lbm-data-tlv?             string
                      +--rw mep-transmit-lbm-vlan-priority?        dot1q-types:priority-type
                      +--rw mep-transmit-lbm-vlan-drop-eligible?   boolean
                      +--ro mep-transmit-lbm-result-ok?            boolean
                      +--rw mep-transmit-lbm-seq-number?           uint32
                      +--ro mep-transmit-ltm-status?               boolean
                      +--rw mep-transmit-ltm-flags?                mep-tx-ltm-flags-type
                      +--rw mep-transmit-ltm-target-mac-address?   ieee:mac-address
                      +--rw mep-transmit-ltm-target-mep-id?        mep-id-or-zero-type
                      +--rw mep-transmit-ltm-target-is-mep-id?     boolean
                      +--rw mep-transmit-ltm-ttl?                  uint32
                      +--ro mep-transmit-ltm-result?               boolean
                      +--ro mep-transmit-ltm-seq-number?           uint32
                      +--ro mep-transmit-ltm-egress-identifier?    string
                      +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
                      |  +--rw ltr-seq-number                   uint32
                      |  +--rw ltr-receive-order                uint32
                      |  +--ro ltr-ttl?                         uint32
                      |  +--ro ltr-forwarded?                   boolean
                      |  +--ro ltr-terminal-mep?                boolean
                      |  +--ro ltr-last-egress-identifier?      string
                      |  +--ro ltr-next-egress-identifier?      string
                      |  +--ro ltr-relay?                       relay-action-field-value
                      |  +--ro ltr-chassis-id-subtype?          lldp-chassis-id-subtype
                      |  +--ro ltr-chassis-id?                  lldp-chassis-id
                      |  +--ro ltr-man-address-domain?          transport-service-domain
                      |  +--ro ltr-man-address?                 transport-service-address
                      |  +--ro ltr-ingress?                     ingress-action-field-value
                      |  +--ro ltr-ingress-mac?                 ieee:mac-address
                      |  +--ro ltr-ingress-port-id-subtype?     lldp-port-id-subtype
                      |  +--ro ltr-egress?                      egress-action-field-value
                      |  +--ro ltr-egress-mac?                  ieee:mac-address
                      |  +--ro ltr-egress-port-id-subtype?      lldp-port-id-subtype
                      |  +--ro ltr-egress-port-id?              lldp-port-id
                      |  +--ro ltr-organization-specific-tlv?   string
                      +--rw mep-db* [rmep-id]
                      |  +--rw rmep-id                        mep-id-type
                      |  +--ro rmep-state?                    remote-mep-state-type
                      |  +--ro rmep-failed-ok-time?           yang:zero-based-counter32
                      |  +--ro mep-db-mac-address?            ieee:mac-address
                      |  +--ro mep-db-rdi?                    boolean
                      |  +--ro mep-db-port-status-tlv?        port-status-tlv-value
                      |  +--ro mep-db-interface-status-tlv?   interface-status-tlv-value
                      |  +--ro mep-db-chassis-id-subtype?     lldp-chassis-id-subtype
                      |  +--ro mep-db-chassis-id?             lldp-chassis-id
                      |  +--ro mep-db-man-address-domain?     transport-service-domain
                      |  +--ro mep-db-man-address?            transport-service-address
                      |  +--rw mep-db-rmep-is-active?         boolean
                      +--ro stats
                         +--ro mep-ccm-sequence-errors?   yang:counter64
                         +--ro mep-sent-ccms?             yang:counter64
                         +--ro mep-lbr-in?                yang:counter64
                         +--ro mep-lbr-in-out-of-order?   yang:counter64
                         +--ro mep-lbr-bad-msdu?          yang:counter64
                         +--ro mep-unexpected-ltr-in?     yang:counter64
                         +--ro mep-lbr-out?               yang:counter64

  rpcs:
    +---x transmit-loopback-message
    |  +---w input
    |  |  +---w md-index?                              uint32
    |  |  +---w ma-index?                              uint32
    |  |  +---w mep-id?                                mep-id-type
    |  |  +---w mep-transmit-lbm-dest-mac-address?     ieee:mac-address
    |  |  +---w mep-transmit-lbm-dest-mep-id?          mep-id-or-zero-type
    |  |  +---w mep-transmit-lbm-dest-is-mep-id?       boolean
    |  |  +---w mep-transmit-lbm-messages?             uint32
    |  |  +---w mep-transmit-lbm-data-tlv?             string
    |  |  +---w mep-transmit-lbm-vlan-priority?        dot1q-types:priority-type
    |  |  +---w mep-transmit-lbm-vlan-drop-eligible?   boolean
    |  +--ro output
    |     +--ro mep-transmit-lbm-result-ok?    boolean
    |     +--ro mep-transmit-lbm-seq-number?   uint32
    +---x transmit-linktrace-message
       +---w input
       |  +---w md-index?                              uint32
       |  +---w ma-index?                              uint32
       |  +---w mep-id?                                mep-id-type
       |  +---w mep-transmit-ltm-flags?                mep-tx-ltm-flags-type
       |  +---w mep-transmit-ltm-target-mac-address?   ieee:mac-address
       |  +---w mep-transmit-ltm-target-mep-id?        mep-id-or-zero-type
       |  +---w mep-transmit-ltm-target-is-mep-id?     boolean
       |  +---w mep-transmit-ltm-ttl?                  uint32
       +--ro output
          +--ro mep-transmit-ltm-result?              boolean
          +--ro mep-transmit-ltm-seq-number?          uint32
          +--ro mep-transmit-ltm-egress-identifier?   string

  notifications:
    +---n mep-fault-alarm
       +--ro md-name?               -> /cfm/maintenance-domains/maintenance-domain/name
       +--ro md-name-format?        -> /cfm/maintenance-domains/maintenance-domain/name-format
       +--ro ma-name?               -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name
       +--ro ma-name-format?        -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name-format
       +--ro mep-id?                -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/maintenance-association-component/mep/mep-id
       +--ro mep-priority-defect?   -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/maintenance-association-component/mep/mep-highest-priority-defect

Confdc Output
No warnings or errors

yanglint Validation
No warnings or errors
