### PR TITLE
Rebased branch to latest.

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -6,8 +6,8 @@ module ieee802-dot1q-cfm {
   import ieee802-types { prefix "ieee"; }
   import ietf-yang-types { prefix "yang"; }
   import ietf-interfaces { prefix "if"; }
-  //import ieee802-dot1q-bridge { prefix "dot1q"; }
   import ieee802-dot1q-types { prefix "dot1q-types"; }
+  //import ieee802-dot1q-bridge { prefix "dot1q"; }
 
   organization
     "Institute of Electrical and Electronics Engineers";
@@ -373,7 +373,7 @@ module ieee802-dot1q-cfm {
   
   typedef md-name-type {
   	type string {
-  		length "1..43";
+  		length "0..43";
   	}
   	description
   		"The Maintenance Domain name type";
@@ -427,6 +427,12 @@ module ieee802-dot1q-cfm {
   	}
   	description
   		"The Maintenance Association name type";
+  }
+  
+  typedef maintenance-group-type {
+  	type string;
+  	description
+  		"The Maintenance Group type";
   }
   
   typedef mhf-creation-type {
@@ -1269,12 +1275,19 @@ module ieee802-dot1q-cfm {
       		reference
       			"IEEE 802.1Q-2017 Clause 12.14.2.1.2c";  		
       	}
+      	leaf maintenance-group {
+      		type maintenance-group-type;
+      		config false;
+      		description
+      			"The maintenance group to which the Maintenance Points
+      			is associated with.";
+      	}
       	leaf maintenance-domain-index {
       		type uint32;
       		config false;
       		description
       			"The Maintenance Domain reference to which the Maintenance
-      			Points Maintenance Assocaition is associated. If none,
+      			Points Maintenance Association is associated. If none,
       			then 0.";
       		reference
       			"IEEE 802.1Q-2017 Clause 12.14.2.1.3b";
@@ -1440,16 +1453,10 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
 			}
-  		leaf primary-selector-type {
+  		leaf selector-type {
   			type service-selector-type;
   			description
-  				"Type of the Primary Service Selector identifier.";
-  		}
-  		leaf primary-selector {
-  			type service-selector-value;
-  			description
-  				"Primary Service Selector identifier of a Service Instance
-  				with no MA configured.";
+  				"Type of the Service Selector identifier.";
   		}
   		leaf-list selectors {
     		type service-selector-value;
@@ -1464,8 +1471,8 @@ module ieee802-dot1q-cfm {
     			"IEEE 802.1Q-2017 Clause 12.14.3.1.3a";
     	}
   		leaf md-level {
-  			type md-level-or-none-type;
-  			default -1;
+  			type md-level-type;
+  			default 0;
   			description
   				"A value indicating the MD Level at which MHFs are to be
   				created, and Sender ID TLV transmission by those MHFs is to
@@ -1699,7 +1706,13 @@ module ieee802-dot1q-cfm {
     					reference
     						"IEEE 802.1Q-2017 Clause 12.3l";
     				}
-    				leaf primary-selector-type {
+    				leaf maintenance-group {
+          		type maintenance-group-type;
+          		description
+          			"The maintenance group provides an identifier
+          			for the MD and MA combination.";
+          	}
+    				leaf service-selector-type {
     					type service-selector-type;
     					description
     						"Type of the Service Selector identifiers. In Services
@@ -1708,35 +1721,6 @@ module ieee802-dot1q-cfm {
     						selector identifiers is the same.";
     					reference
     						"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
-    				}
-    				leaf primary-selector-or-none {
-    					type service-selector-value-or-none;
-    	    		description
-    	    			"Service Selector identifier to which the MP is 
-    	    			attached, or 0, if none.";
-    	    		reference
-    	    			"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
-    				}
-    				leaf mhf-creation {
-        			type mhf-creation-type;
-        			default mhf-defer;
-        			description
-        				"Value indicating whether the management entity can
-        				create MHFs (MIP Half Function) for this Maintenance
-        				Domain. Since there is no encompassing Maintenance
-        				Domain, the vlaue mhf-defer is not allowed.";
-        			reference
-        				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
-        		}
-    				leaf id-permission {
-    					type sender-id-permission-type;
-    	  			default "send-id-defer";
-    	  			description
-    	  				"Enumerated value indicating what, if anything, is to
-    	  				be included in the Sender ID TLV (21.5.3) transmitted
-    	  				by MPs configured in this MA.";
-    	  			reference
-    	  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3d";
     				}
     				leaf number-of-vids {
     					type uint32;
@@ -1758,654 +1742,686 @@ module ieee802-dot1q-cfm {
       	  		reference
       	  			"IEEE 802.1Q-2017 Clause 12.14.5.3.2c, 12.14.6.1.3b";
       	  	}
-    				
-    				list mep {
-      				key "mep-id";
-      				description 
-      					"A list of Maintenance association End Points (MEPs). A
-      					MEP is an actively managed CFM entity, associated with
-      					a specific DoSAP of a service instance, which can
-      					generate and receive CFM PDUs and track any responses.
-      					It is an end point of a single Maintenance Association
-      					(MA) and is an end point of a separate Maintenance
-      					Entity for each of the other MEPs in the same MA.";
-      				leaf mep-id {
-      					type mep-id-type;
-      					description
-      						"Integer that is unique among all the MEPs in the
-      						same Maintenance Association.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
-      				}
-      				leaf ma-reference {
-      					type uint32;
-      					description
-      						"An index reference to the particular Maintenance
-      						Association that this MEP belongs to.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
-      				}
-      				leaf bridge-port {
-      					type if:interface-ref;
-      					description
-      						"The interface index of the interface (i.e., Bridge 
-      						Port) to which the MEP is attached.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
-      				}
-      				leaf direction {
-      					type mp-direction-type;
-      					description
-      						"The direction in which the MEP faces on the Bridge
-      						Port. Example, up or down.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
-      				}
-      				leaf primary-vid {
-      					type uint32 {
-      						range "0..16777215";
-      					}
-      					default 0;
-      					description
-      						"An integer indicating the Primary VID of the MEP. It
-      						is always one of the VIDs assigned to the MEPs MA. A
-      						value of 0 indicates that either the Primary VID is
-      						that of the MEPs MA, or that the MEPs MA is 
-      						associated with no VID.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
-      				}
-      				leaf admin-state {
-      					type boolean;
-      					default "false";
-      					description
-      						"The administrative state of the MEP. TRUE indicates
-      						that the MEP is to functional normally, and FALSE
-      						indicates that it is to cease functioning.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
-      				}
-      				leaf fng-state {
-      					type fng-state-type;
-      					default "fng-reset";
-      					config false;
-      					description
-      						"The current state of the MEP Fault Notification 
-      						Generator state machine.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
-      				}
-      				leaf ccm-enabled {
-      					type boolean;
-      					default "false";
-      					description
-      						"Indicates whether the MEP can generate CCMs. If 
-      						TRUE, the MEP will generate CCM PDUs.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
-      				}
-      				leaf ccm-ltm-priority {
-      					type dot1q-types:priority-type;
-      					description
-      						"The priority value for CCMs and LTMs transmitted by
-      						the MEP. The default value is the highest priority 
-      						allowed to pass through the Bridge Port for any of
-      						the MEPs VID(s).";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
-      				}
-      				leaf mac-address {
-      					type ieee:mac-address;
-      					description
-      						"The MAC address of the MEP.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
-      				}
-      				leaf fault-alarm-address {
-          			type fault-alarm-adress-type;
-          			default "not-specified";
-          			description
-          				"A value indicating whether Fault Alarms are to be 
-          				transmitted or not. The default is not specified, 
-          				which implies that the disposition of the fault-alarm
-          				used by the MD should be used.";
-          			reference
-          				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
-          		}
-      				leaf lowest-priority-defect {
-      					type lowest-alarm-priority-type;
-      					default "mac-remote-error-xcon";
-      					description
-      						"The lowest priority defect that is allowed to
-      						generate fault alarms.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
-      				}
-      				leaf fng-alarm-time {
-      					type yang:zero-based-counter32 {
-      						range "250..1000";
-      					}
-      					units deciseconds;
-      					default 250;
-      					description
-        					"The time that defect must be present before a Fault
-        					Alarm is issued.";
-        				reference
-        					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
-      				}
-      				leaf fng-reset-time {
-        				type yang:zero-based-counter32 {
-        					range "250..1000";  					
-        				}
-        				units deciseconds;
-        				default 1000;
-        				description
-        					"The time that defects must be absent before 
-        					resetting a Fault Alarm.";
-        				reference
-        					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
-        			}
-      				leaf highest-priority-defect {
-      					type highest-defect-priority-type;
-      					config false;
-      					description
-      						"The highest priority defect that has been present
-      						sicne the MEPs Fault Notification Generator state
-      						machine was last in the FNG_RESET state.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
-      				}
-      				leaf defects {
-      					type mep-defects-type;
-      					config false;
-      					description
-      						"Vector of boolean error conditions";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
-      						20.23.3, 20.35.5, 20.35.6, 20.35.7";
-      				}
-      				leaf error-ccm-last-failure {
-      					type string {
-      						length "1..1522";
-      					}
-      					config false;
-      					description
-      						"The last received CCM that triggered a def-error-ccm
-      						fault.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
-      				}
-      				leaf xcon-ccm-last-failure {
-      					type string {
-      						length "1..1522";
-      					}
-      					config false;
-      					description
-      						"The last received CCM that triggered a def-xcon-ccm
-      						fault.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
-      				}
-      				leaf-list active-rmeps {
-      					type mep-id-type;
-      					description
-      						"A list indicating which of the remote MEPs in the
-      						same MA are active. By default, all configured
-      						remote MEPs in the same MA are active.";
-      					reference
-      						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
-      				}
-      				
-      				list linktrace-reply {
-      					key "ltr-seq-number ltr-receive-order";
-      					description
-      						"This table extends the MEP table and contains a list
-      						of Linktrace replies received by a specific MEP in
-      						response to a linktrace message.";
-      					leaf ltr-seq-number {
-      						type uint32 {
-      							range "0..4294967295";
-      						}
-      						description
-      							"Transaction identifier returned by a previous
-      							transmit linktrace message command, indicating
-      							which LTMs response is going to be returned.";
-      						reference
-        						"IEEE 802.1Q-2017 Clause 12.14.7.5.2b";
-      					}
-      					leaf ltr-receive-order {
-      						type uint32 {
-      							range "1..4294967295";
-      						}
-      						description
-      							"An index to distinguish among multiple LTRs with
-      							the same LTR Transaction Identifier field value. 
-      							Assigned sequentially from 1, in the order that the 
-      							Linktrace Initiator received the LTRs.";
-      					}
-      					leaf ltr-ttl {
-      						type uint32 {
-      							range "0..255";
-      						}
-      						config false;
-      						description
-      							"TTL field value for a returned LTR.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5, 20.41.2.2";
-      					}
-      					leaf ltr-forwarded {
-      						type boolean;
-      						config false;
-      						description
-      							"Indicates if a LTM was forwarded by the responding
-      							MP, as returned in the FwdYes flag of the flags 
-      							field.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3c, 20.41.2.1";
-      					}  					
-      					leaf ltr-terminal-mep {
-      						type boolean;
-      						config false;
-      						description
-      							"A Boolean value stating whether the forwarded LTM
-      							reached a MEP enclosing its MA, as returned in the
-      							Terminal MEP flag of the Flags field";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3d, 20.41.2.1";
-      					}
-      					leaf ltr-last-egress-identifier {
-      						type string {
-      							length "8";
-      						}
-      						config false;
-      						description
-      							"An octet field holding the Last Egress Identifier
-      							returned in the LTR Egress Identifier TLV of the
-      							LTR. The Last Egress Identifier identifies the MEP
-      							Linktrace Initiator that originated, or the 
-      							Linktrace Responder that forwarded, the LTM to
-      							which this LTR is the response. This is the same
-      							value as the Egress Identifier TLV of that LTM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3e, 20.41.2.3";
-      					}  					
-      					leaf ltr-next-egress-identifier {
-      						type string {
-      							length "8";
-      						}
-      						config false;
-      						description
-      							"An octet field holding the Next Egress Identifier
-      							returned in the LTR Egress Identifier TLV of the 
-      							LTR. The Next Egress Identifier Identifies the
-      							Linktrace Responder that transmitted this LTR, and
-      							can forward the LTM to the next hop. This is the
-      							same value as the Egress Identifier TLV of the
-      							forwarded LTM, if any. If the FwdYes bit of the
-      							Flags field is false, the contents of this field
-      							are undefined, i.e., any value can be transmitted,
-      							and the field is ignored by the receiver.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3f, 20.41.2.4";
-      					}  					
-      					leaf ltr-relay {
-      						type relay-action-field-value;
-      						config false;
-      						description
-      							"Value returned in teh Relay Action field.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
-      					}  					
-      					leaf ltr-chassis-id-subtype {
-      						type lldp-chassis-id-subtype;
-      						config false;
-      						description
-      							"Specifies the format of the Chassis ID returned
-      							in the Sender ID TLV of the LTR, if any. This value
-      							is meaningless if the ltr-chassis-id has a length
-      							of 0.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3h, 21.5.3.2";
-      					}  					
-      					leaf ltr-chassis-id {
-      						type lldp-chassis-id;
-      						config false;
-      						description
-      							"The Chassis ID returned in the Sender ID TLV of 
-      							the LTR, if any. The format of this object is
-      							determined by the value of the 
-      							ltr-chassis-id-subtype object.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3i, 21.5.3.2";
-      					}  					
-      					leaf ltr-man-address-domain {
-      						type transport-service-domain;
-      						config false;
-      						description
-      							"The transport-service-domain that identifies the
-      							type and format of the related mep-db-man-address
-      							object, used to access the YANG agent of the system
-      							transmitting the LTR. Received in the LTR Sender ID
-      							TLV from that system.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.5,
-      							21.9.6";
-      					}  					
-      					leaf ltr-man-address {
-      						type transport-service-address;
-      						config false;
-      						description
-      							"The transport-service-address that can be used to
-      							access the YANG	agent of the system transmitting
-      							the CCM, received in the CCM Sender ID TLV from
-      							that system.
-      							
-      							If the related object ltr-man-address-domain
-      							contains the value zeroDotZero, this object
-      							ltr-man-address MUST have a zero-length OCTET 
-      							STRING as a value.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.7,
-      							21.9.6";
-      					}  					
-      					leaf ltr-ingress {
-      						type ingress-action-field-value;
-      						config false;
-      						description
-      							"The value returned in the Ingress Action Field of
-      							the LTM. The value ingress-no-tlv indicates that no
-      							Reply Ingress TLV was returned in the LTM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3k, 20.41.2.6";
-      					}  					
-      					leaf ltr-ingress-mac {
-      						type ieee:mac-address;
-      						config false;
-      						description
-      							"MAC address returned in the ingress MAC address
-      							field. If the ltr-ingress object contains the value 
-      							ingress-no-tlv, then the contents of this object
-      							are meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3l, 20.41.2.7";
-      					}  					
-      					leaf ltr-ingress-port-id-subtype {
-      						type lldp-port-id-subtype;
-      						config false;
-      						description
-      							"Ingress Port ID. The format of this object is 
-      							determined by the value of the 
-      							ltr-ingress-port-id-subtype object. If the
-      							ltr-ingress object contains the value 
-      							ingress-no-tlv, then the contents of this object
-      							are meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3n, 20.41.2.9";
-      					}  					
-      					leaf ltr-egress {
-      						type egress-action-field-value;
-      						config false;
-      						description
-      							"The value returned in the Egress Action Field of
-      							the LTM. The value egress-no-tlv indicates that 
-      							no Reply Egress TLV was returned in the LTM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3o, 20.41.2.10";
-      					}  					
-      					leaf ltr-egress-mac {
-      						type ieee:mac-address;
-      						config false;
-      						description
-      							"MAC address returned in the egress MAC address
-      							field. If the ltr-egress object contains the value
-      							egress-no-tlv, then the contents of this object are
-      							meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3p, 20.41.2.11";
-      					}  					
-      					leaf ltr-egress-port-id-subtype {
-      						type lldp-port-id-subtype;
-      						config false;
-      						description
-      							"Format of the egress Port ID. If the ltr-egress
-      							object contains the value egress-no-tlv, then the
-      							contents of this object are meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3q, 20.41.2.12";
-      					}  					
-      					leaf ltr-egress-port-id {
-      						type lldp-port-id;
-      						config false;
-      						description
-      							"Egress Port ID. The format of this object is
-      							determined by the value of the
-      							ltr-egress-port-id-subtype object. If the 
-      							ltr-egress object contains the value egress-no-tlv,
-      							then the contents of this object are meaningless.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3r, 20.41.2.13";
-      					}  					
-      					leaf ltr-organization-specific-tlv {
-      						type string {
-      							length "0 | 4..1500";
-      						}
-      						config false;
-      						description
-      							"All Organization specific TLVs returned in the 
-      							LTR, if any. Includes all octets including and
-      							following the TLV Length field of each TLV, 
-      							concatenated together.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.5.3s, 21.5.2";
-      					}
-      				} // linktrace-reply
-      				
-      				list mep-db {
-      					key rmep-id;
-      					description
-      						"";
-      					leaf rmep-id {
-      						type mep-id-type;
-      						description
-      							"Maintenance association Endpoint Identifier of a
-      							remote MEP whose information from the MEP Database
-      							is to be returned.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.2b";  						
-      					}
-      					leaf rmep-state {
-      						type remote-mep-state-type;
-      						config false;
-      						description 
-      							"The operational state of the remote MEP  state
-      							machine";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3b, 20.20";
-      					}
-      					leaf rmep-failed-ok-time {
-      						type yang:zero-based-counter32;
-      						units seconds;
-      						config false;
-      						description
-      							"The time (SysUpTime) at which the Remote MEP state
-      							machine last entered either the RMEP_FAILED or
-      							RMEP_OK state";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
-      					}
-      					leaf mep-db-mac-address {
-      						type ieee:mac-address;
-      						config false;
-      						description
-      							"The MAC address of the remote MEP.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
-      					}
-      					leaf mep-db-rdi {
-      						type boolean;
-      						config false;
-      						description
-      							"State of the RDI bit in the last received CCM
-      							(true for RDI=1), or false if none has been 
-      							received.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
-      					}
-      					leaf mep-db-port-status-tlv {
-      						type port-status-tlv-value;
-      						default "no-port-state-tlv";
-      						config false;
-      						description
-      							"An enumerated value of the Port status TLV 
-      							received in the last CCM from the remote MEP or 
-      							the default value no-port-state-tlv indicating
-      							either no CCM has been received, or that no port
-      							status TLV was received in the last CCM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
-      					}
-      					leaf mep-db-interface-status-tlv {
-      						type interface-status-tlv-value;
-      						default "is-no-interface-status-tlv";
-      						config false;
-      						description
-      							"An enumerated value of the Interface status TLV
-      							received in the last CCM from the remote MEP or the
-      							default value is-no-interface-status-tlv indicating
-      							either no CCM has been received, or that no 
-      							interface status TLV was received in the last 
-      							CCM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
-      					}
-      					leaf mep-db-chassis-id-subtype {
-      						type lldp-chassis-id-subtype;
-      						config false;
-      						description
-      							"This object specifies the format of the Chassis ID
-      							received in the last CCM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
-      					}
-      					leaf mep-db-chassis-id {
-      						type lldp-chassis-id;
-      						config false;
-      						description
-      							"The Chassis ID. The format of this object is
-      							determined by the value of the 
-      							ltr-chassis-id-subtype object.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
-      					}
-      					leaf mep-db-man-address-domain {
-      						type transport-service-domain;
-      						config false;
-      						description
-      							"The transport-service-domain that identifies the
-      							type and format of the related mep-db-man-address
-      							object, used to access the YANG agent of the system
-      							transmitting the CCM. Received in the CCM Sender ID
-      							TLV from that system.
-      							
-      							The value zeroDotZero (from RFC2578) indicates no
-      							management address was present in the LTR, in which
-      							case the related mep-db-man-address object MUST
-      							have a zero-length OCTET STRING as a value.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
-      							21.6.7";
-      					}
-      					leaf mep-db-man-address {
-      						type transport-service-address;
-      						config false;
-      						description
-      							"The transport-service-address that can be used to 
-      							access the YANG agent of the system transmitting
-      							the CCM, received in the CCM Sender ID TLV from
-      							that system. If the related 
-      							mep-db-man-address-domain object contains the 
-      							value zeroDotZero, this object mep-db-man-address
-      							MUST have a zero-length OCTET STRING as a value.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
-      							21.6.7";
-      					}
-      					leaf mep-db-rmep-is-active {
-      						type boolean;
-      						description
-      							"A Boolean value statign if the remote MEP is 
-      							active.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
-      					}
-      				} // mep-db
-      				
-      				container stats {
-      					config false;
-      					description
-      						"Contains the counters associated with the MEP.";
-      					leaf mep-ccm-sequence-errors {
-      						type yang:counter64;
-      						description
-      							"The total number of out-of-sequence CCMs received
-      							from all remote MEPs.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
-      					}
-      					leaf mep-sent-ccms {
-      						type yang:counter64;
-      						description
-      							"Total number of CCMs transmitted";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3w, 20.10.2";
-      					}
-      					leaf mep-lbr-in {
-      						type yang:counter64;
-      						description
-      							"Total number of valid, in-order Loopback Replies
-      							received.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3y, 20.31.1";
-      					}
-      					leaf mep-lbr-in-out-of-order {
-      						type yang:counter64;
-      						description
-      							"The total number of valid, out-of-order
-      							Loopback Replies received";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3z, 20.31.1";
-      					}
-      					leaf mep-lbr-bad-msdu {
-      						type yang:counter64;
-      						description
-      							"The total number of LBRs receivd whose
-      							mac_service_data_unit did not match (except for the
-      							OpCode) that of the corresponding LBM.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3aa, 20.2.3";
-      					}
-      					leaf mep-unexpected-ltr-in {
-      						type yang:counter64;
-      						description
-      							"The total number of unexpected LTRs received.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ac, 20.44.1";
-      					}
-      					leaf mep-lbr-out {
-      						type yang:counter64;
-      						description
-      							"Total number of Loopback Replies transmitted.";
-      						reference
-      							"IEEE 802.1Q-2017 Clause 12.14.7.1.3ad, 20.28.2";
-      					}
-      				} // stats
-      			} // mep
+    				leaf mhf-creation {
+        			type mhf-creation-type;
+        			default mhf-defer;
+        			description
+        				"Value indicating whether the management entity can
+        				create MHFs (MIP Half Function) for this Maintenance
+        				Domain. Since there is no encompassing Maintenance
+        				Domain, the vlaue mhf-defer is not allowed.";
+        			reference
+        				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
+        		}
+    				leaf id-permission {
+    					type sender-id-permission-type;
+    	  			default "send-id-defer";
+    	  			description
+    	  				"Enumerated value indicating what, if anything, is to
+    	  				be included in the Sender ID TLV (21.5.3) transmitted
+    	  				by MPs configured in this MA.";
+    	  			reference
+    	  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3d";
+    				}
     			} // maintenance-association-component
     		} // maintenance-association
   		} // maintenance-domain
   	} // maintenance-domains
   	
-  	container connectivity-check-message {
+  	container meps {
+  		description
+  			"Contains the Maintenance Association EndPoint configuration
+  			and operational data, as well as related objects.";
+  		list mep {
+  			key "mep-id maintenance-group";
+  			description 
+  				"A list of Maintenance association End Points (MEPs). A
+  				MEP is an actively managed CFM entity, associated with
+  				a specific DoSAP of a service instance, which can
+  				generate and receive CFM PDUs and track any responses.
+  				It is an end point of a single Maintenance Association
+  				(MA) and is an end point of a separate Maintenance
+  				Entity for each of the other MEPs in the same MA.";
+  			leaf mep-id {
+  				type mep-id-type;
+  				description
+  					"Integer that is unique among all the MEPs in the
+  					same Maintenance Association.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+  			}
+  			leaf maintenance-group {
+      		type maintenance-group-type;
+      		description
+      			"The maintenance group provides an identifier
+      			for the MD and MA combination.";
+      	}
+  			leaf ma-reference-index {
+  				type uint32;
+  				description
+  					"An index reference to the particular Maintenance
+  					Association that this MEP belongs to.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
+  			}
+  			leaf bridge-port {
+  				type if:interface-ref;
+  				description
+  					"The interface index of the interface (i.e., Bridge 
+  					Port) to which the MEP is attached.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+  			}
+  			leaf direction {
+  				type mp-direction-type;
+  				description
+  					"The direction in which the MEP faces on the Bridge
+  					Port. Example, up or down.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
+  			}
+  			leaf primary-vid {
+  				type uint32 {
+  					range "0..16777215";
+  				}
+  				default 0;
+  				description
+  					"An integer indicating the Primary VID of the MEP. It
+  					is always one of the VIDs assigned to the MEPs MA. A
+  					value of 0 indicates that either the Primary VID is
+  					that of the MEPs MA, or that the MEPs MA is 
+  					associated with no VID.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
+  			}
+  			leaf admin-state {
+  				type boolean;
+  				default "false";
+  				description
+  					"The administrative state of the MEP. TRUE indicates
+  					that the MEP is to functional normally, and FALSE
+  					indicates that it is to cease functioning.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
+  			}
+  			leaf fng-state {
+  				type fng-state-type;
+  				default "fng-reset";
+  				config false;
+  				description
+  					"The current state of the MEP Fault Notification 
+  					Generator state machine.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
+  			}
+  			leaf ccm-enabled {
+  				type boolean;
+  				default "false";
+  				description
+  					"Indicates whether the MEP can generate CCMs. If 
+  					TRUE, the MEP will generate CCM PDUs.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
+  			}
+  			leaf ccm-ltm-priority {
+  				type dot1q-types:priority-type;
+  				description
+  					"The priority value for CCMs and LTMs transmitted by
+  					the MEP. The default value is the highest priority 
+  					allowed to pass through the Bridge Port for any of
+  					the MEPs VID(s).";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+  			}
+  			leaf mac-address {
+  				type ieee:mac-address;
+  				description
+  					"The MAC address of the MEP.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
+  			}
+  			leaf fault-alarm-address {
+    			type fault-alarm-adress-type;
+    			default "not-specified";
+    			description
+    				"A value indicating whether Fault Alarms are to be 
+    				transmitted or not. The default is not specified, 
+    				which implies that the disposition of the fault-alarm
+    				used by the MD should be used.";
+    			reference
+    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
+    		}
+  			leaf lowest-priority-defect {
+  				type lowest-alarm-priority-type;
+  				default "mac-remote-error-xcon";
+  				description
+  					"The lowest priority defect that is allowed to
+  					generate fault alarms.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
+  			}
+  			leaf fng-alarm-time {
+  				type yang:zero-based-counter32 {
+  					range "250..1000";
+  				}
+  				units deciseconds;
+  				default 250;
+  				description
+  					"The time that defect must be present before a Fault
+  					Alarm is issued.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
+  			}
+  			leaf fng-reset-time {
+  				type yang:zero-based-counter32 {
+  					range "250..1000";  					
+  				}
+  				units deciseconds;
+  				default 1000;
+  				description
+  					"The time that defects must be absent before 
+  					resetting a Fault Alarm.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
+  			}
+  			leaf highest-priority-defect {
+  				type highest-defect-priority-type;
+  				config false;
+  				description
+  					"The highest priority defect that has been present
+  					sicne the MEPs Fault Notification Generator state
+  					machine was last in the FNG_RESET state.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
+  			}
+  			leaf defects {
+  				type mep-defects-type;
+  				config false;
+  				description
+  					"Vector of boolean error conditions";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
+  					20.23.3, 20.35.5, 20.35.6, 20.35.7";
+  			}
+  			leaf error-ccm-last-failure {
+  				type string {
+  					length "1..1522";
+  				}
+  				config false;
+  				description
+  					"The last received CCM that triggered a def-error-ccm
+  					fault.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
+  			}
+  			leaf xcon-ccm-last-failure {
+  				type string {
+  					length "1..1522";
+  				}
+  				config false;
+  				description
+  					"The last received CCM that triggered a def-xcon-ccm
+  					fault.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
+  			}
+  			leaf-list active-rmeps {
+  				type mep-id-type;
+  				description
+  					"A list indicating which of the remote MEPs in the
+  					same MA are active. By default, all configured
+  					remote MEPs in the same MA are active.";
+  				reference
+  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+  			}
+  			
+  			list linktrace-reply {
+  				key "ltr-seq-number ltr-receive-order";
+  				description
+  					"This table extends the MEP table and contains a list
+  					of Linktrace replies received by a specific MEP in
+  					response to a linktrace message.";
+  				leaf ltr-seq-number {
+  					type uint32 {
+  						range "0..4294967295";
+  					}
+  					description
+  						"Transaction identifier returned by a previous
+  						transmit linktrace message command, indicating
+  						which LTMs response is going to be returned.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.2b";
+  				}
+  				leaf ltr-receive-order {
+  					type uint32 {
+  						range "1..4294967295";
+  					}
+  					description
+  						"An index to distinguish among multiple LTRs with
+  						the same LTR Transaction Identifier field value. 
+  						Assigned sequentially from 1, in the order that the 
+  						Linktrace Initiator received the LTRs.";
+  				}
+  				leaf ltr-ttl {
+  					type uint32 {
+  						range "0..255";
+  					}
+  					config false;
+  					description
+  						"TTL field value for a returned LTR.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5, 20.41.2.2";
+  				}
+  				leaf ltr-forwarded {
+  					type boolean;
+  					config false;
+  					description
+  						"Indicates if a LTM was forwarded by the responding
+  						MP, as returned in the FwdYes flag of the flags 
+  						field.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3c, 20.41.2.1";
+  				}  					
+  				leaf ltr-terminal-mep {
+  					type boolean;
+  					config false;
+  					description
+  						"A Boolean value stating whether the forwarded LTM
+  						reached a MEP enclosing its MA, as returned in the
+  						Terminal MEP flag of the Flags field";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3d, 20.41.2.1";
+  				}
+  				leaf ltr-last-egress-identifier {
+  					type string {
+  						length "8";
+  					}
+  					config false;
+  					description
+  						"An octet field holding the Last Egress Identifier
+  						returned in the LTR Egress Identifier TLV of the
+  						LTR. The Last Egress Identifier identifies the MEP
+  						Linktrace Initiator that originated, or the 
+  						Linktrace Responder that forwarded, the LTM to
+  						which this LTR is the response. This is the same
+  						value as the Egress Identifier TLV of that LTM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3e, 20.41.2.3";
+  				}  					
+  				leaf ltr-next-egress-identifier {
+  					type string {
+  						length "8";
+  					}
+  					config false;
+  					description
+  						"An octet field holding the Next Egress Identifier
+  						returned in the LTR Egress Identifier TLV of the 
+  						LTR. The Next Egress Identifier Identifies the
+  						Linktrace Responder that transmitted this LTR, and
+  						can forward the LTM to the next hop. This is the
+  						same value as the Egress Identifier TLV of the
+  						forwarded LTM, if any. If the FwdYes bit of the
+  						Flags field is false, the contents of this field
+  						are undefined, i.e., any value can be transmitted,
+  						and the field is ignored by the receiver.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3f, 20.41.2.4";
+  				}  					
+  				leaf ltr-relay {
+  					type relay-action-field-value;
+  					config false;
+  					description
+  						"Value returned in teh Relay Action field.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
+  				}  					
+  				leaf ltr-chassis-id-subtype {
+  					type lldp-chassis-id-subtype;
+  					config false;
+  					description
+  						"Specifies the format of the Chassis ID returned
+  						in the Sender ID TLV of the LTR, if any. This value
+  						is meaningless if the ltr-chassis-id has a length
+  						of 0.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3h, 21.5.3.2";
+  				}  					
+  				leaf ltr-chassis-id {
+  					type lldp-chassis-id;
+  					config false;
+  					description
+  						"The Chassis ID returned in the Sender ID TLV of 
+  						the LTR, if any. The format of this object is
+  						determined by the value of the 
+  						ltr-chassis-id-subtype object.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3i, 21.5.3.2";
+  				}  					
+  				leaf ltr-man-address-domain {
+  					type transport-service-domain;
+  					config false;
+  					description
+  						"The transport-service-domain that identifies the
+  						type and format of the related mep-db-man-address
+  						object, used to access the YANG agent of the system
+  						transmitting the LTR. Received in the LTR Sender ID
+  						TLV from that system.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.5,
+  						21.9.6";
+  				}  					
+  				leaf ltr-man-address {
+  					type transport-service-address;
+  					config false;
+  					description
+  						"The transport-service-address that can be used to
+  						access the YANG	agent of the system transmitting
+  						the CCM, received in the CCM Sender ID TLV from
+  						that system.
+  						
+  						If the related object ltr-man-address-domain
+  						contains the value zeroDotZero, this object
+  						ltr-man-address MUST have a zero-length OCTET 
+  						STRING as a value.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.7,
+  						21.9.6";
+  				}  					
+  				leaf ltr-ingress {
+  					type ingress-action-field-value;
+  					config false;
+  					description
+  						"The value returned in the Ingress Action Field of
+  						the LTM. The value ingress-no-tlv indicates that no
+  						Reply Ingress TLV was returned in the LTM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3k, 20.41.2.6";
+  				}  					
+  				leaf ltr-ingress-mac {
+  					type ieee:mac-address;
+  					config false;
+  					description
+  						"MAC address returned in the ingress MAC address
+  						field. If the ltr-ingress object contains the value 
+  						ingress-no-tlv, then the contents of this object
+  						are meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3l, 20.41.2.7";
+  				}  					
+  				leaf ltr-ingress-port-id-subtype {
+  					type lldp-port-id-subtype;
+  					config false;
+  					description
+  						"Ingress Port ID. The format of this object is 
+  						determined by the value of the 
+  						ltr-ingress-port-id-subtype object. If the
+  						ltr-ingress object contains the value 
+  						ingress-no-tlv, then the contents of this object
+  						are meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3n, 20.41.2.9";
+  				}  					
+  				leaf ltr-egress {
+  					type egress-action-field-value;
+  					config false;
+  					description
+  						"The value returned in the Egress Action Field of
+  						the LTM. The value egress-no-tlv indicates that 
+  						no Reply Egress TLV was returned in the LTM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3o, 20.41.2.10";
+  				}  					
+  				leaf ltr-egress-mac {
+  					type ieee:mac-address;
+  					config false;
+  					description
+  						"MAC address returned in the egress MAC address
+  						field. If the ltr-egress object contains the value
+  						egress-no-tlv, then the contents of this object are
+  						meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3p, 20.41.2.11";
+  				}  					
+  				leaf ltr-egress-port-id-subtype {
+  					type lldp-port-id-subtype;
+  					config false;
+  					description
+  						"Format of the egress Port ID. If the ltr-egress
+  						object contains the value egress-no-tlv, then the
+  						contents of this object are meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3q, 20.41.2.12";
+  				}  					
+  				leaf ltr-egress-port-id {
+  					type lldp-port-id;
+  					config false;
+  					description
+  						"Egress Port ID. The format of this object is
+  						determined by the value of the
+  						ltr-egress-port-id-subtype object. If the 
+  						ltr-egress object contains the value egress-no-tlv,
+  						then the contents of this object are meaningless.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3r, 20.41.2.13";
+  				}  					
+  				leaf ltr-organization-specific-tlv {
+  					type string {
+  						length "0 | 4..1500";
+  					}
+  					config false;
+  					description
+  						"All Organization specific TLVs returned in the 
+  						LTR, if any. Includes all octets including and
+  						following the TLV Length field of each TLV, 
+  						concatenated together.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3s, 21.5.2";
+  				}
+  			} // linktrace-reply
+  			
+  			list mep-db {
+  				key rmep-id;
+  				description
+  					"The MEP CCM Database.";
+  				leaf rmep-id {
+  					type mep-id-type;
+  					description
+  						"Maintenance association Endpoint Identifier of a
+  						remote MEP whose information from the MEP Database
+  						is to be returned.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.2b";  						
+  				}
+  				leaf rmep-state {
+  					type remote-mep-state-type;
+  					config false;
+  					description 
+  						"The operational state of the remote MEP  state
+  						machine";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3b, 20.20";
+  				}
+  				leaf rmep-failed-ok-time {
+  					type yang:zero-based-counter32;
+  					units seconds;
+  					config false;
+  					description
+  						"The time (SysUpTime) at which the Remote MEP state
+  						machine last entered either the RMEP_FAILED or
+  						RMEP_OK state";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
+  				}
+  				leaf mep-db-mac-address {
+  					type ieee:mac-address;
+  					config false;
+  					description
+  						"The MAC address of the remote MEP.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
+  				}
+  				leaf mep-db-rdi {
+  					type boolean;
+  					config false;
+  					description
+  						"State of the RDI bit in the last received CCM
+  						(true for RDI=1), or false if none has been 
+  						received.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
+  				}
+  				leaf mep-db-port-status-tlv {
+  					type port-status-tlv-value;
+  					default "no-port-state-tlv";
+  					config false;
+  					description
+  						"An enumerated value of the Port status TLV 
+  						received in the last CCM from the remote MEP or 
+  						the default value no-port-state-tlv indicating
+  						either no CCM has been received, or that no port
+  						status TLV was received in the last CCM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
+  				}
+  				leaf mep-db-interface-status-tlv {
+  					type interface-status-tlv-value;
+  					default "is-no-interface-status-tlv";
+  					config false;
+  					description
+  						"An enumerated value of the Interface status TLV
+  						received in the last CCM from the remote MEP or the
+  						default value is-no-interface-status-tlv indicating
+  						either no CCM has been received, or that no 
+  						interface status TLV was received in the last 
+  						CCM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
+  				}
+  				leaf mep-db-chassis-id-subtype {
+  					type lldp-chassis-id-subtype;
+  					config false;
+  					description
+  						"This object specifies the format of the Chassis ID
+  						received in the last CCM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
+  				}
+  				leaf mep-db-chassis-id {
+  					type lldp-chassis-id;
+  					config false;
+  					description
+  						"The Chassis ID. The format of this object is
+  						determined by the value of the 
+  						ltr-chassis-id-subtype object.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
+  				}
+  				leaf mep-db-man-address-domain {
+  					type transport-service-domain;
+  					config false;
+  					description
+  						"The transport-service-domain that identifies the
+  						type and format of the related mep-db-man-address
+  						object, used to access the YANG agent of the system
+  						transmitting the CCM. Received in the CCM Sender ID
+  						TLV from that system.
+  						
+  						The value zeroDotZero (from RFC2578) indicates no
+  						management address was present in the LTR, in which
+  						case the related mep-db-man-address object MUST
+  						have a zero-length OCTET STRING as a value.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
+  						21.6.7";
+  				}
+  				leaf mep-db-man-address {
+  					type transport-service-address;
+  					config false;
+  					description
+  						"The transport-service-address that can be used to 
+  						access the YANG agent of the system transmitting
+  						the CCM, received in the CCM Sender ID TLV from
+  						that system. If the related 
+  						mep-db-man-address-domain object contains the 
+  						value zeroDotZero, this object mep-db-man-address
+  						MUST have a zero-length OCTET STRING as a value.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
+  						21.6.7";
+  				}
+  				leaf mep-db-rmep-is-active {
+  					type boolean;
+  					description
+  						"A Boolean value statign if the remote MEP is 
+  						active.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+  				}
+  			} // mep-db
+  			
+  			container stats {
+  				config false;
+  				description
+  					"Contains the counters associated with the MEP.";
+  				leaf mep-ccm-sequence-errors {
+  					type yang:counter64;
+  					description
+  						"The total number of out-of-sequence CCMs received
+  						from all remote MEPs.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
+  				}
+  				leaf mep-sent-ccms {
+  					type yang:counter64;
+  					description
+  						"Total number of CCMs transmitted";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3w, 20.10.2";
+  				}
+  				leaf mep-lbr-in {
+  					type yang:counter64;
+  					description
+  						"Total number of valid, in-order Loopback Replies
+  						received.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3y, 20.31.1";
+  				}
+  				leaf mep-lbr-in-out-of-order {
+  					type yang:counter64;
+  					description
+  						"The total number of valid, out-of-order
+  						Loopback Replies received";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3z, 20.31.1";
+  				}
+  				leaf mep-lbr-bad-msdu {
+  					type yang:counter64;
+  					description
+  						"The total number of LBRs receivd whose
+  						mac_service_data_unit did not match (except for the
+  						OpCode) that of the corresponding LBM.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3aa, 20.2.3";
+  				}
+  				leaf mep-unexpected-ltr-in {
+  					type yang:counter64;
+  					description
+  						"The total number of unexpected LTRs received.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ac, 20.44.1";
+  				}
+  				leaf mep-lbr-out {
+  					type yang:counter64;
+  					description
+  						"Total number of Loopback Replies transmitted.";
+  					reference
+  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ad, 20.28.2";
+  				}
+  			} // stats
+  		} // mep
+  	} // meps
+  	
+  	container continuity-check {
   		description
   			"Continuity check protocol";
   		leaf mep {
@@ -2459,7 +2475,7 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.6.1.3e";
 			}
-  	} // connectivity-check
+  	} // continuity-check
   	
   	container loopback {
   		description
@@ -2522,6 +2538,7 @@ module ieee802-dot1q-cfm {
 			}
 			leaf dest-is-mep-id {
 				type boolean;
+				default "false";
 				description
 					"TRUE indicates that MEP ID of the target MEP is used
 					for Loopback transmissions. FALSE indicates that
@@ -2550,7 +2567,7 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
 			}
-			leaf vlan-priority {
+			leaf priority {
 				type dot1q-types:priority-type;
 				description
 					"Priority. 3 bit value to be used in the VLAN tag, if
@@ -2781,20 +2798,12 @@ module ieee802-dot1q-cfm {
   	description
   		"To signal to the MEP to transmit some number of LBMs.";
   	input {
-  		leaf md-index {
-  			type uint32;
-  			description
-  				"The index to the Maintenance Domain list.";
-  			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
-  		}
-  		leaf ma-index {
-  			type uint32;
-  			description
-  				"The index to the Maintenance Association list.";
-  			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
-  		}
+  		leaf maintenance-group {
+    		type maintenance-group-type;
+    		description
+    			"The maintenance group to which the Maintenance Points
+    			is associated with.";
+    	}
   		leaf mep-id {
   			type mep-id-type;
 				description
@@ -2901,20 +2910,12 @@ module ieee802-dot1q-cfm {
 			"To signal to the MEP to transmit an LTM and to create an LTM
 			entry in the MEPs Linktrace Database.";
 		input {
-			leaf md-index {
-  			type uint32;
-  			description
-  				"The index to the Maintenance Domain list.";
-  			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
-  		}
-  		leaf ma-index {
-  			type uint32;
-  			description
-  				"The index to the Maintenance Association list.";
-  			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
-  		}
+			leaf maintenance-group {
+    		type maintenance-group-type;
+    		description
+    			"The maintenance group to which the Maintenance Points
+    			is associated with.";
+    	}
   		leaf mep-id {
   			type mep-id-type;
 				description
@@ -3042,6 +3043,12 @@ module ieee802-dot1q-cfm {
 		description
 			"To alert the Manager to the existence of a fault in a monitored
 			MA by issuing a Fault Alarm.";
+		leaf maintenance-group {
+  		type maintenance-group-type;
+  		description
+  			"The maintenance group to which the Maintenance Points
+  			is associated with.";
+  	}
 		leaf md-name {
 			type leafref {
 				path "/cfm/maintenance-domains/maintenance-domain/name";
@@ -3089,9 +3096,7 @@ module ieee802-dot1q-cfm {
 		}
 		leaf mep-id {
 			type leafref {
-				path "/cfm/maintenance-domains/maintenance-domain"+
-			       "/maintenance-association"+
-						 "/maintenance-association-component/mep/mep-id";
+				path "/cfm/meps/mep/mep-id";
 			}
 			description
 				"Integer that is unique among all the MEPs in the same
@@ -3101,10 +3106,7 @@ module ieee802-dot1q-cfm {
 		}
 		leaf mep-priority-defect {
 			type leafref {
-				path "/cfm/maintenance-domains/maintenance-domain"+
-			       "/maintenance-association"+
-			       "/maintenance-association-component/mep"+
-						 "/highest-priority-defect";
+				path "/cfm/meps/mep/highest-priority-defect";
 			}
 			description
 				"The highest priority defect that has been present

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -7,7 +7,7 @@ module ieee802-dot1q-cfm {
   import ietf-yang-types { prefix "yang"; }
   import ietf-interfaces { prefix "if"; }
   import ieee802-dot1q-types { prefix "dot1q-types"; }
-  //import ieee802-dot1q-bridge { prefix "dot1q"; }
+  import ieee802-dot1q-bridge { prefix "dot1q"; }
 
   organization
     "Institute of Electrical and Electronics Engineers";
@@ -32,7 +32,7 @@ module ieee802-dot1q-cfm {
   	for detecting, verifying, and isolating connectivity failures
   	in Virtual Bridged Local Area Networks. These capabilities
   	can be used in networks operated by multiple independent
-  	organizaitons, each wit restricted management access to each others
+  	organizations, each wit restricted management access to each others
   	equipment.";
   
   revision 2017-12-20 {
@@ -276,24 +276,9 @@ module ieee802-dot1q-cfm {
    * Type definitions used by RFC 2579 SNMP v2 YANG module
    * -----------------------------------------------------
    */
-  
-  identity type-of-transport-domain {
-  	description
-  		"Represents the transport service domain type.";
-  }
-  
-  identity yang-tdomain {
-  	base type-of-transport-domain;
-  	description
-  		"Base identity for a YANG transport service domain.";
-  }
-  
+ 
   typedef transport-service-domain {
-  	// Refer to RFC 2579. This is an OBJECT Identifier
-  	// Not sure what to do here!
-  	type identityref {
-  		base type-of-transport-domain;
-  	}
+  	type yang:object-identifier;
   	description
   		"Denotes a kind of transport service";
   	reference
@@ -314,20 +299,18 @@ module ieee802-dot1q-cfm {
    */
   
   typedef bridge-ref {
-  	//type leafref {
-  	//	path "/dot1q:bridges/dot1q:bridge/dot1q:name";
-  	//}
-  	type string;
+  	type leafref {
+  		path "/dot1q:bridges/dot1q:bridge/dot1q:name";
+  	}
   	description
   		"This type is used by data models that need to reference
   		a configured Bridge.";
   }
   
-  typedef component-ref {
-  	type string;
-  	//type leafref {
-  	//	path "/dot1q:bridges/dot1q:bridge/dot1q:component/dot1q:name";
-  	//}
+  typedef bridge-component-ref {
+  	type leafref {
+  		path "/dot1q:bridges/dot1q:bridge/dot1q:component/dot1q:name";
+  	}
   	description
   		"This type is used by data models that need to reference
   		a configured Bridge Component.";
@@ -746,7 +729,7 @@ module ieee802-dot1q-cfm {
   		enum none {
   			value 0;
   			description
-  				"No defects since Fault Notificaiton Generator state
+  				"No defects since Fault Notification Generator state
   				machine reset.";
   		}
   		enum def-rdi-ccm {
@@ -852,7 +835,7 @@ module ieee802-dot1q-cfm {
   			value 4;
   			description
   				"The Chassis ID Length, Chassis ID Subtype, Chassis ID, 
-  				Managment Address Length and Managemetn Address fields are
+  				Management Address Length and Management Address fields are
   				all to be sent.";
   		}
   		enum send-id-defer {
@@ -867,51 +850,51 @@ module ieee802-dot1q-cfm {
   		ID TLV transmitted in CCMs, LBMs, LTMs, and LTRs.";
   }
   
-  typedef ccm-interval-type {
+  typedef cfm-interval-type {
   	type enumeration {
-  		enum inteval-invalid {
+  		enum invalid {
   			value 0;
   			description
-  				"No CCMs are sent.";
+  				"No CFM PDUs are to be sent";
   		}
-  		enum interval-300hz {
+  		enum 300hz {
   			value 1;
   			description
-  				"CCMs are sent every 3 1/3 milliseconds (300Hz).";
+  				"CFM PDUs are sent every 3 1/3 milliseconds (300Hz).";
   		}
-  		enum interval-10ms {
+  		enum 10ms {
   			value 2;
   			description
-  				"CCMs are sent every 10 milliseconds.";
+  				"CFM PDUs are sent every 10 milliseconds.";
   		}
-  		enum interval-100ms {
+  		enum 100ms {
   			value 3;
   			description
-  				"CCMs are sent every 100 milliseconds.";
+  				"CFM PDUs are sent every 100 milliseconds.";
   		}
-  		enum interval-1sec {
+  		enum 1sec {
   			value 4;
   			description
-  				"CCMs are sent every second.";
+  				"CFM PDUs are sent every second.";
   		}
-  		enum interval-10sec {
+  		enum 10sec {
   			value 5;
   			description
-  				"CCMs are sent every 10 seconds.";
+  				"CFm PDUs are sent every 10 seconds.";
   		}
-  		enum interval-1min {
+  		enum 1min {
   			value 6;
   			description
-  				"CCMs are sent every minute.";
+  				"CFM PDUs are sent every minute.";
   		}
-  		enum interval-10min {
+  		enum 10min {
   			value 7;
   			description
-  				"CCMs are sent every 10 minutes.";
+  				"CFM PDUs are sent every 10 minutes.";
   		}
   	}
   	description
-  		"Indicates the interval at which CCMs are sent by a MEP.";
+  		"Indicates the interval at which CFM PDUs are sent by a MEP.";
   }
   
   typedef fng-state-type {
@@ -932,7 +915,7 @@ module ieee802-dot1q-cfm {
   			value 3;
   			description
   				"A momentary state during which the defect is reported by sending a
-  				fault-alarm notifcation, if that action is enabled.";
+  				fault-alarm notification, if that action is enabled.";
   		}
   		enum fng-defect-reported {
   			value 4;
@@ -947,7 +930,7 @@ module ieee802-dot1q-cfm {
   		}
   	}
   	description
-  		"Indicates the diferent states of the MEP Fault Notification
+  		"Indicates the different states of the MEP Fault Notification
   		Generator State Machine.";
   }
   
@@ -962,7 +945,7 @@ module ieee802-dot1q-cfm {
   		enum relay-fdb {
   			value 2;
   			description
-  				"The Egress Port was determiend by consulting the Filtering
+  				"The Egress Port was determined by consulting the Filtering
   				Database.";
   		}
   		enum relay-mpdb {
@@ -992,12 +975,12 @@ module ieee802-dot1q-cfm {
   		enum ingress-down {
   			value 2;
   			description
-  				"The Bridge Ports MAC_Operational paramter is false.";
+  				"The Bridge Ports MAC_Operational parameter is false.";
   		}
   		enum ingress-blocked {
   			value 3;
   			description
-  				"The target data frame woujld not be forarded if received on
+  				"The target data frame would not be forwarded if received on
   				this Port due to active topology enforcement.";
   		}
   		enum ingress-vid {
@@ -1041,7 +1024,7 @@ module ieee802-dot1q-cfm {
   		enum egress-vid {
   			value 4;
   			description
-  				"The Egress Port can be identifid, but the Bridge Port is not
+  				"The Egress Port can be identified, but the Bridge Port is not
   				in the LTMs VIDs member set, so would be filtered by
   				egress filtering.";
   		}
@@ -1174,12 +1157,12 @@ module ieee802-dot1q-cfm {
   		"The flags field for LTMs transmitted by the MEP.";
   }
   
-  typedef fault-alarm-adress-type {
+  typedef fault-alarm-address-type {
   	type enumeration {
   		enum address {
   			value 1;
   			description
-  				"Indicates that a Network address tow hich Fault Alarms
+  				"Indicates that a Network address to which Fault Alarms
   				are to be transmitted should be used.";
   		}
   		enum not-specified {
@@ -1195,7 +1178,93 @@ module ieee802-dot1q-cfm {
   		}
   	}
   	description
-			"The Fault Alarm adress indicators.";
+			"The Fault Alarm address indicators.";
+  }
+  
+  /* -------------------------------------------------
+   * Grouping definitions used by 802.1Qcx YANG module
+   * -------------------------------------------------
+   */
+  
+  grouping service-id {
+  	description
+			"The list of VIDs, I-SID, or the TE-SID monitored by 
+			this MA, or 0, if the MA is not attached to a VID, or
+			I-SID, or TE-SID. In the case of a list of VIDs, the 
+			first VID in the list is the MAs Primary VID (default 
+			none). The specification of I-SID is allowed only in
+			the case of I- or B- components. The TE-SID is allowed
+			only in the case that PBB-TE is supported.";
+  	choice service-id {
+  		default vid;
+  		description
+  			"The service identifiers types";
+			case none {
+				leaf zero {
+					type uint32 {
+						range "0";
+					}
+					description
+						"Represents no service identifier selected.";
+				}
+			}
+			case vid {
+				leaf-list vid {
+					type dot1q-types:vlanid;
+					description
+						"12-Bit identifier VLAN identifier.";
+				}
+			}
+			case isid {
+				leaf isid {
+					type uint32 {
+						range "1..16777215";
+					}
+					description
+						"24-Bit identifier I-SID identifier.";
+				}
+			}
+			case tesid {
+				leaf tesid {
+					type uint32 {
+						range "1..4294967295";
+					}
+					description
+						"The tesid is used as a service selector for MAs that are
+						present in Bridges that implement PBB-TE functionality.";
+				}
+			}
+			case segid {
+				leaf segid {
+					type uint32 {
+						range "1..4294967295";
+					}
+					description
+						"The segid is used as a service selector for MAs that are
+						present in Bridges that implement IPS functionality.";
+				}
+			}
+			case path-tesid {
+				leaf path-tesid {
+					type uint32 {
+						range "1..4294967295";
+					}
+					description
+						"The path-tesid is used as a service selector for SPBM 
+						path MAs.";
+				}
+			}
+			case group-isid {
+				leaf group-isid {
+					type uint32 {
+						range "1..4294967295";
+					}
+					description
+						"The group-isid is used as a service selector for SPBM 
+						group MAs.";
+				}
+			}
+		}
   }
 
 
@@ -1209,19 +1278,50 @@ module ieee802-dot1q-cfm {
   		"Connectivity Fault Management configuration and operational
   		information.";
   	
+  	choice device-reference {
+  		description
+  			"This type is intended to be used as a generic reference. 
+   		 An instance of the reference is a pointer to a Bridge object
+   		 defined by IEEE 802.1Qcp. 
+   		 
+   		 However, to allow non-802.1Q compliant devices that
+   		 wants to utilize IEEE 802.1Q standardized CFM and the 
+   		 accompanying CFM YANG model, this node can be augmented
+   		 with a different device reference.
+  			
+   		 For example, another type of device could create a new
+   		 device type with reference in their YANG module. Then
+   		 they could augment this module, and the cfm/device-reference
+   		 in particular to include a new case statement with
+   		 their device reference.";
+  		case bridge {
+  			leaf bridge-ref {
+  				type bridge-ref;
+  				description
+  					"A 802.1Q compliant Bridge reference on which the CFM 
+  	  			configuration and operational information are 
+  					associated with.";
+  			} 		
+  	  }
+  		//case other-device-ref {
+  		//	leaf other-device-ref {
+  		//		type other-module:other-device-ref;
+  		//		description
+  		//			"An other device reference which the CFM configuration
+  		//			and operational information are associated with.";
+  		//	}
+  		//}
+  	}
+  	
   	container cfm-stacks {
   		description 
   			"he CFM Stack contains information about the Maintenance
     		Points configured on a particular Bridge Port (or
     		aggregated port). It contains all CFM Stack specific related
     		configuration and operational data.";
-  		leaf bridge {
-  			type bridge-ref;
-  			description
-  				"A Bridge on which the CFM Stack is associated with.";
-  		}
+  		
   		list cfm-stack {
-    		key "bridge-port type-of-service-selector service-selector-or-none md-level direction";
+    		key "port md-level direction";
     		description
     			"The CFM Stack contains information about the Maintenance
       		Points configured on a particular Bridge Port (or
@@ -1235,7 +1335,7 @@ module ieee802-dot1q-cfm {
     			indexed before the system restart. If no such entry exists,
     			then the system SHALL delete all entries in the
     			cfm-stack with the interface index.";  		
-    		leaf bridge-port {
+    		leaf port {
       		type if:interface-ref;
       		description
       			"An interface on which maintenance points might be 
@@ -1245,21 +1345,6 @@ module ieee802-dot1q-cfm {
       		reference
       			"IEEE 802.1Q-2017 Clause 12.14.2.1.2a";
       	}
-      	leaf type-of-service-selector {
-      		type service-selector-type;
-      		description
-      			"Type of the service selector identifier.";
-      		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2d, 22.1.7";
-      	}
-      	leaf service-selector-or-none {
-      		type service-selector-value-or-none;
-      		description
-      			"Service Selector identifier to which the MP is attached,
-      			or 0, if none.";
-      		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2d, 22.1.7";
-      	}  	
       	leaf md-level {
       		type md-level-type;
       		description
@@ -1275,6 +1360,14 @@ module ieee802-dot1q-cfm {
       		reference
       			"IEEE 802.1Q-2017 Clause 12.14.2.1.2c";  		
       	}
+      	container service-id {
+    			description 
+    				"A specific VID, I-SID, Traffic Engineering service 
+    				instance Identifier (TE-SID), or Segment Identifier
+    				(SEG-ID) associated with an MP, or 0, in the case that
+    				the MP is associated with no VID, I-SID, TE-SID, or SEG-ID";
+    			uses service-id;
+    		}
       	leaf maintenance-group {
       		type maintenance-group-type;
       		config false;
@@ -1328,14 +1421,9 @@ module ieee802-dot1q-cfm {
   			the list of VIDs attached to any specific Maintenance 
   			Association managed object, and the transmission of the Sender
   			ID TLV by those MHFs.";
-  		leaf bridge {
-  			type bridge-ref;
-  			description
-  				"A Bridge on which the Default MD Level object is associated
-  				with.";
-  		}
+  		
   		list default-md-level {
-    		key "component-id primary-selector-type primary-selector";
+    		key "component-id";
     		description
     			"For each bridge component, the Default MD Level Managed 
     			Object controls MHF creation for VIDs that are not attached
@@ -1349,7 +1437,7 @@ module ieee802-dot1q-cfm {
     			for the same VLAN ID and MD Level as this table's entry, and
     			on which MA an Up MEP is defined. If there exists such an
     			MA, that MA's objects are used by the algorithm in
-    			subclause 22.2.3 in place of this table entrys objects.
+    			subclause 22.2.3 in place of this table entry objects.
     			
     			The agent maintains the value of md-status to indicate
     			whether this entry is overridden by an MA. When first
@@ -1368,36 +1456,33 @@ module ieee802-dot1q-cfm {
     			reference
     				"IEEE 802.1Q-2017 Clause 12.3l";
     		}
-    		leaf primary-selector-type {
-    			type service-selector-type;
+    		container primary-service-id {
     			description
-    				"Type of the Primary Service Selector identifier.";
+    				"A vid or isid in an I or B component.";
+    			uses service-id;
+    			reference
+      			"IEEE 802.1Q-2017 Clause 12.14.3.1.2a";
     		}
-    		leaf primary-selector {
-    			type service-selector-value;
+    		container associated-service-ids {
     			description
-    				"Primary Service Selector identifier of a Service Instance
-    				with no MA configured.";
-    		}
-    		leaf-list selectors {
-      		type service-selector-value;
-      		description
-      			"A list of VIDs associated with any MHF on the VID, always
+    				"A list of VIDs associated with any MHF on the VID, always
       			including that VID, or the Backbone-SID of the B-component
       			or VIP-SID of the I-component associated with any MHF on
       			the I-SID. The first VID is the MAs Primary VID.
       			
-      			List is empty if no VID specified.";
-      		reference
+      			List is empty if no primary VID specified.";
+    			uses service-id;
+    			reference
       			"IEEE 802.1Q-2017 Clause 12.14.3.1.3a";
-      	}
+    		}
     		leaf md-status {
     			type boolean;
+    			config false;
     			description
-    				"State of this Default MD Level table entry. True if there is
-    				no entry in the Maintenance Association table defining an MA
-    				for the same VLAN ID and MD Level as this tables entry, and
-    				on which MA an Up MEP is defined, else false.";
+    				"State of this Default MD Level table entry. True if there
+    				is no entry in the Maintenance Association table defining
+    				an MA for the same VLAN ID and MD Level as this tables
+    				entry, and on which MA an Up MEP is defined, else false.";
     			reference
     				"IEEE 802.1Q-2017 Clause 12.14.3.1.3b";
     		}
@@ -1432,7 +1517,7 @@ module ieee802-dot1q-cfm {
     				"Enumerated value indicating what, if anything, is to be
     				included in the Sender ID TLV transmitted by MHFs
     				created by the Default Maintenance Domain. If this object
-    				has the value send-if-deferr, Sender ID TLV transmission 
+    				has the value send-if-defer, Sender ID TLV transmission 
     				for this VLAN is controlled by md-id-permission-type. The
     				value of this variable is meaningless if the values of
     				md-status is false.";
@@ -1445,7 +1530,7 @@ module ieee802-dot1q-cfm {
   	container mip {
   		description
   			"Maintenance Association Intermediate Point";
-  		leaf bridge-port {
+  		leaf port {
 				type if:interface-ref;
 				description
 					"The interface index of the interface (i.e., Bridge 
@@ -1453,23 +1538,14 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
 			}
-  		leaf selector-type {
-  			type service-selector-type;
+  		container service-ids {
   			description
-  				"Type of the Service Selector identifier.";
-  		}
-  		leaf-list selectors {
-    		type service-selector-value;
-    		description
-    			"A list of VIDs associated with any MHF on the VID, always
+  				"A list of VIDs associated with any MHF on the VID, always
     			including that VID, or the Backbone-SID of the B-component
     			or VIP-SID of the I-component associated with any MHF on
-    			the I-SID. The first VID is the MAs Primary VID.
-    			
-    			List is empty if no VID specified.";
-    		reference
-    			"IEEE 802.1Q-2017 Clause 12.14.3.1.3a";
-    	}
+    			the I-SID. The first VID is the MAs Primary VID.";
+  			uses service-id;
+  		}
   		leaf md-level {
   			type md-level-type;
   			default 0;
@@ -1481,41 +1557,32 @@ module ieee802-dot1q-cfm {
   			reference
   				"IEEE 802.1Q-2017 Clause 12.14.3.1.3c, 12.14.3.2.2b";
   		}
-  		
-  	}
+  		leaf id-permission {
+  			type sender-id-permission-type;
+  			default "send-id-none";
+  			description
+  				"Enumerated value indicating what, if anything, is to be
+  				included in the Sender ID TLV transmitted by MHFs
+  				created by the Default Maintenance Domain. If this object
+  				has the value send-if-defer, Sender ID TLV transmission 
+  				for this VLAN is controlled by md-id-permission-type.";
+  			reference
+  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3e, 12.14.3.2.2a";
+  		}
+  	} // mip
   	
   	container config-errors {
   		description
   			"The Configuration Error List managed object is a list of
   			{identifier, port} pairs configured in error together with
   			the identity of the configuration error.";
-  		leaf bridge {
-  			type bridge-ref;
-  			description
-  				"A Bridge on which the Configuraton Error is associated
-  				with.";
-  		}
+
   		list config-error {
-  			key "type-of-selector selector bridge-port";
+  			key "port";
   			description
   				"The CFM Configuration Error List table provides a list of
   				Interfaces and VIDs that are incorrectly configured.";
-  			leaf type-of-selector {
-  				type service-selector-type;
-    			description
-    				"Type of the Primary Service Selector identifier.";
-    			reference
-    				"IEEE 802.1Q-2017 Clause 12.14.4.1.2a";
-  			}
-  			leaf selector {
-  				type service-selector-value;
-    			description
-    				"The Service Selector Identifier of the Service with 
-    				interfaces in error.";
-    			reference
-    				"IEEE 802.1Q-2017 Clause 12.14.4.1.2a";
-  			}
-  			leaf bridge-port {
+  			leaf port {
   				type if:interface-ref;
   				description
   					"The interface index of the interface (i.e., Bridge 
@@ -1530,6 +1597,14 @@ module ieee802-dot1q-cfm {
   					interface-ref.";
   				reference
   					"IEEE 802.1Q-2017 Clause 12.14.4.1.2b";
+  			}
+  			container service-id {
+  				description 
+  					"The Service Selector Identifier of the Service with 
+    				interfaces in error.";
+  				uses service-id;
+  				reference
+    				"IEEE 802.1Q-2017 Clause 12.14.4.1.2a";
   			}
   			leaf error-type {
   				type config-errors;
@@ -1550,14 +1625,9 @@ module ieee802-dot1q-cfm {
   			Domain managed object, all Maintenance Association managed
   			objects associated with that Maintenance Domain managed object
   			can be accessed, and thus controlled.";
-  		leaf bridge {
-  			type bridge-ref;
-  			description
-  				"A Bridge on which the given list of MDs is associated
-  				with.";
-  		}
+
   		list maintenance-domain {
-    		key "name-format name";
+    		key "md-index";
     		description
     			"Contains the Maintenance Domain configuration and 
     			operational data. A Maintenance Domain is the network or the
@@ -1566,9 +1636,14 @@ module ieee802-dot1q-cfm {
     			a set of Domain Service Access Points (DoSAPs), each of 
     			which can become a point of connectivity to a service 
     			instance.";
+    		leaf md-index {
+    			type uint32;
+    			description
+    				"The index to the Maintenance Domain list.";
+    		}
     		leaf name-format {
     			type md-name-format-type;
-    			//default "char-string";
+    			default char-string;
     			description
     				"The type (or format) of the Maintenance Domain name.";
     			reference
@@ -1576,20 +1651,15 @@ module ieee802-dot1q-cfm {
     		}
     		leaf name {
     			type md-name-type;
-    			//default "DEFAULT";
+    			default "DEFAULT";
     			description
     				"The Maintenance Domain name. Each Maintenance Domain has a
     				unique name among all those used or available to a service
-    				provider or operator. It facilitates easy idenification
+    				provider or operator. It facilitates easy identification
     				of administrative responsibility for each Maintenance
     				Domain.";
     			reference
     				"IEEE 802.1Q-2017 Clause 3.122, 21.6.5.3";
-    		}
-    		leaf md-index {
-    			type uint32;
-    			description
-    				"The index to the Maintenance Domain list.";
     		}
     		leaf md-level {
     			type md-level-type;
@@ -1606,12 +1676,13 @@ module ieee802-dot1q-cfm {
     				"Value indicating whether the management entity can
     				create MHFs (MIP Half Function) for this Maintenance
     				Domain. Since there is no encompassing Maintenance
-    				Domain, the vlaue mhf-defer is not allowed.";
+    				Domain, the value mhf-defer is not allowed.";
     			reference
     				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
     		}
     		leaf id-permission {
     			type sender-id-permission-type;
+    			default send-id-none;
     			description
     				"Value indicating what, if anything, is to be included in
     				the Sender ID TLV transmitted by Maintenance Points
@@ -1622,7 +1693,7 @@ module ieee802-dot1q-cfm {
     				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3d";
     		}
     		leaf fault-alarm-address {
-    			type fault-alarm-adress-type;
+    			type fault-alarm-address-type;
     			default "not-transmitted";
     			description
     				"A value indicating whether Fault Alarms are to be 
@@ -1632,7 +1703,7 @@ module ieee802-dot1q-cfm {
     		}
     		
     		list maintenance-association {
-    			key "name name-format";
+    			key "ma-index";
     			description
     				"Provides configuration and operational data for the
     				Maintenance Associations. A Maintenance Association is a 
@@ -1641,11 +1712,16 @@ module ieee802-dot1q-cfm {
     				service instance. A Maintenance Association can be thought
     				of as a full mesh of Maintenance Entities among a set of
     				MEPs so configured.";
+    			leaf ma-index {
+    				type uint32;
+    				description 
+    					"Key of the Maintenance Association list of entries.";
+    			}
     			leaf name {
     				type ma-name-type;
     				description
     					"The Short Maintenance Association name. The type/format
-    					is determiend by the value of ma-name-format. This name
+    					is determined by the value of ma-name-format. This name
     					must be unique within a maintenance domain.";
     				reference
     					"IEEE 802.1Q-2017 Clause 21.6.5.6";
@@ -1657,12 +1733,7 @@ module ieee802-dot1q-cfm {
     				reference
     					"IEEE 802.1Q-2017 Clause 21.6.5.4";
     			}
-    			leaf ma-index {
-    				type uint32;
-    				description 
-    					"Key of the Maintenance Association list of entries.";
-    			}
-    			leaf md-reference {
+    			leaf md-index {
     				type uint32;
     				description
     					"An index reference to the Maintenance Domain that this
@@ -1671,7 +1742,8 @@ module ieee802-dot1q-cfm {
     					"IEEE 802.1Q-2017 Clause 12.14.5.3.2a";
     			}
     			leaf ccm-interval {
-    				type ccm-interval-type;
+    				type cfm-interval-type;
+    				default "1sec";
     				description
     					"The interval between CCM transmissions to be used by all
     					MEPs in the Maintenance Association.";
@@ -1679,7 +1751,7 @@ module ieee802-dot1q-cfm {
     					"IEEE 802.1Q-2017 Clause 12.14.6.1.3e";
     			}
     			leaf fault-alarm-address {
-      			type fault-alarm-adress-type;
+      			type fault-alarm-address-type;
       			default "not-specified";
       			description
       				"A value indicating whether Fault Alarms are to be 
@@ -1688,7 +1760,13 @@ module ieee802-dot1q-cfm {
       				used by the MD should be used.";
       			reference
       				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3e";
-      		}
+      		}  				
+  				leaf maintenance-group {
+        		type maintenance-group-type;
+        		description
+        			"The maintenance group provides a handle
+        			for the MD and MA combination.";
+        	}
     			
     			list maintenance-association-component {
     				key ma-component-id;
@@ -1706,32 +1784,8 @@ module ieee802-dot1q-cfm {
     					reference
     						"IEEE 802.1Q-2017 Clause 12.3l";
     				}
-    				leaf maintenance-group {
-          		type maintenance-group-type;
-          		description
-          			"The maintenance group provides an identifier
-          			for the MD and MA combination.";
-          	}
-    				leaf service-selector-type {
-    					type service-selector-type;
+    				container service-id {
     					description
-    						"Type of the Service Selector identifiers. In Services
-    						instances made of multiple Service Selector
-    						identifiers, ensures that the type of the Service 
-    						selector identifiers is the same.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
-    				}
-    				leaf number-of-vids {
-    					type uint32;
-    					description
-    						"The number of VIDs associated with the MA.";
-    					reference
-    						"IEEE 802.1Q-2017 Clause 12.14.6.1.3b";
-    				}
-    				leaf-list selectors {
-      	  		type service-selector-value;
-      	  		description
       	  			"The list of VIDs, I-SID, or the TE-SID monitored by 
       	  			this MA, or 0, if the MA is not attached to a VID, or
       	  			I-SID, or TE-SID. In the case of a list of VIDs, the 
@@ -1739,9 +1793,10 @@ module ieee802-dot1q-cfm {
       	  			none). The specification of I-SID is allowed only in
       	  			the case of I- or B- components. The TE-SID is allowed
       	  			only in the case that PBB-TE is supported.";
+    					uses service-id;
       	  		reference
       	  			"IEEE 802.1Q-2017 Clause 12.14.5.3.2c, 12.14.6.1.3b";
-      	  	}
+    				}
     				leaf mhf-creation {
         			type mhf-creation-type;
         			default mhf-defer;
@@ -1749,7 +1804,7 @@ module ieee802-dot1q-cfm {
         				"Value indicating whether the management entity can
         				create MHFs (MIP Half Function) for this Maintenance
         				Domain. Since there is no encompassing Maintenance
-        				Domain, the vlaue mhf-defer is not allowed.";
+        				Domain, the value mhf-defer is not allowed.";
         			reference
         				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
         		}
@@ -1796,7 +1851,7 @@ module ieee802-dot1q-cfm {
       			"The maintenance group provides an identifier
       			for the MD and MA combination.";
       	}
-  			leaf ma-reference-index {
+  			leaf ma-index {
   				type uint32;
   				description
   					"An index reference to the particular Maintenance
@@ -1804,10 +1859,10 @@ module ieee802-dot1q-cfm {
   				reference
   					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
   			}
-  			leaf bridge-port {
+  			leaf port {
   				type if:interface-ref;
   				description
-  					"The interface index of the interface (i.e., Bridge 
+  					"The interface index of the interface (e.g., Bridge 
   					Port) to which the MEP is attached.";
   				reference
   					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
@@ -1854,15 +1909,6 @@ module ieee802-dot1q-cfm {
   				reference
   					"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
   			}
-  			leaf ccm-enabled {
-  				type boolean;
-  				default "false";
-  				description
-  					"Indicates whether the MEP can generate CCMs. If 
-  					TRUE, the MEP will generate CCM PDUs.";
-  				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
-  			}
   			leaf ccm-ltm-priority {
   				type dot1q-types:priority-type;
   				description
@@ -1875,13 +1921,14 @@ module ieee802-dot1q-cfm {
   			}
   			leaf mac-address {
   				type ieee:mac-address;
+  				config false;
   				description
   					"The MAC address of the MEP.";
   				reference
   					"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
   			}
   			leaf fault-alarm-address {
-    			type fault-alarm-adress-type;
+    			type fault-alarm-address-type;
     			default "not-specified";
     			description
     				"A value indicating whether Fault Alarms are to be 
@@ -1945,7 +1992,7 @@ module ieee802-dot1q-cfm {
   			}
   			leaf error-ccm-last-failure {
   				type string {
-  					length "1..1522";
+  					length "1..2000";
   				}
   				config false;
   				description
@@ -1956,7 +2003,7 @@ module ieee802-dot1q-cfm {
   			}
   			leaf xcon-ccm-last-failure {
   				type string {
-  					length "1..1522";
+  					length "1..2000";
   				}
   				config false;
   				description
@@ -1964,15 +2011,6 @@ module ieee802-dot1q-cfm {
   					fault.";
   				reference
   					"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
-  			}
-  			leaf-list active-rmeps {
-  				type mep-id-type;
-  				description
-  					"A list indicating which of the remote MEPs in the
-  					same MA are active. By default, all configured
-  					remote MEPs in the same MA are active.";
-  				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
   			}
   			
   			list linktrace-reply {
@@ -2071,7 +2109,7 @@ module ieee802-dot1q-cfm {
   					type relay-action-field-value;
   					config false;
   					description
-  						"Value returned in teh Relay Action field.";
+  						"Value returned in the Relay Action field.";
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
   				}  					
@@ -2222,7 +2260,9 @@ module ieee802-dot1q-cfm {
   			list mep-db {
   				key rmep-id;
   				description
-  					"The MEP CCM Database.";
+  					"The MEP CCM Database. A database, maintained by every 
+  					MEP, that maintains received information about other MEPs
+  					in the Maintenance Domain.";
   				leaf rmep-id {
   					type mep-id-type;
   					description
@@ -2252,7 +2292,7 @@ module ieee802-dot1q-cfm {
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
   				}
-  				leaf mep-db-mac-address {
+  				leaf mac-address {
   					type ieee:mac-address;
   					config false;
   					description
@@ -2260,7 +2300,7 @@ module ieee802-dot1q-cfm {
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
   				}
-  				leaf mep-db-rdi {
+  				leaf rdi {
   					type boolean;
   					config false;
   					description
@@ -2270,7 +2310,7 @@ module ieee802-dot1q-cfm {
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
   				}
-  				leaf mep-db-port-status-tlv {
+  				leaf port-status-tlv {
   					type port-status-tlv-value;
   					default "no-port-state-tlv";
   					config false;
@@ -2283,7 +2323,7 @@ module ieee802-dot1q-cfm {
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
   				}
-  				leaf mep-db-interface-status-tlv {
+  				leaf interface-status-tlv {
   					type interface-status-tlv-value;
   					default "is-no-interface-status-tlv";
   					config false;
@@ -2297,7 +2337,7 @@ module ieee802-dot1q-cfm {
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
   				}
-  				leaf mep-db-chassis-id-subtype {
+  				leaf chassis-id-subtype {
   					type lldp-chassis-id-subtype;
   					config false;
   					description
@@ -2306,7 +2346,7 @@ module ieee802-dot1q-cfm {
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
   				}
-  				leaf mep-db-chassis-id {
+  				leaf chassis-id {
   					type lldp-chassis-id;
   					config false;
   					description
@@ -2316,7 +2356,7 @@ module ieee802-dot1q-cfm {
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
   				}
-  				leaf mep-db-man-address-domain {
+  				leaf man-address-domain {
   					type transport-service-domain;
   					config false;
   					description
@@ -2334,7 +2374,7 @@ module ieee802-dot1q-cfm {
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
   						21.6.7";
   				}
-  				leaf mep-db-man-address {
+  				leaf man-address {
   					type transport-service-address;
   					config false;
   					description
@@ -2349,7 +2389,7 @@ module ieee802-dot1q-cfm {
   						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
   						21.6.7";
   				}
-  				leaf mep-db-rmep-is-active {
+  				leaf rmep-is-active {
   					type boolean;
   					description
   						"A Boolean value statign if the remote MEP is 
@@ -2371,7 +2411,7 @@ module ieee802-dot1q-cfm {
   					reference
   						"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
   				}
-  				leaf mep-sent-ccms {
+  				leaf mep-ccms-sent {
   					type yang:counter64;
   					description
   						"Total number of CCMs transmitted";
@@ -2397,7 +2437,7 @@ module ieee802-dot1q-cfm {
   				leaf mep-lbr-bad-msdu {
   					type yang:counter64;
   					description
-  						"The total number of LBRs receivd whose
+  						"The total number of LBRs received whose
   						mac_service_data_unit did not match (except for the
   						OpCode) that of the corresponding LBM.";
   					reference
@@ -2432,18 +2472,16 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
   		}
-  		leaf ma-reference {
-				type uint32;
-				description
-					"An index reference to the particular Maintenance
-					Association that this MEP belongs to.";
-				reference
-					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
-			}
-  		leaf bridge-port {
+  		leaf maintenance-group {
+    		type maintenance-group-type;
+    		description
+    			"The maintenance group provides an identifier
+    			for the MD and MA combination.";
+    	}
+  		leaf port {
 				type if:interface-ref;
 				description
-					"The interface index of the interface (i.e., Bridge 
+					"The interface index of the interface (e.g., Bridge 
 					Port) to which the MEP is attached.";
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
@@ -2468,7 +2506,7 @@ module ieee802-dot1q-cfm {
 					"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
 			}
 			leaf ccm-interval {
-				type ccm-interval-type;
+				type cfm-interval-type;
 				description
 					"The interval between CCM transmissions to be used by all
 					MEPs in the Maintenance Association.";
@@ -2488,18 +2526,16 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
   		}
-  		leaf ma-reference {
-				type uint32;
-				description
-					"An index reference to the particular Maintenance
-					Association that this MEP belongs to.";
-				reference
-					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
-			}
-  		leaf bridge-port {
+  		leaf maintenance-group {
+    		type maintenance-group-type;
+    		description
+    			"The maintenance group provides an identifier
+    			for the MD and MA combination.";
+    	}
+  		leaf port {
 				type if:interface-ref;
 				description
-					"The interface index of the interface (i.e., Bridge 
+					"The interface index of the interface (e.g., Bridge 
 					Port) to which the MEP is attached.";
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
@@ -2515,6 +2551,13 @@ module ieee802-dot1q-cfm {
 					initiator state machine.";
 				reference
 					"IEEE 802.1Q-2017 Clause 20.32, Figure 20-11";
+			}
+  		leaf interval {
+				type cfm-interval-type;
+				default 1sec;
+				description
+					"The interval between LBM transmissions to be used by all
+					MEPs in the Maintenance Association.";
 			}
 			leaf dest-mac-address {
 				type ieee:mac-address;
@@ -2560,7 +2603,7 @@ module ieee802-dot1q-cfm {
 			leaf data-tlv {
 				type string;
 				description
-					"An arbitraty amoun tof data to be included in the
+					"An arbitrary amount of data to be included in the
 					Data TLV, if the Data TLV is selected to be sent. The
 					intent is to be able to fill the frame carrying the
 					CFM PDU to its maximum length.";
@@ -2629,25 +2672,23 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
   		}
-  		leaf ma-reference {
-				type uint32;
-				description
-					"An index reference to the particular Maintenance
-					Association that this MEP belongs to.";
-				reference
-					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
-			}
-  		leaf bridge-port {
+  		leaf maintenance-group {
+    		type maintenance-group-type;
+    		description
+    			"The maintenance group provides an identifier
+    			for the MD and MA combination.";
+    	}
+  		leaf port {
 				type if:interface-ref;
 				description
-					"The interface index of the interface (i.e., Bridge 
+					"The interface index of the interface (e.g., Bridge 
 					Port) to which the MEP is attached.";
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
 			}
   		leaf status {
 				type boolean;
-				default "true";
+				default "false";
 				description
 					"A Boolean flag set to TRUE by the Bridge Port to 
 					indicate that another LTM may be transmitted. Reset
@@ -2655,6 +2696,13 @@ module ieee802-dot1q-cfm {
 					machine.";
 				reference
 					"IEEE 802.1Q-2017 Clause 20.49, Figure 20-17";
+			}
+  		leaf interval {
+				type cfm-interval-type;
+				default 1sec;
+				description
+					"The interval between LTM transmissions to be used by all
+					MEPs in the Maintenance Association.";
 			}
   		leaf priority {
 				type dot1q-types:priority-type;
@@ -2689,7 +2737,7 @@ module ieee802-dot1q-cfm {
 				type mep-id-or-zero-type;
 				description
 					"The target MAC address field to be transmitted. The
-					MEP identifier of another MEP in teh same MA. This
+					MEP identifier of another MEP in the same MA. This
 					address will be used if the value of 
 					mep-transmit-ltm-target-is-mep-id is TRUE.";
 				reference
@@ -2699,7 +2747,7 @@ module ieee802-dot1q-cfm {
 				type boolean;
 				default "false";
 				description
-					"TRUE indicates taht MEP id of the target MEP is used
+					"TRUE indicates that MEP id of the target MEP is used
 					for Linktrace transmission. FALSE indicates that
 					unicast destination MAC address of the target MEP is
 					used for LinkTrace transmission.";
@@ -2812,6 +2860,13 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
   		}
+  		leaf interval {
+				type cfm-interval-type;
+				default 1sec;
+				description
+					"The interval between LBM transmissions to be used by all
+					MEPs in the Maintenance Association.";
+			}
   		leaf mep-transmit-lbm-dest-mac-address {
 				type ieee:mac-address;
 				description
@@ -2855,7 +2910,7 @@ module ieee802-dot1q-cfm {
 			leaf mep-transmit-lbm-data-tlv {
 				type string;
 				description
-					"An arbitraty amount of data to be included in the
+					"An arbitrary amount of data to be included in the
 					Data TLV, if the Data TLV is selected to be sent. The
 					intent is to be able to fill the frame carrying the
 					CFM PDU to its maximum length.";
@@ -2924,6 +2979,13 @@ module ieee802-dot1q-cfm {
 				reference
 					"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
   		}
+  		leaf interval {
+				type cfm-interval-type;
+				default 1sec;
+				description
+					"The interval between LTM transmissions to be used by all
+					MEPs in the Maintenance Association.";
+			}
   		leaf mep-transmit-ltm-flags {
 				type mep-tx-ltm-flags-type;
 				default use-fdb-only;
@@ -2946,7 +3008,7 @@ module ieee802-dot1q-cfm {
 				type mep-id-or-zero-type;
 				description
 					"The target MAC address field to be transmitted. The
-					MEP identifier of another MEP in teh same MA. This
+					MEP identifier of another MEP in the same MA. This
 					address will be used if the value of 
 					mep-transmit-ltm-target-is-mep-id is TRUE.";
 				reference
@@ -2956,7 +3018,7 @@ module ieee802-dot1q-cfm {
 				type boolean;
 				default "false";
 				description
-					"TRUE indicates taht MEP id of the target MEP is used
+					"TRUE indicates that MEP id of the target MEP is used
 					for Linktrace transmission. FALSE indicates that
 					unicast destination MAC address of the target MEP is
 					used for LinkTrace transmission.";
@@ -3056,7 +3118,7 @@ module ieee802-dot1q-cfm {
 			description
 				"The Maintenance Domain name. Each Maintenance Domain has a
 				unique name among all those used or available to a service
-				provider or operator. It facilitates easy idenification
+				provider or operator. It facilitates easy identification
 				of administrative responsibility for each Maintenance
 				Domain.";
 			reference
@@ -3079,7 +3141,7 @@ module ieee802-dot1q-cfm {
 			}
 			description
 				"The Short Maintenance Association name. The type/format
-				is determiend by the value of ma-name-format. This name
+				is determined by the value of ma-name-format. This name
 				must be unique within a maintenance domain.";
 			reference
 				"IEEE 802.1Q-2017 Clause 21.6.5.6";
@@ -3110,7 +3172,7 @@ module ieee802-dot1q-cfm {
 			}
 			description
 				"The highest priority defect that has been present
-				sicne the MEPs Fault Notification Generator state
+				since the MEPs Fault Notification Generator state
 				machine was last in the FNG_RESET state.";
 		}
 	} // mep-fault-alarm


### PR DESCRIPTION
Still clean compile.

**ieee802-dot1q-cfm.yang**

Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"

Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw (device-reference)?
       |  +--:(bridge)
       |     +--rw bridge-ref?            bridge-ref
       +--rw cfm-stacks
       |  +--rw cfm-stack* [port md-level direction]
       |     +--rw port                             if:interface-ref
       |     +--rw md-level                         md-level-type
       |     +--rw direction                        mp-direction-type
       |     +--rw service-id
       |     |  +--rw (service-id)?
       |     |     +--:(none)
       |     |     |  +--rw zero?         uint32
       |     |     +--:(vid)
       |     |     |  +--rw vid*          dot1q-types:vlanid
       |     |     +--:(isid)
       |     |     |  +--rw isid?         uint32
       |     |     +--:(tesid)
       |     |     |  +--rw tesid?        uint32
       |     |     +--:(segid)
       |     |     |  +--rw segid?        uint32
       |     |     +--:(path-tesid)
       |     |     |  +--rw path-tesid?   uint32
       |     |     +--:(group-isid)
       |     |        +--rw group-isid?   uint32
       |     +--ro maintenance-group?               maintenance-group-type
       |     +--ro maintenance-domain-index?        uint32
       |     +--ro maintenance-association-index?   uint32
       |     +--ro mep-id?                          mep-id-or-zero-type
       |     +--ro mac-address?                     ieee:mac-address
       +--rw default-md-levels
       |  +--rw default-md-level* [component-id]
       |     +--rw component-id              component-identifier-type
       |     +--rw primary-service-id
       |     |  +--rw (service-id)?
       |     |     +--:(none)
       |     |     |  +--rw zero?         uint32
       |     |     +--:(vid)
       |     |     |  +--rw vid*          dot1q-types:vlanid
       |     |     +--:(isid)
       |     |     |  +--rw isid?         uint32
       |     |     +--:(tesid)
       |     |     |  +--rw tesid?        uint32
       |     |     +--:(segid)
       |     |     |  +--rw segid?        uint32
       |     |     +--:(path-tesid)
       |     |     |  +--rw path-tesid?   uint32
       |     |     +--:(group-isid)
       |     |        +--rw group-isid?   uint32
       |     +--rw associated-service-ids
       |     |  +--rw (service-id)?
       |     |     +--:(none)
       |     |     |  +--rw zero?         uint32
       |     |     +--:(vid)
       |     |     |  +--rw vid*          dot1q-types:vlanid
       |     |     +--:(isid)
       |     |     |  +--rw isid?         uint32
       |     |     +--:(tesid)
       |     |     |  +--rw tesid?        uint32
       |     |     +--:(segid)
       |     |     |  +--rw segid?        uint32
       |     |     +--:(path-tesid)
       |     |     |  +--rw path-tesid?   uint32
       |     |     +--:(group-isid)
       |     |        +--rw group-isid?   uint32
       |     +--ro md-status?                boolean
       |     +--rw md-level?                 md-level-or-none-type
       |     +--rw mhf-creation?             mhf-creation-type
       |     +--rw id-permission?            sender-id-permission-type
       +--rw mip
       |  +--rw port?            if:interface-ref
       |  +--rw service-ids
       |  |  +--rw (service-id)?
       |  |     +--:(none)
       |  |     |  +--rw zero?         uint32
       |  |     +--:(vid)
       |  |     |  +--rw vid*          dot1q-types:vlanid
       |  |     +--:(isid)
       |  |     |  +--rw isid?         uint32
       |  |     +--:(tesid)
       |  |     |  +--rw tesid?        uint32
       |  |     +--:(segid)
       |  |     |  +--rw segid?        uint32
       |  |     +--:(path-tesid)
       |  |     |  +--rw path-tesid?   uint32
       |  |     +--:(group-isid)
       |  |        +--rw group-isid?   uint32
       |  +--rw md-level?        md-level-type
       |  +--rw id-permission?   sender-id-permission-type
       +--rw config-errors
       |  +--rw config-error* [port]
       |     +--rw port          if:interface-ref
       |     +--rw service-id
       |     |  +--rw (service-id)?
       |     |     +--:(none)
       |     |     |  +--rw zero?         uint32
       |     |     +--:(vid)
       |     |     |  +--rw vid*          dot1q-types:vlanid
       |     |     +--:(isid)
       |     |     |  +--rw isid?         uint32
       |     |     +--:(tesid)
       |     |     |  +--rw tesid?        uint32
       |     |     +--:(segid)
       |     |     |  +--rw segid?        uint32
       |     |     +--:(path-tesid)
       |     |     |  +--rw path-tesid?   uint32
       |     |     +--:(group-isid)
       |     |        +--rw group-isid?   uint32
       |     +--ro error-type?   config-errors
       +--rw maintenance-domains
       |  +--rw maintenance-domain* [md-index]
       |     +--rw md-index                   uint32
       |     +--rw name-format?               md-name-format-type
       |     +--rw name?                      md-name-type
       |     +--rw md-level?                  md-level-type
       |     +--rw mhf-creation?              mhf-creation-type
       |     +--rw id-permission?             sender-id-permission-type
       |     +--rw fault-alarm-address?       fault-alarm-address-type
       |     +--rw maintenance-association* [ma-index]
       |        +--rw ma-index                             uint32
       |        +--rw name?                                ma-name-type
       |        +--rw name-format?                         ma-name-format-type
       |        +--rw md-index?                            uint32
       |        +--rw ccm-interval?                        cfm-interval-type
       |        +--rw fault-alarm-address?                 fault-alarm-address-type
       |        +--rw maintenance-group?                   maintenance-group-type
       |        +--rw maintenance-association-component* [ma-component-id]
       |           +--rw ma-component-id    component-identifier-type
       |           +--rw service-id
       |           |  +--rw (service-id)?
       |           |     +--:(none)
       |           |     |  +--rw zero?         uint32
       |           |     +--:(vid)
       |           |     |  +--rw vid*          dot1q-types:vlanid
       |           |     +--:(isid)
       |           |     |  +--rw isid?         uint32
       |           |     +--:(tesid)
       |           |     |  +--rw tesid?        uint32
       |           |     +--:(segid)
       |           |     |  +--rw segid?        uint32
       |           |     +--:(path-tesid)
       |           |     |  +--rw path-tesid?   uint32
       |           |     +--:(group-isid)
       |           |        +--rw group-isid?   uint32
       |           +--rw mhf-creation?      mhf-creation-type
       |           +--rw id-permission?     sender-id-permission-type
       +--rw meps
       |  +--rw mep* [mep-id maintenance-group]
       |     +--rw mep-id                     mep-id-type
       |     +--rw maintenance-group          maintenance-group-type
       |     +--rw ma-index?                  uint32
       |     +--rw port?                      if:interface-ref
       |     +--rw direction?                 mp-direction-type
       |     +--rw primary-vid?               uint32
       |     +--rw admin-state?               boolean
       |     +--ro fng-state?                 fng-state-type
       |     +--rw ccm-ltm-priority?          dot1q-types:priority-type
       |     +--ro mac-address?               ieee:mac-address
       |     +--rw fault-alarm-address?       fault-alarm-address-type
       |     +--rw lowest-priority-defect?    lowest-alarm-priority-type
       |     +--rw fng-alarm-time?            yang:zero-based-counter32
       |     +--rw fng-reset-time?            yang:zero-based-counter32
       |     +--ro highest-priority-defect?   highest-defect-priority-type
       |     +--ro defects?                   mep-defects-type
       |     +--ro error-ccm-last-failure?    string
       |     +--ro xcon-ccm-last-failure?     string
       |     +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
       |     |  +--rw ltr-seq-number                   uint32
       |     |  +--rw ltr-receive-order                uint32
       |     |  +--ro ltr-ttl?                         uint32
       |     |  +--ro ltr-forwarded?                   boolean
       |     |  +--ro ltr-terminal-mep?                boolean
       |     |  +--ro ltr-last-egress-identifier?      string
       |     |  +--ro ltr-next-egress-identifier?      string
       |     |  +--ro ltr-relay?                       relay-action-field-value
       |     |  +--ro ltr-chassis-id-subtype?          lldp-chassis-id-subtype
       |     |  +--ro ltr-chassis-id?                  lldp-chassis-id
       |     |  +--ro ltr-man-address-domain?          transport-service-domain
       |     |  +--ro ltr-man-address?                 transport-service-address
       |     |  +--ro ltr-ingress?                     ingress-action-field-value
       |     |  +--ro ltr-ingress-mac?                 ieee:mac-address
       |     |  +--ro ltr-ingress-port-id-subtype?     lldp-port-id-subtype
       |     |  +--ro ltr-egress?                      egress-action-field-value
       |     |  +--ro ltr-egress-mac?                  ieee:mac-address
       |     |  +--ro ltr-egress-port-id-subtype?      lldp-port-id-subtype
       |     |  +--ro ltr-egress-port-id?              lldp-port-id
       |     |  +--ro ltr-organization-specific-tlv?   string
       |     +--rw mep-db* [rmep-id]
       |     |  +--rw rmep-id                 mep-id-type
       |     |  +--ro rmep-state?             remote-mep-state-type
       |     |  +--ro rmep-failed-ok-time?    yang:zero-based-counter32
       |     |  +--ro mac-address?            ieee:mac-address
       |     |  +--ro rdi?                    boolean
       |     |  +--ro port-status-tlv?        port-status-tlv-value
       |     |  +--ro interface-status-tlv?   interface-status-tlv-value
       |     |  +--ro chassis-id-subtype?     lldp-chassis-id-subtype
       |     |  +--ro chassis-id?             lldp-chassis-id
       |     |  +--ro man-address-domain?     transport-service-domain
       |     |  +--ro man-address?            transport-service-address
       |     |  +--rw rmep-is-active?         boolean
       |     +--ro stats
       |        +--ro mep-ccm-sequence-errors?   yang:counter64
       |        +--ro mep-ccms-sent?             yang:counter64
       |        +--ro mep-lbr-in?                yang:counter64
       |        +--ro mep-lbr-in-out-of-order?   yang:counter64
       |        +--ro mep-lbr-bad-msdu?          yang:counter64
       |        +--ro mep-unexpected-ltr-in?     yang:counter64
       |        +--ro mep-lbr-out?               yang:counter64
       +--rw continuity-check
       |  +--rw mep?                 mep-id-type
       |  +--rw maintenance-group?   maintenance-group-type
       |  +--rw port?                if:interface-ref
       |  +--rw ccm-enabled?         boolean
       |  +--rw priority?            dot1q-types:priority-type
       |  +--rw ccm-interval?        cfm-interval-type
       +--rw loopback
       |  +--rw mep?                  mep-id-type
       |  +--rw maintenance-group?    maintenance-group-type
       |  +--rw port?                 if:interface-ref
       |  +--rw status?               boolean
       |  +--rw interval?             cfm-interval-type
       |  +--rw dest-mac-address?     ieee:mac-address
       |  +--rw dest-mep-id?          mep-id-or-zero-type
       |  +--rw dest-is-mep-id?       boolean
       |  +--rw message-count?        uint32
       |  +--rw data-tlv?             string
       |  +--rw priority?             dot1q-types:priority-type
       |  +--rw vlan-drop-eligible?   boolean
       |  +--ro result-ok?            boolean
       |  +--rw seq-number?           uint32
       |  +--ro next-lbm-trans-id?    uint32
       +--rw linktrace
          +--rw mep?                  mep-id-type
          +--rw maintenance-group?    maintenance-group-type
          +--rw port?                 if:interface-ref
          +--rw status?               boolean
          +--rw interval?             cfm-interval-type
          +--rw priority?             dot1q-types:priority-type
          +--rw flags?                mep-tx-ltm-flags-type
          +--rw target-mac-address?   ieee:mac-address
          +--rw target-mep-id?        mep-id-or-zero-type
          +--rw target-is-mep-id?     boolean
          +--rw ttl?                  uint32
          +--ro result?               boolean
          +--ro seq-number?           uint32
          +--ro egress-identifier?    string
          +--ro next-seq-number?      uint32

  rpcs:
    +---x transmit-loopback-message
    |  +---w input
    |  |  +---w maintenance-group?                     maintenance-group-type
    |  |  +---w mep-id?                                mep-id-type
    |  |  +---w interval?                              cfm-interval-type
    |  |  +---w mep-transmit-lbm-dest-mac-address?     ieee:mac-address
    |  |  +---w mep-transmit-lbm-dest-mep-id?          mep-id-or-zero-type
    |  |  +---w mep-transmit-lbm-dest-is-mep-id?       boolean
    |  |  +---w mep-transmit-lbm-messages?             uint32
    |  |  +---w mep-transmit-lbm-data-tlv?             string
    |  |  +---w mep-transmit-lbm-vlan-priority?        dot1q-types:priority-type
    |  |  +---w mep-transmit-lbm-vlan-drop-eligible?   boolean
    |  +--ro output
    |     +--ro mep-transmit-lbm-result-ok?    boolean
    |     +--ro mep-transmit-lbm-seq-number?   uint32
    +---x transmit-linktrace-message
       +---w input
       |  +---w maintenance-group?                     maintenance-group-type
       |  +---w mep-id?                                mep-id-type
       |  +---w interval?                              cfm-interval-type
       |  +---w mep-transmit-ltm-flags?                mep-tx-ltm-flags-type
       |  +---w mep-transmit-ltm-target-mac-address?   ieee:mac-address
       |  +---w mep-transmit-ltm-target-mep-id?        mep-id-or-zero-type
       |  +---w mep-transmit-ltm-target-is-mep-id?     boolean
       |  +---w mep-transmit-ltm-ttl?                  uint32
       +--ro output
          +--ro mep-transmit-ltm-result?              boolean
          +--ro mep-transmit-ltm-seq-number?          uint32
          +--ro mep-transmit-ltm-egress-identifier?   string

  notifications:
    +---n mep-fault-alarm
       +--ro maintenance-group?     maintenance-group-type
       +--ro md-name?               -> /cfm/maintenance-domains/maintenance-domain/name
       +--ro md-name-format?        -> /cfm/maintenance-domains/maintenance-domain/name-format
       +--ro ma-name?               -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name
       +--ro ma-name-format?        -> /cfm/maintenance-domains/maintenance-domain/maintenance-association/name-format
       +--ro mep-id?                -> /cfm/meps/mep/mep-id
       +--ro mep-priority-defect?   -> /cfm/meps/mep/highest-priority-defect

Confdc Output
No warnings or errors

yanglint Validation
No warnings or errors
