### PR TITLE
Refine structure of the module

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -6,8 +6,8 @@ module ieee802-dot1q-cfm {
   import ieee802-types { prefix "ieee"; }
   import ietf-yang-types { prefix "yang"; }
   import ietf-interfaces { prefix "if"; }
-  //import ieee802-dot1q-bridge { prefix "dot1q"; }
   import ieee802-dot1q-types { prefix "dot1q-types"; }
+  //import ieee802-dot1q-bridge { prefix "dot1q"; }
 
   organization
     "Institute of Electrical and Electronics Engineers";
@@ -373,7 +373,7 @@ module ieee802-dot1q-cfm {
   
   typedef md-name-type {
   	type string {
-  		length "1..43";
+  		length "0..43";
   	}
   	description
   		"The Maintenance Domain name type";
@@ -427,6 +427,12 @@ module ieee802-dot1q-cfm {
   	}
   	description
   		"The Maintenance Association name type";
+  }
+  
+  typedef maintenance-group-type {
+  	type string;
+  	description
+  		"The Maintenance Group type";
   }
   
   typedef mhf-creation-type {
@@ -1269,12 +1275,19 @@ module ieee802-dot1q-cfm {
       		reference
       			"IEEE 802.1Q-2017 Clause 12.14.2.1.2c";  		
       	}
+      	leaf maintenance-group {
+      		type maintenance-group-type;
+      		config false;
+      		description
+      			"The maintenance group to which the Maintenance Points
+      			is associated with.";
+      	}
       	leaf maintenance-domain-index {
       		type uint32;
       		config false;
       		description
       			"The Maintenance Domain reference to which the Maintenance
-      			Points Maintenance Assocaition is associated. If none,
+      			Points Maintenance Association is associated. If none,
       			then 0.";
       		reference
       			"IEEE 802.1Q-2017 Clause 12.14.2.1.3b";
@@ -1440,16 +1453,10 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
 			}
-  		leaf primary-selector-type {
+  		leaf selector-type {
   			type service-selector-type;
   			description
-  				"Type of the Primary Service Selector identifier.";
-  		}
-  		leaf primary-selector {
-  			type service-selector-value;
-  			description
-  				"Primary Service Selector identifier of a Service Instance
-  				with no MA configured.";
+  				"Type of the Service Selector identifier.";
   		}
   		leaf-list selectors {
     		type service-selector-value;
@@ -1464,8 +1471,8 @@ module ieee802-dot1q-cfm {
     			"IEEE 802.1Q-2017 Clause 12.14.3.1.3a";
     	}
   		leaf md-level {
-  			type md-level-or-none-type;
-  			default -1;
+  			type md-level-type;
+  			default 0;
   			description
   				"A value indicating the MD Level at which MHFs are to be
   				created, and Sender ID TLV transmission by those MHFs is to
@@ -1699,7 +1706,13 @@ module ieee802-dot1q-cfm {
     					reference
     						"IEEE 802.1Q-2017 Clause 12.3l";
     				}
-    				leaf primary-selector-type {
+    				leaf maintenance-group {
+          		type maintenance-group-type;
+          		description
+          			"The maintenance group provides an identifier
+          			for the MD and MA combination.";
+          	}
+    				leaf service-selector-type {
     					type service-selector-type;
     					description
     						"Type of the Service Selector identifiers. In Services
@@ -1708,35 +1721,6 @@ module ieee802-dot1q-cfm {
     						selector identifiers is the same.";
     					reference
     						"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
-    				}
-    				leaf primary-selector-or-none {
-    					type service-selector-value-or-none;
-    	    		description
-    	    			"Service Selector identifier to which the MP is 
-    	    			attached, or 0, if none.";
-    	    		reference
-    	    			"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
-    				}
-    				leaf mhf-creation {
-        			type mhf-creation-type;
-        			default mhf-defer;
-        			description
-        				"Value indicating whether the management entity can
-        				create MHFs (MIP Half Function) for this Maintenance
-        				Domain. Since there is no encompassing Maintenance
-        				Domain, the vlaue mhf-defer is not allowed.";
-        			reference
-        				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
-        		}
-    				leaf id-permission {
-    					type sender-id-permission-type;
-    	  			default "send-id-defer";
-    	  			description
-    	  				"Enumerated value indicating what, if anything, is to
-    	  				be included in the Sender ID TLV (21.5.3) transmitted
-    	  				by MPs configured in this MA.";
-    	  			reference
-    	  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3d";
     				}
     				leaf number-of-vids {
     					type uint32;
@@ -1758,654 +1742,686 @@ module ieee802-dot1q-cfm {
       	  		reference
       	  			"IEEE 802.1Q-2017 Clause 12.14.5.3.2c, 12.14.6.1.3b";
       	  	}
-    				
-    				list mep {
-      				key "mep-id";
-      				description 
-      					"A list of Maintenance association End Points (MEPs). A
-      					MEP is an actively managed CFM entity, associated with
-      					a specific DoSAP of a service instance, which can
-      					generate and receive CFM PDUs and track any responses.
-      					It is an end point of a single Maintenance Association
-      					(MA) and is an end point of a separate Maintenance
-      					Entity for each of the other MEPs in the same MA.";
-      				leaf mep-id {
-      					type mep-id-type;
-      					description
-      						"Integer that is unique among all the MEPs in the
-      						same Maintenance Association.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
-      				}
-      				leaf ma-reference {
-      					type uint32;
-      					description
-      						"An index reference to the particular Maintenance
-      						Association that this MEP belongs to.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
-      				}
-      				leaf bridge-port {
-      					type if:interface-ref;
-      					description
-      						"The interface index of the interface (i.e., Bridge 
-      						Port) to which the MEP is attached.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
-      				}
-      				leaf direction {
-      					type mp-direction-type;
-      					description
-      						"The direction in which the MEP faces on the Bridge
-      						Port. Example, up or down.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
-      				}
-      				leaf primary-vid {
-      					type uint32 {
-      						range "0..16777215";
-      					}
-      					default 0;
-      					description
-      						"An integer indicating the Primary VID of the MEP. It
-      						is always one of the VIDs assigned to the MEPs MA. A
-      						value of 0 indicates that either the Primary VID is
-      						that of the MEPs MA, or that the MEPs MA is 
-      						associated with no VID.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
-      				}
-      				leaf admin-state {
-      					type boolean;
-      					default "false";
-      					description
-      						"The administrative state of the MEP. TRUE indicates
-      						that the MEP is to functional normally, and FALSE
-      						indicates that it is to cease functioning.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
-      				}
-      				leaf fng-state {
-      					type fng-state-type;
-      					default "fng-reset";
-      					config false;
-      					description
-      						"The current state of the MEP Fault Notification 
-      						Generator state machine.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
-      				}
-      				leaf ccm-enabled {
-      					type boolean;
-      					default "false";
-      					description
-      						"Indicates whether the MEP can generate CCMs. If 
-      						TRUE, the MEP will generate CCM PDUs.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
-      				}
-      				leaf ccm-ltm-priority {
-      					type dot1q-types:priority-type;
-      					description
-      						"The priority value for CCMs and LTMs transmitted by
-      						the MEP. The default value is the highest priority 
-      						allowed to pass through the Bridge Port for any of
-      						the MEPs VID(s).";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
-      				}
-      				leaf mac-address {
-      					type ieee:mac-address;
-      					description
-      						"The MAC address of the MEP.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
-      				}
-      				leaf fault-alarm-address {
-          			type fault-alarm-adress-type;
-          			default "not-specified";
-          			description
-          				"A value indicating whether Fault Alarms are to be 
-          				transmitted or not. The default is not specified, 
-          				which implies that the disposition of the fault-alarm
-          				used by the MD should be used.";
-          			reference
-          				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
-          		}
-      				leaf lowest-priority-defect {
-      					type lowest-alarm-priority-type;
-      					default "mac-remote-error-xcon";
-      					description
-      						"The lowest priority defect that is allowed to
-      						generate fault alarms.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
-      				}
-      				leaf fng-alarm-time {
-      					type yang:zero-based-counter32 {
-      						range "250..1000";
-      					}
-      					units deciseconds;
-      					default 250;
-      					description
-        					"The time that defect must be present before a Fault
-        					Alarm is issued.";
-        				reference
-        					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
-      				}
-      				leaf fng-reset-time {
-        				type yang:zero-based-counter32 {
-        					range "250..1000";  					
-        				}
-        				units deciseconds;
-        				default 1000;
-        				description
-        					"The time that defects must be absent before 
-        					resetting a Fault Alarm.";
-        				reference
-        					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
-        			}
-      				leaf highest-priority-defect {
-      					type highest-defect-priority-type;
-      					config false;
-      					description
-      						"The highest priority defect that has been present
-      						sicne the MEPs Fault Notification Generator state
-      						machine was last in the FNG_RESET state.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
-      				}
-      				leaf defects {
-      					type mep-defects-type;
-      					config false;
-      					description
-      						"Vector of boolean error conditions";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
-      						20.23.3, 20.35.5, 20.35.6, 20.35.7";
-      				}
-      				leaf error-ccm-last-failure {
-      					type string {
-      						length "1..1522";
-      					}
-      					config false;
-      					description
-      						"The last received CCM that triggered a def-error-ccm
-      						fault.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
-      				}
-      				leaf xcon-ccm-last-failure {
-      					type string {
-      						length "1..1522";
-      					}
-      					config false;
-      					description
-      						"The last received CCM that triggered a def-xcon-ccm
-      						fault.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
-      				}
-      				leaf-list active-rmeps {
-      					type mep-id-type;
-      					description
-      						"A list indicating which of the remote MEPs in the
-      						same MA are active. By default, all configured
-      						remote MEPs in the same MA are active.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
-      				}
-      				
-      				list linktrace-reply {
-      					key "ltr-seq-number ltr-receive-order";
-      					description
-      						"This table extends the MEP table and contains a list
-      						of Linktrace replies received by a specific MEP in
-      						response to a linktrace message.";
-      					leaf ltr-seq-number {
-      						type uint32 {
-      							range "0..4294967295";
-      						}
-      						description
-      							"Transaction identifier returned by a previous
-      							transmit linktrace message command, indicating
-      							which LTMs response is going to be returned.";
-      						reference
-        						"IEEE 802.1Q-2017 Clause 12.14.7.5.2b";
-      					}
-      					leaf ltr-receive-order {
-      						type uint32 {
-      							range "1..4294967295";
-      						}
-      						description
-      							"An index to distinguish among multiple LTRs with
-      							the same LTR Transaction Identifier field value. 
-      							Assigned sequentially from 1, in the order that the 
-      							Linktrace Initiator received the LTRs.";
-      					}
-      					leaf ltr-ttl {
-      						type uint32 {
-      							range "0..255";
-      						}
-      						config false;
-      						description
-      							"TTL field value for a returned LTR.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5, 20.41.2.2";
-      					}
-      					leaf ltr-forwarded {
-      						type boolean;
-      						config false;
-      						description
-      							"Indicates if a LTM was forwarded by the responding
-      							MP, as returned in the FwdYes flag of the flags 
-      							field.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3c, 20.41.2.1";
-      					}  					
-      					leaf ltr-terminal-mep {
-      						type boolean;
-      						config false;
-      						description
-      							"A Boolean value stating whether the forwarded LTM
-      							reached a MEP enclosing its MA, as returned in the
-      							Terminal MEP flag of the Flags field";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3d, 20.41.2.1";
-      					}
-      					leaf ltr-last-egress-identifier {
-      						type string {
-      							length "8";
-      						}
-      						config false;
-      						description
-      							"An octet field holding the Last Egress Identifier
-      							returned in the LTR Egress Identifier TLV of the
-      							LTR. The Last Egress Identifier identifies the MEP
-      							Linktrace Initiator that originated, or the 
-      							Linktrace Responder that forwarded, the LTM to
-      							which this LTR is the response. This is the same
-      							value as the Egress Identifier TLV of that LTM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3e, 20.41.2.3";
-      					}  					
-      					leaf ltr-next-egress-identifier {
-      						type string {
-      							length "8";
-      						}
-      						config false;
-      						description
-      							"An octet field holding the Next Egress Identifier
-      							returned in the LTR Egress Identifier TLV of the 
-      							LTR. The Next Egress Identifier Identifies the
-      							Linktrace Responder that transmitted this LTR, and
-      							can forward the LTM to the next hop. This is the
-      							same value as the Egress Identifier TLV of the
-      							forwarded LTM, if any. If the FwdYes bit of the
-      							Flags field is false, the contents of this field
-      							are undefined, i.e., any value can be transmitted,
-      							and the field is ignored by the receiver.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3f, 20.41.2.4";
-      					}  					
-      					leaf ltr-relay {
-      						type relay-action-field-value;
-      						config false;
-      						description
-      							"Value returned in teh Relay Action field.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
-      					}  					
-      					leaf ltr-chassis-id-subtype {
-      						type lldp-chassis-id-subtype;
-      						config false;
-      						description
-      							"Specifies the format of the Chassis ID returned
-      							in the Sender ID TLV of the LTR, if any. This value
-      							is meaningless if the ltr-chassis-id has a length
-      							of 0.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3h, 21.5.3.2";
-      					}  					
-      					leaf ltr-chassis-id {
-      						type lldp-chassis-id;
-      						config false;
-      						description
-      							"The Chassis ID returned in the Sender ID TLV of 
-      							the LTR, if any. The format of this object is
-      							determined by the value of the 
-      							ltr-chassis-id-subtype object.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3i, 21.5.3.2";
-      					}  					
-      					leaf ltr-man-address-domain {
-      						type transport-service-domain;
-      						config false;
-      						description
-      							"The transport-service-domain that identifies the
-      							type and format of the related mep-db-man-address
-      							object, used to access the YANG agent of the system
-      							transmitting the LTR. Received in the LTR Sender ID
-      							TLV from that system.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.5,
-      							21.9.6";
-      					}  					
-      					leaf ltr-man-address {
-      						type transport-service-address;
-      						config false;
-      						description
-      							"The transport-service-address that can be used to
-      							access the YANG	agent of the system transmitting
-      							the CCM, received in the CCM Sender ID TLV from
-      							that system.
-      							
-      							If the related object ltr-man-address-domain
-      							contains the value zeroDotZero, this object
-      							ltr-man-address MUST have a zero-length OCTET 
-      							STRING as a value.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.7,
-      							21.9.6";
-      					}  					
-      					leaf ltr-ingress {
-      						type ingress-action-field-value;
-      						config false;
-      						description
-      							"The value returned in the Ingress Action Field of
-      							the LTM. The value ingress-no-tlv indicates that no
-      							Reply Ingress TLV was returned in the LTM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3k, 20.41.2.6";
-      					}  					
-      					leaf ltr-ingress-mac {
-      						type ieee:mac-address;
-      						config false;
-      						description
-      							"MAC address returned in the ingress MAC address
-      							field. If the ltr-ingress object contains the value 
-      							ingress-no-tlv, then the contents of this object
-      							are meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3l, 20.41.2.7";
-      					}  					
-      					leaf ltr-ingress-port-id-subtype {
-      						type lldp-port-id-subtype;
-      						config false;
-      						description
-      							"Ingress Port ID. The format of this object is 
-      							determined by the value of the 
-      							ltr-ingress-port-id-subtype object. If the
-      							ltr-ingress object contains the value 
-      							ingress-no-tlv, then the contents of this object
-      							are meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3n, 20.41.2.9";
-      					}  					
-      					leaf ltr-egress {
-      						type egress-action-field-value;
-      						config false;
-      						description
-      							"The value returned in the Egress Action Field of
-      							the LTM. The value egress-no-tlv indicates that 
-      							no Reply Egress TLV was returned in the LTM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3o, 20.41.2.10";
-      					}  					
-      					leaf ltr-egress-mac {
-      						type ieee:mac-address;
-      						config false;
-      						description
-      							"MAC address returned in the egress MAC address
-      							field. If the ltr-egress object contains the value
-      							egress-no-tlv, then the contents of this object are
-      							meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3p, 20.41.2.11";
-      					}  					
-      					leaf ltr-egress-port-id-subtype {
-      						type lldp-port-id-subtype;
-      						config false;
-      						description
-      							"Format of the egress Port ID. If the ltr-egress
-      							object contains the value egress-no-tlv, then the
-      							contents of this object are meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3q, 20.41.2.12";
-      					}  					
-      					leaf ltr-egress-port-id {
-      						type lldp-port-id;
-      						config false;
-      						description
-      							"Egress Port ID. The format of this object is
-      							determined by the value of the
-      							ltr-egress-port-id-subtype object. If the 
-      							ltr-egress object contains the value egress-no-tlv,
-      							then the contents of this object are meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3r, 20.41.2.13";
-      					}  					
-      					leaf ltr-organization-specific-tlv {
-      						type string {
-      							length "0 | 4..1500";
-      						}
-      						config false;
-      						description
-      							"All Organization specific TLVs returned in the 
-      							LTR, if any. Includes all octets including and
-      							following the TLV Length field of each TLV, 
-      							concatenated together.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3s, 21.5.2";
-      					}
-      				} // linktrace-reply
-      				
-      				list mep-db {
-      					key rmep-id;
-      					description
-      						"";
-      					leaf rmep-id {
-      						type mep-id-type;
-      						description
-      							"Maintenance association Endpoint Identifier of a
-      							remote MEP whose information from the MEP Database
-      							is to be returned.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.2b";  						
-      					}
-      					leaf rmep-state {
-      						type remote-mep-state-type;
-      						config false;
-      						description 
-      							"The operational state of the remote MEP  state
-      							machine";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3b, 20.20";
-      					}
-      					leaf rmep-failed-ok-time {
-      						type yang:zero-based-counter32;
-      						units seconds;
-      						config false;
-      						description
-      							"The time (SysUpTime) at which the Remote MEP state
-      							machine last entered either the RMEP_FAILED or
-      							RMEP_OK state";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
-      					}
-      					leaf mep-db-mac-address {
-      						type ieee:mac-address;
-      						config false;
-      						description
-      							"The MAC address of the remote MEP.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
-      					}
-      					leaf mep-db-rdi {
-      						type boolean;
-      						config false;
-      						description
-      							"State of the RDI bit in the last received CCM
-      							(true for RDI=1), or false if none has been 
-      							received.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
-      					}
-      					leaf mep-db-port-status-tlv {
-      						type port-status-tlv-value;
-      						default "no-port-state-tlv";
-      						config false;
-      						description
-      							"An enumerated value of the Port status TLV 
-      							received in the last CCM from the remote MEP or 
-      							the default value no-port-state-tlv indicating
-      							either no CCM has been received, or that no port
-      							status TLV was received in the last CCM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
-      					}
-      					leaf mep-db-interface-status-tlv {
-      						type interface-status-tlv-value;
-      						default "is-no-interface-status-tlv";
-      						config false;
-      						description
-      							"An enumerated value of the Interface status TLV
-      							received in the last CCM from the remote MEP or the
-      							default value is-no-interface-status-tlv indicating
-      							either no CCM has been received, or that no 
-      							interface status TLV was received in the last 
-      							CCM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
-      					}
-      					leaf mep-db-chassis-id-subtype {
-      						type lldp-chassis-id-subtype;
-      						config false;
-      						description
-      							"This object specifies the format of the Chassis ID
-      							received in the last CCM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
-      					}
-      					leaf mep-db-chassis-id {
-      						type lldp-chassis-id;
-      						config false;
-      						description
-      							"The Chassis ID. The format of this object is
-      							determined by the value of the 
-      							ltr-chassis-id-subtype object.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
-      					}
-      					leaf mep-db-man-address-domain {
-      						type transport-service-domain;
-      						config false;
-      						description
-      							"The transport-service-domain that identifies the
-      							type and format of the related mep-db-man-address
-      							object, used to access the YANG agent of the system
-      							transmitting the CCM. Received in the CCM Sender ID
-      							TLV from that system.
-      							
-      							The value zeroDotZero (from RFC2578) indicates no
-      							management address was present in the LTR, in which
-      							case the related mep-db-man-address object MUST
-      							have a zero-length OCTET STRING as a value.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
-      							21.6.7";
-      					}
-      					leaf mep-db-man-address {
-      						type transport-service-address;
-      						config false;
-      						description
-      							"The transport-service-address that can be used to 
-      							access the YANG agent of the system transmitting
-      							the CCM, received in the CCM Sender ID TLV from
-      							that system. If the related 
-      							mep-db-man-address-domain object contains the 
-      							value zeroDotZero, this object mep-db-man-address
-      							MUST have a zero-length OCTET STRING as a value.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
-      							21.6.7";
-      					}
-      					leaf mep-db-rmep-is-active {
-      						type boolean;
-      						description
-      							"A Boolean value statign if the remote MEP is 
-      							active.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
-      					}
-      				} // mep-db
-      				
-      				container stats {
-      					config false;
-      					description
-      						"Contains the counters associated with the MEP.";
-      					leaf mep-ccm-sequence-errors {
-      						type yang:counter64;
-      						description
-      							"The total number of out-of-sequence CCMs received
-      							from all remote MEPs.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
-      					}
-      					leaf mep-sent-ccms {
-      						type yang:counter64;
-      						description
-      							"Total number of CCMs transmitted";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3w, 20.10.2";
-      					}
-      					leaf mep-lbr-in {
-      						type yang:counter64;
-      						description
-      							"Total number of valid, in-order Loopback Replies
-      							received.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3y, 20.31.1";
-      					}
-      					leaf mep-lbr-in-out-of-order {
-      						type yang:counter64;
-      						description
-      							"The total number of valid, out-of-order
-      							Loopback Replies received";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3z, 20.31.1";
-      					}
-      					leaf mep-lbr-bad-msdu {
-      						type yang:counter64;
-      						description
-      							"The total number of LBRs receivd whose
-      							mac_service_data_unit did not match (except for the
-      							OpCode) that of the corresponding LBM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3aa, 20.2.3";
-      					}
-      					leaf mep-unexpected-ltr-in {
-      						type yang:counter64;
-      						description
-      							"The total number of unexpected LTRs received.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ac, 20.44.1";
-      					}
-      					leaf mep-lbr-out {
-      						type yang:counter64;
-      						description
-      							"Total number of Loopback Replies transmitted.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ad, 20.28.2";
-      					}
-      				} // stats
-      			} // mep
+    				leaf mhf-creation {
+        			type mhf-creation-type;
+        			default mhf-defer;
+        			description
+        				"Value indicating whether the management entity can
+        				create MHFs (MIP Half Function) for this Maintenance
+        				Domain. Since there is no encompassing Maintenance
+        				Domain, the vlaue mhf-defer is not allowed.";
+        			reference
+        				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
+        		}
+    				leaf id-permission {
+    					type sender-id-permission-type;
+    	  			default "send-id-defer";
+    	  			description
+    	  				"Enumerated value indicating what, if anything, is to
+    	  				be included in the Sender ID TLV (21.5.3) transmitted
+    	  				by MPs configured in this MA.";
+    	  			reference
+    	  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3d";
+    				}
     			} // maintenance-association-component
     		} // maintenance-association
   		} // maintenance-domain
   	} // maintenance-domains
   	
-  	container connectivity-check-message {
+  	container meps {
+  		description
+  			"Contains the Maintenance Association EndPoint configuration
+  			and operational data, as well as related objects.";
+  		list mep {
+  			key "mep-id maintenance-group";
+  			description 
+  				"A list of Maintenance association End Points (MEPs). A
+  				MEP is an actively managed CFM entity, associated with
+  				a specific DoSAP of a service instance, which can
+  				generate and receive CFM PDUs and track any responses.
+  				It is an end point of a single Maintenance Association
+  				(MA) and is an end point of a separate Maintenance
+  				Entity for each of the other MEPs in the same MA.";
+  			leaf mep-id {
+  				type mep-id-type;
+  				description
+  					"Integer that is unique among all the MEPs in the
+  					same Maintenance Association.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+  			}
+  			leaf maintenance-group {
+      		type maintenance-group-type;
+      		description
+      			"The maintenance group provides an identifier
+      			for the MD and MA combination.";
+      	}
+  			leaf ma-reference-index {
+  				type uint32;
+  				description
+  					"An index reference to the particular Maintenance
+  					Association that this MEP belongs to.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
+  			}
+  			leaf bridge-port {
+  				type if:interface-ref;
+  				description
+  					"The interface index of the interface (i.e., Bridge 
+  					Port) to which the MEP is attached.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+  			}
+  			leaf direction {
+  				type mp-direction-type;
+  				description
+  					"The direction in which the MEP faces on the Bridge
+  					Port. Example, up or down.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
+  			}
+  			leaf primary-vid {
+  				type uint32 {
+  					range "0..16777215";
+  				}
+  				default 0;
+  				description
+  					"An integer indicating the Primary VID of the MEP. It
+  					is always one of the VIDs assigned to the MEPs MA. A
+  					value of 0 indicates that either the Primary VID is
+  					that of the MEPs MA, or that the MEPs MA is 
+  					associated with no VID.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
+  			}
+  			leaf admin-state {
+  				type boolean;
+  				default "false";
+  				description
+  					"The administrative state of the MEP. TRUE indicates
+  					that the MEP is to functional normally, and FALSE
+  					indicates that it is to cease functioning.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
+  			}
+  			leaf fng-state {
+  				type fng-state-type;
+  				default "fng-reset";
+  				config false;
+  				description
+  					"The current state of the MEP Fault Notification 
+  					Generator state machine.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
+  			}
+  			leaf ccm-enabled {
+  				type boolean;
+  				default "false";
+  				description
+  					"Indicates whether the MEP can generate CCMs. If 
+  					TRUE, the MEP will generate CCM PDUs.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
+  			}
+  			leaf ccm-ltm-priority {
+  				type dot1q-types:priority-type;
+  				description
+  					"The priority value for CCMs and LTMs transmitted by
+  					the MEP. The default value is the highest priority 
+  					allowed to pass through the Bridge Port for any of
+  					the MEPs VID(s).";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+  			}
+  			leaf mac-address {
+  				type ieee:mac-address;
+  				description
+  					"The MAC address of the MEP.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
+  			}
+  			leaf fault-alarm-address {
+    			type fault-alarm-adress-type;
+    			default "not-specified";
+    			description
+    				"A value indicating whether Fault Alarms are to be 
+    				transmitted or not. The default is not specified, 
+    				which implies that the disposition of the fault-alarm
+    				used by the MD should be used.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
+    		}
+  			leaf lowest-priority-defect {
+  				type lowest-alarm-priority-type;
+  				default "mac-remote-error-xcon";
+  				description
+  					"The lowest priority defect that is allowed to
+  					generate fault alarms.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
+  			}
+  			leaf fng-alarm-time {
+  				type yang:zero-based-counter32 {
+  					range "250..1000";
+  				}
+  				units deciseconds;
+  				default 250;
+  				description
+  					"The time that defect must be present before a Fault
+  					Alarm is issued.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
+  			}
+  			leaf fng-reset-time {
+  				type yang:zero-based-counter32 {
+  					range "250..1000";  					
+  				}
+  				units deciseconds;
+  				default 1000;
+  				description
+  					"The time that defects must be absent before 
+  					resetting a Fault Alarm.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
+  			}
+  			leaf highest-priority-defect {
+  				type highest-defect-priority-type;
+  				config false;
+  				description
+  					"The highest priority defect that has been present
+  					sicne the MEPs Fault Notification Generator state
+  					machine was last in the FNG_RESET state.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
+  			}
+  			leaf defects {
+  				type mep-defects-type;
+  				config false;
+  				description
+  					"Vector of boolean error conditions";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
+  					20.23.3, 20.35.5, 20.35.6, 20.35.7";
+  			}
+  			leaf error-ccm-last-failure {
+  				type string {
+  					length "1..1522";
+  				}
+  				config false;
+  				description
+  					"The last received CCM that triggered a def-error-ccm
+  					fault.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
+  			}
+  			leaf xcon-ccm-last-failure {
+  				type string {
+  					length "1..1522";
+  				}
+  				config false;
+  				description
+  					"The last received CCM that triggered a def-xcon-ccm
+  					fault.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
+  			}
+  			leaf-list active-rmeps {
+  				type mep-id-type;
+  				description
+  					"A list indicating which of the remote MEPs in the
+  					same MA are active. By default, all configured
+  					remote MEPs in the same MA are active.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+  			}
+  			
+  			list linktrace-reply {
+  				key "ltr-seq-number ltr-receive-order";
+  				description
+  					"This table extends the MEP table and contains a list
+  					of Linktrace replies received by a specific MEP in
+  					response to a linktrace message.";
+  				leaf ltr-seq-number {
+  					type uint32 {
+  						range "0..4294967295";
+  					}
+  					description
+  						"Transaction identifier returned by a previous
+  						transmit linktrace message command, indicating
+  						which LTMs response is going to be returned.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.2b";
+  				}
+  				leaf ltr-receive-order {
+  					type uint32 {
+  						range "1..4294967295";
+  					}
+  					description
+  						"An index to distinguish among multiple LTRs with
+  						the same LTR Transaction Identifier field value. 
+  						Assigned sequentially from 1, in the order that the 
+  						Linktrace Initiator received the LTRs.";
+  				}
+  				leaf ltr-ttl {
+  					type uint32 {
+  						range "0..255";
+  					}
+  					config false;
+  					description
+  						"TTL field value for a returned LTR.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5, 20.41.2.2";
+  				}
+  				leaf ltr-forwarded {
+  					type boolean;
+  					config false;
+  					description
+  						"Indicates if a LTM was forwarded by the responding
+  						MP, as returned in the FwdYes flag of the flags 
+  						field.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3c, 20.41.2.1";
+  				}  					
+  				leaf ltr-terminal-mep {
+  					type boolean;
+  					config false;
+  					description
+  						"A Boolean value stating whether the forwarded LTM
+  						reached a MEP enclosing its MA, as returned in the
+  						Terminal MEP flag of the Flags field";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3d, 20.41.2.1";
+  				}
+  				leaf ltr-last-egress-identifier {
+  					type string {
+  						length "8";
+  					}
+  					config false;
+  					description
+  						"An octet field holding the Last Egress Identifier
+  						returned in the LTR Egress Identifier TLV of the
+  						LTR. The Last Egress Identifier identifies the MEP
+  						Linktrace Initiator that originated, or the 
+  						Linktrace Responder that forwarded, the LTM to
+  						which this LTR is the response. This is the same
+  						value as the Egress Identifier TLV of that LTM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3e, 20.41.2.3";
+  				}  					
+  				leaf ltr-next-egress-identifier {
+  					type string {
+  						length "8";
+  					}
+  					config false;
+  					description
+  						"An octet field holding the Next Egress Identifier
+  						returned in the LTR Egress Identifier TLV of the 
+  						LTR. The Next Egress Identifier Identifies the
+  						Linktrace Responder that transmitted this LTR, and
+  						can forward the LTM to the next hop. This is the
+  						same value as the Egress Identifier TLV of the
+  						forwarded LTM, if any. If the FwdYes bit of the
+  						Flags field is false, the contents of this field
+  						are undefined, i.e., any value can be transmitted,
+  						and the field is ignored by the receiver.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3f, 20.41.2.4";
+  				}  					
+  				leaf ltr-relay {
+  					type relay-action-field-value;
+  					config false;
+  					description
+  						"Value returned in teh Relay Action field.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
+  				}  					
+  				leaf ltr-chassis-id-subtype {
+  					type lldp-chassis-id-subtype;
+  					config false;
+  					description
+  						"Specifies the format of the Chassis ID returned
+  						in the Sender ID TLV of the LTR, if any. This value
+  						is meaningless if the ltr-chassis-id has a length
+  						of 0.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3h, 21.5.3.2";
+  				}  					
+  				leaf ltr-chassis-id {
+  					type lldp-chassis-id;
+  					config false;
+  					description
+  						"The Chassis ID returned in the Sender ID TLV of 
+  						the LTR, if any. The format of this object is
+  						determined by the value of the 
+  						ltr-chassis-id-subtype object.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3i, 21.5.3.2";
+  				}  					
+  				leaf ltr-man-address-domain {
+  					type transport-service-domain;
+  					config false;
+  					description
+  						"The transport-service-domain that identifies the
+  						type and format of the related mep-db-man-address
+  						object, used to access the YANG agent of the system
+  						transmitting the LTR. Received in the LTR Sender ID
+  						TLV from that system.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.5,
+  						21.9.6";
+  				}  					
+  				leaf ltr-man-address {
+  					type transport-service-address;
+  					config false;
+  					description
+  						"The transport-service-address that can be used to
+  						access the YANG	agent of the system transmitting
+  						the CCM, received in the CCM Sender ID TLV from
+  						that system.
+  						
+  						If the related object ltr-man-address-domain
+  						contains the value zeroDotZero, this object
+  						ltr-man-address MUST have a zero-length OCTET 
+  						STRING as a value.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.7,
+  						21.9.6";
+  				}  					
+  				leaf ltr-ingress {
+  					type ingress-action-field-value;
+  					config false;
+  					description
+  						"The value returned in the Ingress Action Field of
+  						the LTM. The value ingress-no-tlv indicates that no
+  						Reply Ingress TLV was returned in the LTM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3k, 20.41.2.6";
+  				}  					
+  				leaf ltr-ingress-mac {
+  					type ieee:mac-address;
+  					config false;
+  					description
+  						"MAC address returned in the ingress MAC address
+  						field. If the ltr-ingress object contains the value 
+  						ingress-no-tlv, then the contents of this object
+  						are meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3l, 20.41.2.7";
+  				}  					
+  				leaf ltr-ingress-port-id-subtype {
+  					type lldp-port-id-subtype;
+  					config false;
+  					description
+  						"Ingress Port ID. The format of this object is 
+  						determined by the value of the 
+  						ltr-ingress-port-id-subtype object. If the
+  						ltr-ingress object contains the value 
+  						ingress-no-tlv, then the contents of this object
+  						are meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3n, 20.41.2.9";
+  				}  					
+  				leaf ltr-egress {
+  					type egress-action-field-value;
+  					config false;
+  					description
+  						"The value returned in the Egress Action Field of
+  						the LTM. The value egress-no-tlv indicates that 
+  						no Reply Egress TLV was returned in the LTM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3o, 20.41.2.10";
+  				}  					
+  				leaf ltr-egress-mac {
+  					type ieee:mac-address;
+  					config false;
+  					description
+  						"MAC address returned in the egress MAC address
+  						field. If the ltr-egress object contains the value
+  						egress-no-tlv, then the contents of this object are
+  						meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3p, 20.41.2.11";
+  				}  					
+  				leaf ltr-egress-port-id-subtype {
+  					type lldp-port-id-subtype;
+  					config false;
+  					description
+  						"Format of the egress Port ID. If the ltr-egress
+  						object contains the value egress-no-tlv, then the
+  						contents of this object are meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3q, 20.41.2.12";
+  				}  					
+  				leaf ltr-egress-port-id {
+  					type lldp-port-id;
+  					config false;
+  					description
+  						"Egress Port ID. The format of this object is
+  						determined by the value of the
+  						ltr-egress-port-id-subtype object. If the 
+  						ltr-egress object contains the value egress-no-tlv,
+  						then the contents of this object are meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3r, 20.41.2.13";
+  				}  					
+  				leaf ltr-organization-specific-tlv {
+  					type string {
+  						length "0 | 4..1500";
+  					}
+  					config false;
+  					description
+  						"All Organization specific TLVs returned in the 
+  						LTR, if any. Includes all octets including and
+  						following the TLV Length field of each TLV, 
+  						concatenated together.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3s, 21.5.2";
+  				}
+  			} // linktrace-reply
+  			
+  			list mep-db {
+  				key rmep-id;
+  				description
+  					"The MEP CCM Database.";
+  				leaf rmep-id {
+  					type mep-id-type;
+  					description
+  						"Maintenance association Endpoint Identifier of a
+  						remote MEP whose information from the MEP Database
+  						is to be returned.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.2b";  						
+  				}
+  				leaf rmep-state {
+  					type remote-mep-state-type;
+  					config false;
+  					description 
+  						"The operational state of the remote MEP  state
+  						machine";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3b, 20.20";
+  				}
+  				leaf rmep-failed-ok-time {
+  					type yang:zero-based-counter32;
+  					units seconds;
+  					config false;
+  					description
+  						"The time (SysUpTime) at which the Remote MEP state
+  						machine last entered either the RMEP_FAILED or
+  						RMEP_OK state";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
+  				}
+  				leaf mep-db-mac-address {
+  					type ieee:mac-address;
+  					config false;
+  					description
+  						"The MAC address of the remote MEP.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
+  				}
+  				leaf mep-db-rdi {
+  					type boolean;
+  					config false;
+  					description
+  						"State of the RDI bit in the last received CCM
+  						(true for RDI=1), or false if none has been 
+  						received.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
+  				}
+  				leaf mep-db-port-status-tlv {
+  					type port-status-tlv-value;
+  					default "no-port-state-tlv";
+  					config false;
+  					description
+  						"An enumerated value of the Port status TLV 
+  						received in the last CCM from the remote MEP or 
+  						the default value no-port-state-tlv indicating
+  						either no CCM has been received, or that no port
+  						status TLV was received in the last CCM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
+  				}
+  				leaf mep-db-interface-status-tlv {
+  					type interface-status-tlv-value;
+  					default "is-no-interface-status-tlv";
+  					config false;
+  					description
+  						"An enumerated value of the Interface status TLV
+  						received in the last CCM from the remote MEP or the
+  						default value is-no-interface-status-tlv indicating
+  						either no CCM has been received, or that no 
+  						interface status TLV was received in the last 
+  						CCM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
+  				}
+  				leaf mep-db-chassis-id-subtype {
+  					type lldp-chassis-id-subtype;
+  					config false;
+  					description
+  						"This object specifies the format of the Chassis ID
+  						received in the last CCM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
+  				}
+  				leaf mep-db-chassis-id {
+  					type lldp-chassis-id;
+  					config false;
+  					description
+  						"The Chassis ID. The format of this object is
+  						determined by the value of the 
+  						ltr-chassis-id-subtype object.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
+  				}
+  				leaf mep-db-man-address-domain {
+  					type transport-service-domain;
+  					config false;
+  					description
+  						"The transport-service-domain that identifies the
+  						type and format of the related mep-db-man-address
+  						object, used to access the YANG agent of the system
+  						transmitting the CCM. Received in the CCM Sender ID
+  						TLV from that system.
+  						
+  						The value zeroDotZero (from RFC2578) indicates no
+  						management address was present in the LTR, in which
+  						case the related mep-db-man-address object MUST
+  						have a zero-length OCTET STRING as a value.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
+  						21.6.7";
+  				}
+  				leaf mep-db-man-address {
+  					type transport-service-address;
+  					config false;
+  					description
+  						"The transport-service-address that can be used to 
+  						access the YANG agent of the system transmitting
+  						the CCM, received in the CCM Sender ID TLV from
+  						that system. If the related 
+  						mep-db-man-address-domain object contains the 
+  						value zeroDotZero, this object mep-db-man-address
+  						MUST have a zero-length OCTET STRING as a value.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
+  						21.6.7";
+  				}
+  				leaf mep-db-rmep-is-active {
+  					type boolean;
+  					description
+  						"A Boolean value statign if the remote MEP is 
+  						active.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+  				}
+  			} // mep-db
+  			
+  			container stats {
+  				config false;
+  				description
+  					"Contains the counters associated with the MEP.";
+  				leaf mep-ccm-sequence-errors {
+  					type yang:counter64;
+  					description
+  						"The total number of out-of-sequence CCMs received
+  						from all remote MEPs.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
+  				}
+  				leaf mep-sent-ccms {
+  					type yang:counter64;
+  					description
+  						"Total number of CCMs transmitted";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3w, 20.10.2";
+  				}
+  				leaf mep-lbr-in {
+  					type yang:counter64;
+  					description
+  						"Total number of valid, in-order Loopback Replies
+  						received.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3y, 20.31.1";
+  				}
+  				leaf mep-lbr-in-out-of-order {
+  					type yang:counter64;
+  					description
+  						"The total number of valid, out-of-order
+  						Loopback Replies received";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3z, 20.31.1";
+  				}
+  				leaf mep-lbr-bad-msdu {
+  					type yang:counter64;
+  					description
+  						"The total number of LBRs receivd whose
+  						mac_service_data_unit did not match (except for the
+  						OpCode) that of the corresponding LBM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3aa, 20.2.3";
+  				}
+  				leaf mep-unexpected-ltr-in {
+  					type yang:counter64;
+  					description
+  						"The total number of unexpected LTRs received.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ac, 20.44.1";
+  				}
+  				leaf mep-lbr-out {
+  					type yang:counter64;
+  					description
+  						"Total number of Loopback Replies transmitted.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ad, 20.28.2";
+  				}
+  			} // stats
+  		} // mep
+  	} // meps
+  	
+  	container continuity-check {
   		description
   			"Continuity check protocol";
   		leaf mep {
@@ -2459,7 +2475,7 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.6.1.3e";
 			}
-  	} // connectivity-check
+  	} // continuity-check
   	
   	container loopback {
   		description
@@ -2522,6 +2538,7 @@ module ieee802-dot1q-cfm {
 			}
 			leaf dest-is-mep-id {
 				type boolean;
+				default "false";
 				description
 					"TRUE indicates that MEP ID of the target MEP is used
 					for Loopback transmissions. FALSE indicates that
@@ -2550,7 +2567,7 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
 			}
-			leaf vlan-priority {
+			leaf priority {
 				type dot1q-types:priority-type;
 				description
 					"Priority. 3 bit value to be used in the VLAN tag, if
@@ -2781,20 +2798,12 @@ module ieee802-dot1q-cfm {
   	description
   		"To signal to the MEP to transmit some number of LBMs.";
   	input {
-  		leaf md-index {
-  			type uint32;
-  			description
-  				"The index to the Maintenance Domain list.";
-  			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
-  		}
-  		leaf ma-index {
-  			type uint32;
-  			description
-  				"The index to the Maintenance Association list.";
-  			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
-  		}
+  		leaf maintenance-group {
+    		type maintenance-group-type;
+    		description
+    			"The maintenance group to which the Maintenance Points
+    			is associated with.";
+    	}
   		leaf mep-id {
   			type mep-id-type;
 				description
@@ -2901,20 +2910,12 @@ module ieee802-dot1q-cfm {
 			"To signal to the MEP to transmit an LTM and to create an LTM
 			entry in the MEPs Linktrace Database.";
 		input {
-			leaf md-index {
-  			type uint32;
-  			description
-  				"The index to the Maintenance Domain list.";
-  			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
-  		}
-  		leaf ma-index {
-  			type uint32;
-  			description
-  				"The index to the Maintenance Association list.";
-  			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
-  		}
+			leaf maintenance-group {
+    		type maintenance-group-type;
+    		description
+    			"The maintenance group to which the Maintenance Points
+    			is associated with.";
+    	}
   		leaf mep-id {
   			type mep-id-type;
 				description
@@ -3042,6 +3043,12 @@ module ieee802-dot1q-cfm {
 		description
 			"To alert the Manager to the existence of a fault in a monitored
 			MA by issuing a Fault Alarm.";
+		leaf maintenance-group {
+  		type maintenance-group-type;
+  		description
+  			"The maintenance group to which the Maintenance Points
+  			is associated with.";
+  	}
 		leaf md-name {
 			type leafref {
 				path "/cfm/maintenance-domains/maintenance-domain/name";
@@ -3089,9 +3096,7 @@ module ieee802-dot1q-cfm {
 		}
 		leaf mep-id {
 			type leafref {
-				path "/cfm/maintenance-domains/maintenance-domain"+
-			       "/maintenance-association"+
-						 "/maintenance-association-component/mep/mep-id";
+				path "/cfm/meps/mep/mep-id";
 			}
 			description
 				"Integer that is unique among all the MEPs in the same
@@ -3101,10 +3106,7 @@ module ieee802-dot1q-cfm {
 		}
 		leaf mep-priority-defect {
 			type leafref {
-				path "/cfm/maintenance-domains/maintenance-domain"+
-			       "/maintenance-association"+
-			       "/maintenance-association-component/mep"+
-						 "/highest-priority-defect";
+				path "/cfm/meps/mep/highest-priority-defect";
 			}
 			description
 				"The highest priority defect that has been present


### PR DESCRIPTION
Clean PYANG compile and YANG Validator

**ieee802-dot1q-cfm.yang**

Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw cfm-stacks
       |  +--rw bridge?      bridge-ref
       |  +--rw cfm-stack* [bridge-port type-of-service-selector service-selector-or-none md-level direction]
       |     +--rw bridge-port                      if:interface-ref
       |     +--rw type-of-service-selector         service-selector-type
       |     +--rw service-selector-or-none         service-selector-value-or-none
       |     +--rw md-level                         md-level-type
       |     +--rw direction                        mp-direction-type
       |     +--ro maintenance-group?               maintenance-group-type
       |     +--ro maintenance-domain-index?        uint32
       |     +--ro maintenance-association-index?   uint32
       |     +--ro mep-id?                          mep-id-or-zero-type
       |     +--ro mac-address?                     ieee:mac-address
       +--rw default-md-levels
       |  +--rw bridge?             bridge-ref
       |  +--rw default-md-level* [component-id primary-selector-type primary-selector]
       |     +--rw component-id             component-identifier-type
       |     +--rw primary-selector-type    service-selector-type
       |     +--rw primary-selector         service-selector-value
       |     +--rw selectors*               service-selector-value
       |     +--rw md-status?               boolean
       |     +--rw md-level?                md-level-or-none-type
       |     +--rw mhf-creation?            mhf-creation-type
       |     +--rw id-permission?           sender-id-permission-type
       +--rw mip
       |  +--rw bridge-port?     if:interface-ref
       |  +--rw selector-type?   service-selector-type
       |  +--rw selectors*       service-selector-value
       |  +--rw md-level?        md-level-type
       +--rw config-errors
       |  +--rw bridge?         bridge-ref
       |  +--rw config-error* [type-of-selector selector bridge-port]
       |     +--rw type-of-selector    service-selector-type
       |     +--rw selector            service-selector-value
       |     +--rw bridge-port         if:interface-ref
       |     +--ro error-type?         config-errors
       +--rw maintenance-domains
       |  +--rw bridge?               bridge-ref
       |  +--rw maintenance-domain* [name-format name]
       |     +--rw name-format                md-name-format-type
       |     +--rw name                       md-name-type
       |     +--rw md-index?                  uint32
       |     +--rw md-level?                  md-level-type
       |     +--rw mhf-creation?              mhf-creation-type
       |     +--rw id-permission?             sender-id-permission-type
       |     +--rw fault-alarm-address?       fault-alarm-adress-type
       |     +--rw maintenance-association* [name name-format]
       |        +--rw name                                 ma-name-type
       |        +--rw name-format                          ma-name-format-type
       |        +--rw ma-index?                            uint32
       |        +--rw md-reference?                        uint32
       |        +--rw ccm-interval?                        ccm-interval-type
       |        +--rw fault-alarm-address?                 fault-alarm-adress-type
       |        +--rw maintenance-association-component* [ma-component-id]
       |           +--rw ma-component-id          component-identifier-type
       |           +--rw maintenance-group?       maintenance-group-type
       |           +--rw service-selector-type?   service-selector-type
       |           +--rw number-of-vids?          uint32
       |           +--rw selectors*               service-selector-value
       |           +--rw mhf-creation?            mhf-creation-type
       |           +--rw id-permission?           sender-id-permission-type
       +--rw meps
       |  +--rw mep* [mep-id maintenance-group]
       |     +--rw mep-id                     mep-id-type
       |     +--rw maintenance-group          maintenance-group-type
       |     +--rw ma-reference-index?        uint32
       |     +--rw bridge-port?               if:interface-ref
       |     +--rw direction?                 mp-direction-type
       |     +--rw primary-vid?               uint32
       |     +--rw admin-state?               boolean
       |     +--ro fng-state?                 fng-state-type
       |     +--rw ccm-enabled?               boolean
       |     +--rw ccm-ltm-priority?          dot1q-types:priority-type
       |     +--rw mac-address?               ieee:mac-address
       |     +--rw fault-alarm-address?       fault-alarm-adress-type
       |     +--rw lowest-priority-defect?    lowest-alarm-priority-type
       |     +--rw fng-alarm-time?            yang:zero-based-counter32
       |     +--rw fng-reset-time?            yang:zero-based-counter32
       |     +--ro highest-priority-defect?   highest-defect-priority-type
       |     +--ro defects?                   mep-defects-type
       |     +--ro error-ccm-last-failure?    string
       |     +--ro xcon-ccm-last-failure?     string
       |     +--rw active-rmeps*              mep-id-type
       |     +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
       |     |  +--rw ltr-seq-number                   uint32
       |     |  +--rw ltr-receive-order                uint32
       |     |  +--ro ltr-ttl?                         uint32
       |     |  +--ro ltr-forwarded?                   boolean
       |     |  +--ro ltr-terminal-mep?                boolean
       |     |  +--ro ltr-last-egress-identifier?      string
       |     |  +--ro ltr-next-egress-identifier?      string
       |     |  +--ro ltr-relay?                       relay-action-field-value
       |     |  +--ro ltr-chassis-id-subtype?          lldp-chassis-id-subtype
       |     |  +--ro ltr-chassis-id?                  lldp-chassis-id
       |     |  +--ro ltr-man-address-domain?          transport-service-domain
       |     |  +--ro ltr-man-address?                 transport-service-address
       |     |  +--ro ltr-ingress?                     ingress-action-field-value
       |     |  +--ro ltr-ingress-mac?                 ieee:mac-address
       |     |  +--ro ltr-ingress-port-id-subtype?     lldp-port-id-subtype
       |     |  +--ro ltr-egress?                      egress-action-field-value
       |     |  +--ro ltr-egress-mac?                  ieee:mac-address
       |     |  +--ro ltr-egress-port-id-subtype?      lldp-port-id-subtype
       |     |  +--ro ltr-egress-port-id?              lldp-port-id
       |     |  +--ro ltr-organization-specific-tlv?   string
       |     +--rw mep-db* [rmep-id]
       |     |  +--rw rmep-id                        mep-id-type
       |     |  +--ro rmep-state?                    remote-mep-state-type
       |     |  +--ro rmep-failed-ok-time?           yang:zero-based-counter32
       |     |  +--ro mep-db-mac-address?            ieee:mac-address
       |     |  +--ro mep-db-rdi?                    boolean
       |     |  +--ro mep-db-port-status-tlv?        port-status-tlv-value
       |     |  +--ro mep-db-interface-status-tlv?   interface-status-tlv-value
       |     |  +--ro mep-db-chassis-id-subtype?     lldp-chassis-id-subtype
       |     |  +--ro mep-db-chassis-id?             lldp-chassis-id
       |     |  +--ro mep-db-man-address-domain?     transport-service-domain
       |     |  +--ro mep-db-man-address?            transport-service-address
       |     |  +--rw mep-db-rmep-is-active?         boolean
       |     +--ro stats
       |        +--ro mep-ccm-sequence-errors?   yang:counter64
       |        +--ro mep-sent-ccms?             yang:counter64
       |        +--ro mep-lbr-in?                yang:counter64
       |        +--ro mep-lbr-in-out-of-order?   yang:counter64
       |        +--ro mep-lbr-bad-msdu?          yang:counter64
       |        +--ro mep-unexpected-ltr-in?     yang:counter64
       |        +--ro mep-lbr-out?               yang:counter64
       +--rw continuity-check
       |  +--rw mep?            mep-id-type
       |  +--rw ma-reference?   uint32
       |  +--rw bridge-port?    if:interface-ref
       |  +--rw ccm-enabled?    boolean
       |  +--rw priority?       dot1q-types:priority-type
       |  +--rw ccm-interval?   ccm-interval-type
       +--rw loopback
       |  +--rw mep?                  mep-id-type
       |  +--rw ma-reference?         uint32
       |  +--rw bridge-port?          if:interface-ref
       |  +--rw status?               boolean
       |  +--rw dest-mac-address?     ieee:mac-address
       |  +--rw dest-mep-id?          mep-id-or-zero-type
       |  +--rw dest-is-mep-id?       boolean
       |  +--rw message-count?        uint32
       |  +--rw data-tlv?             string
       |  +--rw priority?             dot1q-types:priority-type
       |  +--rw vlan-drop-eligible?   boolean
       |  +--ro result-ok?            boolean
       |  +--rw seq-number?           uint32
       |  +--ro next-lbm-trans-id?    uint32
       +--rw linktrace
          +--rw mep?                  mep-id-type
          +--rw ma-reference?         uint32
          +--rw bridge-port?          if:interface-ref
          +--rw status?               boolean
          +--rw priority?             dot1q-types:priority-type
          +--rw flags?                mep-tx-ltm-flags-type
          +--rw target-mac-address?   ieee:mac-address
          +--rw target-mep-id?        mep-id-or-zero-type
          +--rw target-is-mep-id?     boolean
          +--rw ttl?                  uint32
          +--ro result?               boolean
          +--ro seq-number?           uint32
          +--ro egress-identifier?    string
          +--ro next-seq-number?      uint32

  rpcs:
    +---x transmit-loopback-message
    |  +---w input
    |  |  +---w maintenance-group?                     maintenance-group-type
    |  |  +---w mep-id?                                mep-id-type
    |  |  +---w mep-transmit-lbm-dest-mac-address?     ieee:mac-address
    |  |  +---w mep-transmit-lbm-dest-mep-id?          mep-id-or-zero-type
    |  |  +---w mep-transmit-lbm-dest-is-mep-id?       boolean
    |  |  +---w mep-transmit-lbm-messages?             uint32
    |  |  +---w mep-transmit-lbm-data-tlv?             string
    |  |  +---w mep-transmit-lbm-vlan-priority?        dot1q-types:priority-type
    |  |  +---w mep-transmit-lbm-vlan-drop-eligible?   boolean
    |  +--ro output
    |     +--ro mep-transmit-lbm-result-ok?    boolean
    |     +--ro mep-transmit-lbm-seq-number?   uint32
    +---x transmit-linktrace-message
       +---w input
       |  +---w maintenance-group?                     maintenance-group-type
       |  +---w mep-id?                                mep-id-type
       |  +---w mep-transmit-ltm-flags?                mep-tx-ltm-flags-type
       |  +---w mep-transmit-ltm-target-mac-address?   ieee:mac-address
       |  +---w mep-transmit-ltm-target-mep-id?        mep-id-or-zero-type
       |  +---w mep-transmit-ltm-target-is-mep-id?     boolean
       |  +---w mep-transmit-ltm-ttl?                  uint32
       +--ro output
          +--ro mep-transmit-ltm-result?              boolean
          +--ro mep-transmit-ltm-seq-number?          uint32
          +--ro mep-transmit-ltm-egress-identifier?   string

  notifications:
    +---n mep-fault-alarm
       +--ro maintenance-group?     maintenance-group-type
       +--ro md-name?               -> /cfm/maintenance-domains/maintenance-domain/name
       +--ro md-name-format?        -> /cfm/maintenance-domains/maintenance-domain/name-format
       +--ro ma-name?               -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name
       +--ro ma-name-format?        -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name-format
       +--ro mep-id?                -> /cfm/meps/mep/mep-id
       +--ro mep-priority-defect?   -> /cfm/meps/mep/highest-priority-defect

Confdc Output
No warnings or errors

yanglint Validation
No warnings or errors