### PR TITLE
Update cfm domain type definition

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -363,18 +363,6 @@ module ieee802-dot1q-cfm {
   				"RFC2579 DisplayString, except that the character codes
   				0-31 (decimal) are not used.";
   		}
-  		enum ieee-reserved-5-31-64-255 {
-  			value 5;
-  			description
-  				"Reserved for definition by IEEE 802.1. Can be [5..31] and
-  				[64..255].";
-  		}
-  		enum itu-reserved-32-63 {
-  			value 6;
-  			description
-  				"Reserved for definition by ITU-T Y.1731. Values range from
-  				[32..63].";
-  		}
   	}
   	description
   		"A value that represents a type (and thereby the format)
@@ -424,18 +412,6 @@ module ieee802-dot1q-cfm {
   			value 32;
   			description
   				"ICC-based format as specified in ITU-T Y.1731.";
-  		}
-  		enum ieee-reserved-5-31-64-255 {
-  			value 5;
-  			description
-  				"Reserved for definition by IEEE 802.1. Values can be [5..31]
-  				and [64..255].";
-  		}
-  		enum itu-reserved-33-63 {
-  			value 6;
-  			description
-  				"Reserved for definition by ITU-T Y.1731. Values range from
-  				[33..63].";
   		}
   	}
   	description

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -6,7 +6,7 @@ module ieee802-dot1q-cfm {
   import ieee802-types { prefix "ieee"; }
   import ietf-yang-types { prefix "yang"; }
   import ietf-interfaces { prefix "if"; }
-  import ieee802-dot1q-bridge { prefix "dot1q"; }
+  //import ieee802-dot1q-bridge { prefix "dot1q"; }
   import ieee802-dot1q-types { prefix "dot1q-types"; }
 
   organization
@@ -314,21 +314,23 @@ module ieee802-dot1q-cfm {
    */
   
   typedef bridge-ref {
-  	type leafref {
-  		path "/dot1q:bridges/dot1q:bridge/dot1q:name";
-  	}
+  	//type leafref {
+  	//	path "/dot1q:bridges/dot1q:bridge/dot1q:name";
+  	//}
+  	type string;
   	description
   		"This type is used by data models that need to reference
   		a configured Bridge.";
   }
   
   typedef component-ref {
-  	type leafref {
-  		path "/dot1q:bridges/dot1q:bridge/dot1q:component/dot1q:name";
-  	}
+  	type string;
+  	//type leafref {
+  	//	path "/dot1q:bridges/dot1q:bridge/dot1q:component/dot1q:name";
+  	//}
   	description
   		"This type is used by data models that need to reference
-  		a configured Bridge.";
+  		a configured Bridge Component.";
   }
   
   typedef md-name-format-type {
@@ -1427,6 +1429,54 @@ module ieee802-dot1q-cfm {
     	} // default-md-level
   	} // default-md-levels
   	
+  	container mip {
+  		description
+  			"Maintenance Association Intermediate Point";
+  		leaf bridge-port {
+				type if:interface-ref;
+				description
+					"The interface index of the interface (i.e., Bridge 
+					Port) to which the MEP is attached.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+			}
+  		leaf primary-selector-type {
+  			type service-selector-type;
+  			description
+  				"Type of the Primary Service Selector identifier.";
+  		}
+  		leaf primary-selector {
+  			type service-selector-value;
+  			description
+  				"Primary Service Selector identifier of a Service Instance
+  				with no MA configured.";
+  		}
+  		leaf-list selectors {
+    		type service-selector-value;
+    		description
+    			"A list of VIDs associated with any MHF on the VID, always
+    			including that VID, or the Backbone-SID of the B-component
+    			or VIP-SID of the I-component associated with any MHF on
+    			the I-SID. The first VID is the MAs Primary VID.
+    			
+    			List is empty if no VID specified.";
+    		reference
+    			"IEEE 802.1Q-2017 Clause 12.14.3.1.3a";
+    	}
+  		leaf md-level {
+  			type md-level-or-none-type;
+  			default -1;
+  			description
+  				"A value indicating the MD Level at which MHFs are to be
+  				created, and Sender ID TLV transmission by those MHFs is to
+  				be controlled, for the VLAN to which this entry's objects
+  				apply.";
+  			reference
+  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3c, 12.14.3.2.2b";
+  		}
+  		
+  	}
+  	
   	container config-errors {
   		description
   			"The Configuration Error List managed object is a list of
@@ -1743,7 +1793,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
       				}
-      				leaf mep-direction {
+      				leaf direction {
       					type mp-direction-type;
       					description
       						"The direction in which the MEP faces on the Bridge
@@ -1751,7 +1801,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
       				}
-      				leaf mep-primary-vid {
+      				leaf primary-vid {
       					type uint32 {
       						range "0..16777215";
       					}
@@ -1765,7 +1815,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
       				}
-      				leaf mep-admin-state {
+      				leaf admin-state {
       					type boolean;
       					default "false";
       					description
@@ -1775,7 +1825,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
       				}
-      				leaf mep-fng-state {
+      				leaf fng-state {
       					type fng-state-type;
       					default "fng-reset";
       					config false;
@@ -1785,7 +1835,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
       				}
-      				leaf mep-ccm-enabled {
+      				leaf ccm-enabled {
       					type boolean;
       					default "false";
       					description
@@ -1794,7 +1844,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
       				}
-      				leaf mep-ccm-ltm-priority {
+      				leaf ccm-ltm-priority {
       					type dot1q-types:priority-type;
       					description
       						"The priority value for CCMs and LTMs transmitted by
@@ -1804,7 +1854,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
       				}
-      				leaf mep-mac-address {
+      				leaf mac-address {
       					type ieee:mac-address;
       					description
       						"The MAC address of the MEP.";
@@ -1822,7 +1872,7 @@ module ieee802-dot1q-cfm {
           			reference
           				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
           		}
-      				leaf mep-lowest-priority-defect {
+      				leaf lowest-priority-defect {
       					type lowest-alarm-priority-type;
       					default "mac-remote-error-xcon";
       					description
@@ -1831,7 +1881,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
       				}
-      				leaf mep-fng-alarm-time {
+      				leaf fng-alarm-time {
       					type yang:zero-based-counter32 {
       						range "250..1000";
       					}
@@ -1843,7 +1893,7 @@ module ieee802-dot1q-cfm {
         				reference
         					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
       				}
-      				leaf mep-fng-reset-time {
+      				leaf fng-reset-time {
         				type yang:zero-based-counter32 {
         					range "250..1000";  					
         				}
@@ -1855,7 +1905,7 @@ module ieee802-dot1q-cfm {
         				reference
         					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
         			}
-      				leaf mep-highest-priority-defect {
+      				leaf highest-priority-defect {
       					type highest-defect-priority-type;
       					config false;
       					description
@@ -1865,7 +1915,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
       				}
-      				leaf mep-defects {
+      				leaf defects {
       					type mep-defects-type;
       					config false;
       					description
@@ -1874,7 +1924,7 @@ module ieee802-dot1q-cfm {
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
       						20.23.3, 20.35.5, 20.35.6, 20.35.7";
       				}
-      				leaf mep-error-ccm-last-failure {
+      				leaf error-ccm-last-failure {
       					type string {
       						length "1..1522";
       					}
@@ -1885,7 +1935,7 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
       				}
-      				leaf mep-xcon-ccm-last-failure {
+      				leaf xcon-ccm-last-failure {
       					type string {
       						length "1..1522";
       					}
@@ -1896,26 +1946,6 @@ module ieee802-dot1q-cfm {
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
       				}
-      				leaf mep-next-lbm-trans-id {
-      					type uint32;
-      					config false;
-      					description
-      						"Next sequence number identifier to be sent in a
-      						Loopback message. This sequence number can be zero
-      						since it can wrap around.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3x, 20.28.2";
-      				}
-      				leaf mep-ltm-next-seq-number {
-      					type uint32;
-      					config false;
-      					description
-      						"Next transaction identifier to be sent in a 
-      						LinkTrace message.This sequence number can be zero
-      						since it can wrap around.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ab, 20.41.1";
-      				}
       				leaf-list active-rmeps {
       					type mep-id-type;
       					description
@@ -1924,228 +1954,6 @@ module ieee802-dot1q-cfm {
       						remote MEPs in the same MA are active.";
       					reference
       						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
-      				}
-      				leaf mep-transmit-lbm-status {
-      					type boolean;
-      					default "false";
-      					description
-      						"A Boolean flag set to TRUE by the MEP Loopback
-      						Initiator state machine or YANG network configuration
-      						manager to indicate that another LBM is being 
-      						transmitted. Reset to FALSE by the MEP Loopback
-      						initiator state machine.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 20.32, Figure 20-11";
-      				}
-      				leaf mep-transmit-lbm-dest-mac-address {
-      					type ieee:mac-address;
-      					description
-      						"The target MAC Address field to be transmitted.
-      						A unicast destination MAC address. This address
-      						is used if node mep-transmit-lbm-dest-is-mep-id
-      						is FALSE.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
-      				}
-      				leaf mep-transmit-lbm-dest-mep-id {
-      					type mep-id-or-zero-type;
-      					description
-      						"The identifier of a remote MEP in the same MA to
-      						which the LBM is to be sent. This address
-      						is used if node mep-transmit-lbm-dest-is-mep-id
-      						is TRUE.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
-      				}
-      				leaf mep-transmit-lbm-dest-is-mep-id {
-      					type boolean;
-      					description
-      						"TRUE indicates that MEP ID of the target MEP is used
-      						for Loopback transmissions. FALSE indicates that
-      						unicast destination MAC address of the target MEP is
-      						used for Loopback transmissions.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
-      				}
-      				leaf mep-transmit-lbm-messages {
-      					type uint32 {
-      						range "1..1024";
-      					}
-      					default 1;
-      					description
-      						"The number of Loopback messages to be transmitted.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2c";
-      				}
-      				leaf mep-transmit-lbm-data-tlv {
-      					type string;
-      					description
-      						"An arbitraty amoun tof data to be included in the
-      						Data TLV, if the Data TLV is selected to be sent. The
-      						intent is to be able to fill the frame carrying the
-      						CFM PDU to its maximum length.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
-      				}
-      				leaf mep-transmit-lbm-vlan-priority {
-      					type dot1q-types:priority-type;
-      					description
-      						"Priority. 3 bit value to be used in the VLAN tag, if
-      						present in the transmitted frame. The default value
-      						should be the CCM priority.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
-      				}
-      				leaf mep-transmit-lbm-vlan-drop-eligible {
-      					type boolean;
-      					default "false";
-      					description
-      						"Drop eligible bit value to be used in the VLAN tag,
-      						if present in the transmitted frame";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
-      				}
-      				leaf mep-transmit-lbm-result-ok {
-      					type boolean;
-      					default "true";
-      					config false;
-      					description
-      						"Indicates the result of the operation:
-      						   TRUE - The LBM will be (or has been) sent.
-      						   FALSE - The LBM will not be sent.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.3a";
-      				}
-      				leaf mep-transmit-lbm-seq-number {
-      					type uint32;
-      					description
-      						"The Loopback transaction identifier
-      						(mep-next-lbm-trans-id) of the first LBM (to be) 
-      						sent. The value returned is undefined if 
-      						mep-transmit-lbm-result-ok is FALSE.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.3.3b";
-      				}
-      				leaf mep-transmit-ltm-status {
-      					type boolean;
-      					default "true";
-      					config false;
-      					description
-      						"A Boolean flag set to TRUE by the Bridge Port to 
-      						indicate that another LTM may be transmitted. Reset
-      						to FALSE by the MEP Linktrace initiator state 
-      						machine.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 20.49, Figure 20-17";
-      				}
-      				leaf mep-transmit-ltm-flags {
-      					type mep-tx-ltm-flags-type;
-      					default use-fdb-only;
-      					description
-      						"The flags field for the LTMs transmitted by the 
-      						MEP.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2b, 20.42.1";
-      					
-      				}
-      				leaf mep-transmit-ltm-target-mac-address {
-      					type ieee:mac-address;
-      					description
-      						"The target MAC address field to be transmitted. A
-      						unicast MAC address. This address will be used if the
-      						value of mep-transmit-ltm-target-is-mep-id is FALSE.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
-      				}
-      				leaf mep-transmit-ltm-target-mep-id {
-      					type mep-id-or-zero-type;
-      					description
-      						"The target MAC address field to be transmitted. The
-      						MEP identifier of another MEP in teh same MA. This
-      						address will be used if the value of 
-      						mep-transmit-ltm-target-is-mep-id is TRUE.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
-      				}
-      				leaf mep-transmit-ltm-target-is-mep-id {
-      					type boolean;
-      					default "false";
-      					description
-      						"TRUE indicates taht MEP id of the target MEP is used
-      						for Linktrace transmission. FALSE indicates that
-      						unicast destination MAC address of the target MEP is
-      						used for LinkTrace transmission.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
-      				}
-      				leaf mep-transmit-ltm-ttl {
-      					type uint32 {
-      						range "0..255";
-      					}
-      					default 64;
-      					description
-      						"The LTM TTL field. Indicates the number of hops 
-      						remaining to the LTM. Decremented by 1 by each
-      						Linktrace Responder that handles the LTM. The value
-      						returned in the LTR is one less than that received in
-      						the LTM. If the LTM TTL is 0 or 1, the LTM is not
-      						forwarded to the next hop, and if 0, no LTR is 
-      						generated.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.4.2d, 21.8.4";
-      				}
-      				leaf mep-transmit-ltm-result {
-      					type boolean;
-      					default "true";
-      					config false;
-      					description
-      						"Indicates the result of the operation:
-      						   TRUE - The Linktrace message will be (or has been) 
-      						          sent.
-      						   FALSE - The Linktrace message will not be sent.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.4.3a";
-      				}
-      				leaf mep-transmit-ltm-seq-number {
-      					type uint32;
-      					config false;
-      					description
-      						"The LTM transaction identifier 
-      						(mep-ltm-next-seq-number) of the LTM sent. The value
-      						returned is undefined if mep-transmit-ltm-result is 
-      						FALSE.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.4.3b";
-      				}
-      				leaf mep-transmit-ltm-egress-identifier {
-      					type string {
-      						length "8";
-      					}
-      					config false;
-      					description
-      						"Identifies the MEP Linktrace Initiator that is 
-      						originating, or the Linktrace Responder that is
-      						forwarding, this LTM.
-      						
-      						The low-order six octets contain a 48-bit IEEE MAC
-      						address unique to the system in which the MEP 
-      						Linktrace Initiator or Linktrace Responder resides.
-      						The high-order two octets contain a value sufficient
-      						to uniquely identify the MEP Linktrace Initiator or 
-      						Linktrace Responder within that system.
-      						
-      						For most Bridges, the address of any MAC attached to
-      						the Bridge will suffice for the low-order six octets,
-      						and 0 for the high-order octets. In some situations,
-      						e.g., if multiple virtual Bridges utilizing emulated
-      						LANs are implemented in a single physical system, the
-      						high-order two octets can be used to differentiate
-      						among the transmitting entities.
-      						
-      						The value returned is undefined if 
-      						mep-transmit-ltm-result is FALSE.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.4.3c";  					
       				}
       				
       				list linktrace-reply {
@@ -2596,6 +2404,372 @@ module ieee802-dot1q-cfm {
     		} // maintenance-association
   		} // maintenance-domain
   	} // maintenance-domains
+  	
+  	container connectivity-check-message {
+  		description
+  			"Continuity check protocol";
+  		leaf mep {
+  			type mep-id-type;
+  			description
+					"Integer that is unique among all the MEPs in the
+					same Maintenance Association.";
+				reference
+					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+  		}
+  		leaf ma-reference {
+				type uint32;
+				description
+					"An index reference to the particular Maintenance
+					Association that this MEP belongs to.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
+			}
+  		leaf bridge-port {
+				type if:interface-ref;
+				description
+					"The interface index of the interface (i.e., Bridge 
+					Port) to which the MEP is attached.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+			}
+  		leaf ccm-enabled {
+				type boolean;
+				default "false";
+				description
+					"Indicates whether the MEP can generate CCMs. If 
+					TRUE, the MEP will generate CCM PDUs.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
+			}
+			leaf priority {
+				type dot1q-types:priority-type;
+				description
+					"The priority value for CCMs and LTMs transmitted by
+					the MEP. The default value is the highest priority 
+					allowed to pass through the Bridge Port for any of
+					the MEPs VID(s).";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+			}
+			leaf ccm-interval {
+				type ccm-interval-type;
+				description
+					"The interval between CCM transmissions to be used by all
+					MEPs in the Maintenance Association.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.6.1.3e";
+			}
+  	} // connectivity-check
+  	
+  	container loopback {
+  		description
+  			"Loopback protocol";
+  		leaf mep {
+  			type mep-id-type;
+  			description
+					"Integer that is unique among all the MEPs in the
+					same Maintenance Association.";
+				reference
+					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+  		}
+  		leaf ma-reference {
+				type uint32;
+				description
+					"An index reference to the particular Maintenance
+					Association that this MEP belongs to.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
+			}
+  		leaf bridge-port {
+				type if:interface-ref;
+				description
+					"The interface index of the interface (i.e., Bridge 
+					Port) to which the MEP is attached.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+			}
+  		leaf status {
+				type boolean;
+				default "false";
+				description
+					"A Boolean flag set to TRUE by the MEP Loopback
+					Initiator state machine or YANG network configuration
+					manager to indicate that another LBM is being 
+					transmitted. Reset to FALSE by the MEP Loopback
+					initiator state machine.";
+				reference
+					"IEEE 802.1Q-2017 Clause 20.32, Figure 20-11";
+			}
+			leaf dest-mac-address {
+				type ieee:mac-address;
+				description
+					"The target MAC Address field to be transmitted.
+					A unicast destination MAC address. This address
+					is used if node mep-transmit-lbm-dest-is-mep-id
+					is FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+			}
+			leaf dest-mep-id {
+				type mep-id-or-zero-type;
+				description
+					"The identifier of a remote MEP in the same MA to
+					which the LBM is to be sent. This address
+					is used if node mep-transmit-lbm-dest-is-mep-id
+					is TRUE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+			}
+			leaf dest-is-mep-id {
+				type boolean;
+				description
+					"TRUE indicates that MEP ID of the target MEP is used
+					for Loopback transmissions. FALSE indicates that
+					unicast destination MAC address of the target MEP is
+					used for Loopback transmissions.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+			}
+			leaf message-count {
+				type uint32 {
+					range "1..1024";
+				}
+				default 1;
+				description
+					"The number of Loopback messages to be transmitted.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2c";
+			}
+			leaf data-tlv {
+				type string;
+				description
+					"An arbitraty amoun tof data to be included in the
+					Data TLV, if the Data TLV is selected to be sent. The
+					intent is to be able to fill the frame carrying the
+					CFM PDU to its maximum length.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
+			}
+			leaf vlan-priority {
+				type dot1q-types:priority-type;
+				description
+					"Priority. 3 bit value to be used in the VLAN tag, if
+					present in the transmitted frame. The default value
+					should be the CCM priority.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+			}
+			leaf vlan-drop-eligible {
+				type boolean;
+				default "false";
+				description
+					"Drop eligible bit value to be used in the VLAN tag,
+					if present in the transmitted frame";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+			}
+			leaf result-ok {
+				type boolean;
+				default "true";
+				config false;
+				description
+					"Indicates the result of the operation:
+					   TRUE - The LBM will be (or has been) sent.
+					   FALSE - The LBM will not be sent.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.3a";
+			}
+			leaf seq-number {
+				type uint32;
+				description
+					"The Loopback transaction identifier
+					(mep-next-lbm-trans-id) of the first LBM (to be) 
+					sent. The value returned is undefined if 
+					mep-transmit-lbm-result-ok is FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.3.3b";
+			}
+			leaf next-lbm-trans-id {
+				type uint32;
+				config false;
+				description
+					"Next sequence number identifier to be sent in a
+					Loopback message. This sequence number can be zero
+					since it can wrap around.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3x, 20.28.2";
+			}
+  	} // loopback
+  	
+  	container linktrace {
+  		description
+  			"Linktrace protocol";
+  		leaf mep {
+  			type mep-id-type;
+  			description
+					"Integer that is unique among all the MEPs in the
+					same Maintenance Association.";
+				reference
+					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+  		}
+  		leaf ma-reference {
+				type uint32;
+				description
+					"An index reference to the particular Maintenance
+					Association that this MEP belongs to.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
+			}
+  		leaf bridge-port {
+				type if:interface-ref;
+				description
+					"The interface index of the interface (i.e., Bridge 
+					Port) to which the MEP is attached.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+			}
+  		leaf status {
+				type boolean;
+				default "true";
+				description
+					"A Boolean flag set to TRUE by the Bridge Port to 
+					indicate that another LTM may be transmitted. Reset
+					to FALSE by the MEP Linktrace initiator state 
+					machine.";
+				reference
+					"IEEE 802.1Q-2017 Clause 20.49, Figure 20-17";
+			}
+  		leaf priority {
+				type dot1q-types:priority-type;
+				description
+					"The priority value for CCMs and LTMs transmitted by
+					the MEP. The default value is the highest priority 
+					allowed to pass through the Bridge Port for any of
+					the MEPs VID(s).";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+			}
+			leaf flags {
+				type mep-tx-ltm-flags-type;
+				default use-fdb-only;
+				description
+					"The flags field for the LTMs transmitted by the 
+					MEP.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2b, 20.42.1";
+				
+			}
+			leaf target-mac-address {
+				type ieee:mac-address;
+				description
+					"The target MAC address field to be transmitted. A
+					unicast MAC address. This address will be used if the
+					value of mep-transmit-ltm-target-is-mep-id is FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+			}
+			leaf target-mep-id {
+				type mep-id-or-zero-type;
+				description
+					"The target MAC address field to be transmitted. The
+					MEP identifier of another MEP in teh same MA. This
+					address will be used if the value of 
+					mep-transmit-ltm-target-is-mep-id is TRUE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+			}
+			leaf target-is-mep-id {
+				type boolean;
+				default "false";
+				description
+					"TRUE indicates taht MEP id of the target MEP is used
+					for Linktrace transmission. FALSE indicates that
+					unicast destination MAC address of the target MEP is
+					used for LinkTrace transmission.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+			}
+			leaf ttl {
+				type uint32 {
+					range "0..255";
+				}
+				default 64;
+				description
+					"The LTM TTL field. Indicates the number of hops 
+					remaining to the LTM. Decremented by 1 by each
+					Linktrace Responder that handles the LTM. The value
+					returned in the LTR is one less than that received in
+					the LTM. If the LTM TTL is 0 or 1, the LTM is not
+					forwarded to the next hop, and if 0, no LTR is 
+					generated.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.2d, 21.8.4";
+			}
+			leaf result {
+				type boolean;
+				default "true";
+				config false;
+				description
+					"Indicates the result of the operation:
+					   TRUE - The Linktrace message will be (or has been) 
+					          sent.
+					   FALSE - The Linktrace message will not be sent.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.3a";
+			}
+			leaf seq-number {
+				type uint32;
+				config false;
+				description
+					"The LTM transaction identifier 
+					(mep-ltm-next-seq-number) of the LTM sent. The value
+					returned is undefined if mep-transmit-ltm-result is 
+					FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.3b";
+			}
+			leaf egress-identifier {
+				type string {
+					length "8";
+				}
+				config false;
+				description
+					"Identifies the MEP Linktrace Initiator that is 
+					originating, or the Linktrace Responder that is
+					forwarding, this LTM.
+					
+					The low-order six octets contain a 48-bit IEEE MAC
+					address unique to the system in which the MEP 
+					Linktrace Initiator or Linktrace Responder resides.
+					The high-order two octets contain a value sufficient
+					to uniquely identify the MEP Linktrace Initiator or 
+					Linktrace Responder within that system.
+					
+					For most Bridges, the address of any MAC attached to
+					the Bridge will suffice for the low-order six octets,
+					and 0 for the high-order octets. In some situations,
+					e.g., if multiple virtual Bridges utilizing emulated
+					LANs are implemented in a single physical system, the
+					high-order two octets can be used to differentiate
+					among the transmitting entities.
+					
+					The value returned is undefined if 
+					mep-transmit-ltm-result is FALSE.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.4.3c";  					
+			}
+  		leaf next-seq-number {
+				type uint32;
+				config false;
+				description
+					"Next transaction identifier to be sent in a 
+					LinkTrace message.This sequence number can be zero
+					since it can wrap around.";
+				reference
+					"IEEE 802.1Q-2017 Clause 12.14.7.1.3ab, 20.41.1";
+			}
+  	} // linktrace
+  	
   } // cfm
   
   
@@ -2930,7 +3104,7 @@ module ieee802-dot1q-cfm {
 				path "/cfm/maintenance-domains/maintenance-domain"+
 			       "/maintenance-association"+
 			       "/maintenance-association-component/mep"+
-						 "/mep-highest-priority-defect";
+						 "/highest-priority-defect";
 			}
 			description
 				"The highest priority defect that has been present


### PR DESCRIPTION
Clean PYANG

**ieee802-dot1q-cfm.yang**

Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw cfm-stacks
       |  +--rw bridge?      bridge-ref
       |  +--rw cfm-stack* [bridge-port type-of-service-selector service-selector-or-none md-level direction]
       |     +--rw bridge-port                      if:interface-ref
       |     +--rw type-of-service-selector         service-selector-type
       |     +--rw service-selector-or-none         service-selector-value-or-none
       |     +--rw md-level                         md-level-type
       |     +--rw direction                        mp-direction-type
       |     +--ro maintenance-domain-index?        uint32
       |     +--ro maintenance-association-index?   uint32
       |     +--ro mep-id?                          mep-id-or-zero-type
       |     +--ro mac-address?                     ieee:mac-address
       +--rw default-md-levels
       |  +--rw bridge?             bridge-ref
       |  +--rw default-md-level* [component-id primary-selector-type primary-selector]
       |     +--rw component-id             component-identifier-type
       |     +--rw primary-selector-type    service-selector-type
       |     +--rw primary-selector         service-selector-value
       |     +--rw selectors*               service-selector-value
       |     +--rw md-status?               boolean
       |     +--rw md-level?                md-level-or-none-type
       |     +--rw mhf-creation?            mhf-creation-type
       |     +--rw id-permission?           sender-id-permission-type
       +--rw config-errors
       |  +--rw bridge?         bridge-ref
       |  +--rw config-error* [type-of-selector selector bridge-port]
       |     +--rw type-of-selector    service-selector-type
       |     +--rw selector            service-selector-value
       |     +--rw bridge-port         if:interface-ref
       |     +--ro error-type?         config-errors
       +--rw maintenance-domains
          +--rw bridge?               bridge-ref
          +--rw maintenance-domain* [name-format name]
             +--rw name-format                md-name-format-type
             +--rw name                       md-name-type
             +--rw md-index?                  uint32
             +--rw md-level?                  md-level-type
             +--rw mhf-creation?              mhf-creation-type
             +--rw id-permission?             sender-id-permission-type
             +--rw fault-alarm-address?       fault-alarm-adress-type
             +--rw maintenance-association* [name name-format]
                +--rw name                                 ma-name-type
                +--rw name-format                          ma-name-format-type
                +--rw ma-index?                            uint32
                +--rw md-reference?                        uint32
                +--rw ccm-interval?                        ccm-interval-type
                +--rw fault-alarm-address?                 fault-alarm-adress-type
                +--rw maintenance-association-component* [ma-component-id]
                   +--rw ma-component-id             component-identifier-type
                   +--rw primary-selector-type?      service-selector-type
                   +--rw primary-selector-or-none?   service-selector-value-or-none
                   +--rw mhf-creation?               mhf-creation-type
                   +--rw id-permission?              sender-id-permission-type
                   +--rw number-of-vids?             uint32
                   +--rw selectors*                  service-selector-value
                   +--rw mep* [mep-id]
                      +--rw mep-id                                 mep-id-type
                      +--rw ma-reference?                          uint32
                      +--rw bridge-port?                           if:interface-ref
                      +--rw mep-direction?                         mp-direction-type
                      +--rw mep-primary-vid?                       uint32
                      +--rw mep-admin-state?                       boolean
                      +--ro mep-fng-state?                         fng-state-type
                      +--rw mep-ccm-enabled?                       boolean
                      +--rw mep-ccm-ltm-priority?                  dot1q-types:priority-type
                      +--rw mep-mac-address?                       ieee:mac-address
                      +--rw fault-alarm-address?                   fault-alarm-adress-type
                      +--rw mep-lowest-priority-defect?            lowest-alarm-priority-type
                      +--rw mep-fng-alarm-time?                    yang:zero-based-counter32
                      +--rw mep-fng-reset-time?                    yang:zero-based-counter32
                      +--ro mep-highest-priority-defect?           highest-defect-priority-type
                      +--ro mep-defects?                           mep-defects-type
                      +--ro mep-error-ccm-last-failure?            string
                      +--ro mep-xcon-ccm-last-failure?             string
                      +--ro mep-next-lbm-trans-id?                 uint32
                      +--ro mep-ltm-next-seq-number?               uint32
                      +--rw active-rmeps*                          mep-id-type
                      +--rw mep-transmit-lbm-status?               boolean
                      +--rw mep-transmit-lbm-dest-mac-address?     ieee:mac-address
                      +--rw mep-transmit-lbm-dest-mep-id?          mep-id-or-zero-type
                      +--rw mep-transmit-lbm-dest-is-mep-id?       boolean
                      +--rw mep-transmit-lbm-messages?             uint32
                      +--rw mep-transmit-lbm-data-tlv?             string
                      +--rw mep-transmit-lbm-vlan-priority?        dot1q-types:priority-type
                      +--rw mep-transmit-lbm-vlan-drop-eligible?   boolean
                      +--ro mep-transmit-lbm-result-ok?            boolean
                      +--rw mep-transmit-lbm-seq-number?           uint32
                      +--ro mep-transmit-ltm-status?               boolean
                      +--rw mep-transmit-ltm-flags?                mep-tx-ltm-flags-type
                      +--rw mep-transmit-ltm-target-mac-address?   ieee:mac-address
                      +--rw mep-transmit-ltm-target-mep-id?        mep-id-or-zero-type
                      +--rw mep-transmit-ltm-target-is-mep-id?     boolean
                      +--rw mep-transmit-ltm-ttl?                  uint32
                      +--ro mep-transmit-ltm-result?               boolean
                      +--ro mep-transmit-ltm-seq-number?           uint32
                      +--ro mep-transmit-ltm-egress-identifier?    string
                      +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
                      |  +--rw ltr-seq-number                   uint32
                      |  +--rw ltr-receive-order                uint32
                      |  +--ro ltr-ttl?                         uint32
                      |  +--ro ltr-forwarded?                   boolean
                      |  +--ro ltr-terminal-mep?                boolean
                      |  +--ro ltr-last-egress-identifier?      string
                      |  +--ro ltr-next-egress-identifier?      string
                      |  +--ro ltr-relay?                       relay-action-field-value
                      |  +--ro ltr-chassis-id-subtype?          lldp-chassis-id-subtype
                      |  +--ro ltr-chassis-id?                  lldp-chassis-id
                      |  +--ro ltr-man-address-domain?          transport-service-domain
                      |  +--ro ltr-man-address?                 transport-service-address
                      |  +--ro ltr-ingress?                     ingress-action-field-value
                      |  +--ro ltr-ingress-mac?                 ieee:mac-address
                      |  +--ro ltr-ingress-port-id-subtype?     lldp-port-id-subtype
                      |  +--ro ltr-egress?                      egress-action-field-value
                      |  +--ro ltr-egress-mac?                  ieee:mac-address
                      |  +--ro ltr-egress-port-id-subtype?      lldp-port-id-subtype
                      |  +--ro ltr-egress-port-id?              lldp-port-id
                      |  +--ro ltr-organization-specific-tlv?   string
                      +--rw mep-db* [rmep-id]
                      |  +--rw rmep-id                        mep-id-type
                      |  +--ro rmep-state?                    remote-mep-state-type
                      |  +--ro rmep-failed-ok-time?           yang:zero-based-counter32
                      |  +--ro mep-db-mac-address?            ieee:mac-address
                      |  +--ro mep-db-rdi?                    boolean
                      |  +--ro mep-db-port-status-tlv?        port-status-tlv-value
                      |  +--ro mep-db-interface-status-tlv?   interface-status-tlv-value
                      |  +--ro mep-db-chassis-id-subtype?     lldp-chassis-id-subtype
                      |  +--ro mep-db-chassis-id?             lldp-chassis-id
                      |  +--ro mep-db-man-address-domain?     transport-service-domain
                      |  +--ro mep-db-man-address?            transport-service-address
                      |  +--rw mep-db-rmep-is-active?         boolean
                      +--ro stats
                         +--ro mep-ccm-sequence-errors?   yang:counter64
                         +--ro mep-sent-ccms?             yang:counter64
                         +--ro mep-lbr-in?                yang:counter64
                         +--ro mep-lbr-in-out-of-order?   yang:counter64
                         +--ro mep-lbr-bad-msdu?          yang:counter64
                         +--ro mep-unexpected-ltr-in?     yang:counter64
                         +--ro mep-lbr-out?               yang:counter64

  rpcs:
    +---x transmit-loopback-message
    |  +---w input
    |  |  +---w md-index?                              uint32
    |  |  +---w ma-index?                              uint32
    |  |  +---w mep-id?                                mep-id-type
    |  |  +---w mep-transmit-lbm-dest-mac-address?     ieee:mac-address
    |  |  +---w mep-transmit-lbm-dest-mep-id?          mep-id-or-zero-type
    |  |  +---w mep-transmit-lbm-dest-is-mep-id?       boolean
    |  |  +---w mep-transmit-lbm-messages?             uint32
    |  |  +---w mep-transmit-lbm-data-tlv?             string
    |  |  +---w mep-transmit-lbm-vlan-priority?        dot1q-types:priority-type
    |  |  +---w mep-transmit-lbm-vlan-drop-eligible?   boolean
    |  +--ro output
    |     +--ro mep-transmit-lbm-result-ok?    boolean
    |     +--ro mep-transmit-lbm-seq-number?   uint32
    +---x transmit-linktrace-message
       +---w input
       |  +---w md-index?                              uint32
       |  +---w ma-index?                              uint32
       |  +---w mep-id?                                mep-id-type
       |  +---w mep-transmit-ltm-flags?                mep-tx-ltm-flags-type
       |  +---w mep-transmit-ltm-target-mac-address?   ieee:mac-address
       |  +---w mep-transmit-ltm-target-mep-id?        mep-id-or-zero-type
       |  +---w mep-transmit-ltm-target-is-mep-id?     boolean
       |  +---w mep-transmit-ltm-ttl?                  uint32
       +--ro output
          +--ro mep-transmit-ltm-result?              boolean
          +--ro mep-transmit-ltm-seq-number?          uint32
          +--ro mep-transmit-ltm-egress-identifier?   string

  notifications:
    +---n mep-fault-alarm
       +--ro md-name?               -> /cfm/maintenance-domains/maintenance-domain/name
       +--ro md-name-format?        -> /cfm/maintenance-domains/maintenance-domain/name-format
       +--ro ma-name?               -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name
       +--ro ma-name-format?        -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name-format
       +--ro mep-id?                -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/maintenance-association-component/mep/mep-id
       +--ro mep-priority-defect?   -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/maintenance-association-component/mep/mep-highest-priority-defect
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors