### PR TITLE
802.1Qcp YANG modules for Sponsor Ballot

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
@@ -1,21 +1,27 @@
 module ieee802-dot1q-bridge {
-
-  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-bridge";
-  prefix "dot1q";
-
-  import ieee802-types { prefix "ieee"; }
-  import ietf-yang-types { prefix "yang"; }
-  import ietf-interfaces { prefix "if"; }
-  import iana-if-type { prefix "ianaif"; }
-  import ieee802-dot1q-types { prefix "dot1qtypes"; }
-
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-bridge;
+  prefix dot1q;
+  import ieee802-types {
+    prefix ieee;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
+  import iana-if-type {
+    prefix ianaif;
+  }
+  import ieee802-dot1q-types {
+    prefix dot1qtypes;
+  }
   organization
-    "Institute of Electrical and Electronics Engineers";
-
+    "IEEE 802.1 Working Group";
   contact
-  	"WG-URL: http://grouper.ieee.org/groups/802/1/
-    WG-EMail: stds-802-1@ieee.org
-
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+    
     Contact: IEEE 802.1 Working Group Chair
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
@@ -24,28 +30,94 @@ module ieee802-dot1q-bridge {
             Piscataway
             NJ 08855-1331
             USA
- 	
-    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
-
+    
+    E-mail: STDS-802-1-L@IEEE.ORG";
   description
-    "This YANG module describes the bridge configuration model for
-    the following IEEE 802.1Q Bridges:
-      1. Two Port MAC Relay Bridges
-      2. Customer VLAN Bridges
-      3. Provider Bridges.";
- 
-  revision 2017-09-07 {
+    "This YANG module describes the bridge configuration model for the
+    following IEEE 802.1Q Bridges: 
+  	  1) Two Port MAC Relays
+  	  2) Customer VLAN Bridges
+  	  3) Provider Bridges.";
+  revision 2018-03-07 {
     description
-      "Updates based upon comment resolution on draft
-      D1.2 of P802.1Qcp.";
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
     reference
-      "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
-      Virtual Bridged Local Area Networks.";
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
-
-  /*
-  * IEEE 802.1Q Bridge Type identities.
-  */
+  
+  feature ingress-filtering {
+    description
+      "Each Port may support an Enable Ingress Filtering parameter. A
+      frame received on a Port that is not in the member set (8.8.10)
+      associated with the frames VID shall be discarded if this
+      parameter is set. The default value for this parameter is reset,
+      i.e., Disable Ingress Filtering, for all Ports. Any Port that
+      supports setting this parameter shall also support resetting it.
+      The parameter may be configured by the management operations
+      defined in Clause 12.";
+    reference
+      "8.6.2 of IEEE Std 802.1Q-2018";
+  }
+  feature extended-filtering-services {
+    description
+      "Extended Filtering Services support the filtering behavior
+      required for regions of a network in which potential recipients
+      of multicast frames exist, and where both the potential
+      recipients of frames and the Bridges are able to support dynamic
+      configuration of filtering information for group MAC addresses.
+      In order to integrate this extended filtering behavior with the
+      needs of regions of the network that support only Basic
+      Filtering Services, Bridges that support Extended Filtering
+      Services can be statically and dynamically configured to modify
+      their filtering behavior on a per-group MAC address basis, and
+      also on the basis of the overall filtering service provided by
+      each outbound Port with regard to multicast frames. The latter
+      capability permits configuration of the Ports default forwarding
+      or filtering behavior with regard to group MAC addresses for
+      which no specific static or dynamic filtering information has
+      been configured.";
+    reference
+      "8.8.4 of IEEE Std 802.1Q-2018
+      Clause 10 of IEEE Std 802.1Q-2018";
+  }
+  feature port-and-protocol-based-vlan {
+    description
+      "A VLAN-aware bridge component implementation in conformance to
+      the provisions of this standard for Port-and-Protocol-based VLAN
+      classification (5.4.1) shall 1) Support one or more of the
+      following Protocol Classifications and Protocol Template
+      formats: Ethernet, RFC_1042, SNAP_8021H, SNAP_Other, or
+      LLC_Other (6.12); and may 2) Support configuration of the
+      contents of the Protocol Group Database.";
+    reference
+      "5.4.1.2 of IEEE Std 802.1Q-2018";
+  }
+  feature flow-filtering {
+    description
+      "Flow filtering support enables Bridges to distinguish frames
+      belonging to different client flows and to use this information
+      in the forwarding process. Information related to client flows
+      may be used at the boundary of an SPT Domain to generate a flow
+      hash value. The flow hash, carried in an F-TAG, serves to
+      distinguish frames belonging to different flows and can be used
+      in the forwarding process to distribute frames over equal cost
+      paths. This provides for finer granularity load spreading while
+      maintaining frame order for each client flow.";
+    reference
+      "44.2 of IEEE Std 802.1Q-2018";
+  }
+  feature simple-bridge-port {
+    description
+      "A simple bridge port allows underlying (MAC) layers to share
+      the same Interface as the Bridge Port.";
+  }
+  feature flexible-bridge-port {
+    description
+      "A flexible bridge port supports an Interface that is a Bridge
+      Port to be a separate Interface from the underlying (MAC) layer.";
+  }
+  
   identity type-of-bridge {
     description
       "Represents the configured Bridge type.";
@@ -68,12 +140,8 @@ module ieee802-dot1q-bridge {
   identity two-port-mac-relay-bridge {
     base type-of-bridge;
     description
-      "Base identity for a Two Port MAC Relay (TPMR) Bridge.";
+      "Base identity for a Two Port MAC Relay (TPMR).";
   }
-
-  /*
-   * IEEE 802.1Q Bridge Component identities.
-   */
   identity type-of-component {
     description
       "Represents the type of Component.";
@@ -98,10 +166,6 @@ module ieee802-dot1q-bridge {
     description
       "Base identity for an EVB station ER component.";
   }
-
-  /*
-   * IEEE 802.1Q Bridge Port Type identities.
-   */
   identity type-of-port {
     description
       "Represents the type of Bridge port.";
@@ -116,9 +180,9 @@ module ieee802-dot1q-bridge {
     base type-of-port;
     description
       "Indicates the port can be an S-TAG aware port of a Provider
-      Bridge or Backbone Edge Bridge used for connections within a
-      PBN (Provider Bridged Network) or PBBN (Provider Backbone
-    	Bridged Network).";
+      Bridge or Backbone Edge Bridge used for connections within a PBN
+      (Provider Bridged Network) or PBBN (Provider Backbone Bridged
+      Network).";
   }
   identity customer-network-port {
     base type-of-port;
@@ -126,15 +190,14 @@ module ieee802-dot1q-bridge {
       "Indicates the port can be an S-TAG aware port of a Provider
       Bridge or Backbone Edge Bridge used for connections to the
       exterior of a PBN (Provider Bridged Network) or PBBN (Provider
-    	Backbone Bridged Network).";
+      Backbone Bridged Network).";
   }
   identity customer-edge-port {
     base type-of-port;
     description
       "Indicates the port can be a C-TAG aware port of a Provider
-      Bridge used for connections to the exterior of a PBN
-    	(Provider Bridged Network) or PBBN (Provider Backbone Bridged
-    	Network).";
+      Bridge used for connections to the exterior of a PBN (Provider
+      Bridged Network) or PBBN (Provider Backbone Bridged Network).";
   }
   identity d-bridge-port {
     base type-of-port;
@@ -146,13 +209,8 @@ module ieee802-dot1q-bridge {
     base type-of-port;
     description
       "Indicates the port can be an S-TAG aware port of a Provider
-      Bridge capable of providing Remote Customer Service
-      Interfaces.";
+      Bridge capable of providing Remote Customer Service Interfaces.";
   }
-
-  /*
-   * Generic bridge Interface
-   */
   identity bridge-interface {
     description
       "Generic interface property that represents any interface that
@@ -161,89 +219,12 @@ module ieee802-dot1q-bridge {
       identity to automatically pick up Bridge related configuration
       or operational data.";
   }
-
-  /*
-   * IEEE 802.1Q Bridge features.
-   */
-
-  feature ingress-filtering {
-    description
-      "Each Port may support an Enable Ingress Filtering parameter.
-      A frame received on a Port that is not in the member set
-      (8.8.10) associated with the frames VID shall be discarded if
-      this parameter is set. The default value for this parameter is
-      reset, i.e., Disable Ingress Filtering, for all Ports. Any
-      Port that supports setting this parameter shall also support
-      resetting it. The parameter may be configured by the
-      management operations defined in Clause 12.";
-    reference
-      "IEEE 802.1Q-2017 Clause 8.6.2";
-  }
-  feature extended-filtering-services {
-    description
-      "Extended Filtering Services support the filtering behavior
-      required for regions of a network in which potential recipients
-      of multicast frames exist, and where both the potential
-      recipients of frames and the Bridges are able to support
-      dynamic configuration of filtering information for group MAC
-      addresses. In order to integrate this extended filtering
-      behavior with the needs of regions of the network that support
-      only Basic Filtering Services, Bridges that support Extended
-      Filtering Services can be statically and dynamically configured
-      to modify their filtering behavior on a per-group MAC address
-      basis, and also on the basis of the overall filtering service
-      provided by each outbound Port with regard to multicast
-      frames. The latter capability permits configuration of the
-      Ports default forwarding or filtering behavior with regard to
-      group MAC addresses for which no specific static or dynamic
-      filtering information has been configured.";
-    reference
-      "IEEE 802.1Q-2017 Clause 8.8.4, Clause 10";
-  }
-  feature port-and-protocol-based-vlan {
-    description
-      "A VLAN-aware bridge component implementation in conformance to
-      the provisions of this standard for Port-and-Protocol-based
-      VLAN classification (5.4.1) shall 1) Support one or more of
-      the following Protocol Classifications and Protocol Template
-      formats: Ethernet, RFC_1042, SNAP_8021H, SNAP_Other, or
-      LLC_Other (6.12); and may 2) Support configuration of the
-      contents of the Protocol Group Database.";
-    reference
-      "IEEE 802.1Q-2017 Clause 5.4.1.2";
-  }
-  feature flow-filtering {
-    description
-      "Flow filtering support enables Bridges to distinguish frames
-      belonging to different client flows and to use this
-      information in the forwarding process. Information related to
-      client flows may be used at the boundary of an SPT Domain to
-      generate a flow hash value. The flow hash, carried in an F-TAG,
-      serves to distinguish frames belonging to different flows and
-      can be used in the forwarding process to distribute frames
-      over equal cost paths. This provides for finer granularity
-      load spreading while maintaining frame order for each client
-      flow.";
-    reference
-      "IEEE 802.1Q-2017 Clause 44.2";
-  }
-  feature simple-bridge-port {
-    description
-      "A simple bridge port allows underlying (MAC) layers to share
-      the same Interface as the Bridge Port.";
-  }
-  feature flexible-bridge-port {
-    description
-      "A flexible bridge port supports an Interface that is a Bridge
-      Port to be a separate Interface from the underlying (MAC)
-      layer.";
-  }
-
+   
   container bridges {
     description
       "Contains the Bridge(s) configuration information.";
     list bridge {
-      key name;
+      key "name";
       unique "address";
       description
         "Provides configuration data in support of the Bridge
@@ -255,7 +236,7 @@ module ieee802-dot1q-bridge {
           "A text string associated with the Bridge, of locally
           determined significance.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.4";
+          "12.4 of IEEE Std 802.1Q-2018";
       }
       leaf address {
         type ieee:mac-address;
@@ -264,7 +245,7 @@ module ieee802-dot1q-bridge {
           "The MAC address for the Bridge from which the Bridge
           Identifiers used by the STP, RSTP, and MSTP are derived.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.4";
+          "12.4 of IEEE Std 802.1Q-2018";
       }
       leaf bridge-type {
         type identityref {
@@ -274,45 +255,43 @@ module ieee802-dot1q-bridge {
         description
           "The type of Bridge.";
       }
-	    leaf ports {
-	    	type uint16 {
-	        range "1..4095";
-	      }
-	    	config false;
-	      description
-	        "The number of Bridge Ports (MAC Entities)";
-	      reference
-	        "IEEE 802.1Q-2017 Clause 12.4";
-	    }
-	    leaf up-time {
-	      type yang:zero-based-counter32;
-	      units seconds;
-	      config false;
-	      description
-	        "The count in seconds of the time elapsed since the Bridge
-	        was last reset or initialized.";
-	      reference
-	        "IEEE 802.1Q-2017 Clause 12.4";
-	    }
-	    leaf components {
-	      type uint32;
-	      config false;
-	      description
-	        "The number of components associated with the Bridge.";
-	    }
+      leaf ports {
+        type uint16 {
+          range "1..4095";
+        }
+        config false;
+        description
+          "The number of Bridge Ports (MAC Entities)";
+        reference
+          "12.4 of IEEE Std 802.1Q-2018";
+      }
+      leaf up-time {
+        type yang:zero-based-counter32;
+        units "seconds";
+        config false;
+        description
+          "The count in seconds of the time elapsed since the Bridge
+          was last reset or initialized.";
+        reference
+          "12.4 of IEEE Std 802.1Q-2018";
+      }
+      leaf components {
+        type uint32;
+        config false;
+        description
+          "The number of components associated with the Bridge.";
+      }
       list component {
         key "name";
         description
-          "The set of components associated with a given Bridge.
-          For example,
-             - A TPMR Bridge is associated with a single VLAN
-               unaware component.
-             - A Customer VLAN Bridge is associated with a single
-               VLAN aware component.
-             - A Provider Bridge is associated with a single S-VLAN
-               component and zero or more C-VLAN components.";
+          "The set of components associated with a given Bridge. For
+          example, - A TPMR is associated with a single VLAN
+          unaware component. - A Customer VLAN Bridge is associated
+          with a single VLAN aware component. - A Provider Bridge is
+          associated with a single S-VLAN component and zero or more
+          C-VLAN components.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.3";
+          "12.3 of IEEE Std 802.1Q-2018";
         leaf name {
           type string;
           description
@@ -324,7 +303,7 @@ module ieee802-dot1q-bridge {
             "Unique identifier for a particular Bridge component
             within the system.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.3 l)";
+            "12.3, item l) of IEEE Std 802.1Q-2018";
         }
         leaf type {
           type identityref {
@@ -336,7 +315,7 @@ module ieee802-dot1q-bridge {
             Bridge component within a Bridge system comprising
             multiple components.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.3 m)";
+            "12.3, item m) of IEEE Std 802.1Q-2018";
         }
         leaf address {
           type ieee:mac-address;
@@ -344,31 +323,31 @@ module ieee802-dot1q-bridge {
             "Unique EUI-48 Universally Administered MAC address
             assigned to a Bridge component.";
           reference
-            "IEEE 802.1Q-2017 Clause 8.13.8, 13.24";
+            "13.24 of IEEE Std 802.1Q-2018
+            8.13.8 of IEEE Std 802.1Q-2018";
         }
         leaf traffic-class-enabled {
           type boolean;
           default "true";
           description
-            "Indication of Traffic Classes enablement associated
-            with the Bridge Component. A value of True indicates
-            that Traffic Classes are enabled on this Bridge
-            Component. A value of False indicates that the Bridge
-            Component operates with a single priority level for all
-            traffic.";
+            "Indication of Traffic Classes enablement associated with
+            the Bridge Component. A value of True indicates that
+            Traffic Classes are enabled on this Bridge Component. A
+            value of False indicates that the Bridge Component
+            operates with a single priority level for all traffic.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.4.1.5.1";
+            "12.4.1.5.1 of IEEE Std 802.1Q-2018";
         }
         leaf ports {
-        	type uint16 {
+          type uint16 {
             range "1..4095";
           }
-        	config false;
+          config false;
           description
             "The number of Bridge Ports associated with the Bridge
             Component.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.4.1.1.3 c)";
+            "12.4.1.1.3, item c) of IEEE Std 802.1Q-2018";
         }
         leaf-list bridge-port {
           type if:interface-ref;
@@ -377,20 +356,21 @@ module ieee802-dot1q-bridge {
             "List of bridge-port references.";
         }
         container capabilities {
-        	config false;
+          config false;
           description
             "Array of Boolean values of the feature capabilities
             associated with a given Bridge Component.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.4.1.5.2, 12.10.1.1.3 b)";
+            "12.10.1.1.3, item b) of IEEE Std 802.1Q-2018
+            12.4.1.5.2 of IEEE Std 802.1Q-2018";
           leaf extended-filtering {
             type boolean;
             default "false";
             description
-              "Can perform filtering on individual multicast
-              addresses controlled by MMRP.";
+              "Can perform filtering on individual multicast addresses
+              controlled by MMRP.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.4.1.5.2";
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
           }
           leaf traffic-classes {
             type boolean;
@@ -398,7 +378,7 @@ module ieee802-dot1q-bridge {
             description
               "Can map priority to multiple traffic classes.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.4.1.5.2";
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
           }
           leaf static-entry-individual-port {
             type boolean;
@@ -406,7 +386,7 @@ module ieee802-dot1q-bridge {
             description
               "Static entries per port.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.4.1.5.2";
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
           }
           leaf ivl-capable {
             type boolean;
@@ -414,7 +394,7 @@ module ieee802-dot1q-bridge {
             description
               "Independent VLAN Learning (IVL).";
             reference
-              "IEEE 802.1Q-2017 Clause 12.4.1.5.2";
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
           }
           leaf svl-capable {
             type boolean;
@@ -422,7 +402,7 @@ module ieee802-dot1q-bridge {
             description
               "Shared VLAN Learning (SVL).";
             reference
-              "IEEE 802.1Q-2017 Clause 12.4.1.5.2";
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
           }
           leaf hybrid-capable {
             type boolean;
@@ -430,7 +410,7 @@ module ieee802-dot1q-bridge {
             description
               "Both IVL and SVL simultaneously.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.4.1.5.2";
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
           }
           leaf configurable-pvid-tagging {
             type boolean;
@@ -440,7 +420,7 @@ module ieee802-dot1q-bridge {
               override the default PVID setting and its egress status
               (VLAN-tagged or Untagged) on each port.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.4.1.5.2";
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
           }
           leaf local-vlan-capable {
             type boolean;
@@ -449,32 +429,32 @@ module ieee802-dot1q-bridge {
               "Can support multiple local Bridges, outside the scope
               of 802.1Q defined VLANs.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.4.1.5.2";
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
           }
         }
-
         container filtering-database {
           when "../../bridge-type != 'two-port-mac-relay-bridge'" {
             description
-              "Applies to non TPMR Bridges.";
+              "Applies to non TPMRs.";
           }
           description
             "Contains filtering information used by the Forwarding
             Process in deciding through which Ports of the Bridge
             frames should be forwarded.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.7";
+            "12.7 of IEEE Std 802.1Q-2018";
           leaf aging-time {
             type uint32 {
               range "10..10000000";
             }
-            units seconds;
-            default 300;
+            units "seconds";
+            default "300";
             description
               "The timeout period in seconds for aging out
               dynamically-learned forwarding information.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.7, 8.8.3";
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.3 of IEEE Std 802.1Q-2018";
           }
           leaf size {
             type yang:gauge32;
@@ -483,16 +463,17 @@ module ieee802-dot1q-bridge {
               "The maximum number of entries that can be held in the
               FDB.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.7";
+              "12.7 of IEEE Std 802.1Q-2018";
           }
           leaf static-entries {
             type yang:gauge32;
             config false;
             description
-              "The number of Static Filtering entries currently in
-              the FDB.";
+              "The number of Static Filtering entries currently in the
+              FDB.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.7, 8.8.1";
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.1 of IEEE Std 802.1Q-2018";
           }
           leaf dynamic-entries {
             type yang:gauge32;
@@ -501,7 +482,8 @@ module ieee802-dot1q-bridge {
               "The number of Dynamic Filtering entries currently in
               the FDB.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.7, 8.8.3";
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.3 of IEEE Std 802.1Q-2018";
           }
           leaf static-vlan-registration-entries {
             type yang:gauge32;
@@ -510,7 +492,8 @@ module ieee802-dot1q-bridge {
               "The number of Static VLAN Registration entries
               currently in the FDB.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.7, 8.8.2";
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.2 of IEEE Std 802.1Q-2018";
           }
           leaf dynamic-vlan-registration-entries {
             type yang:gauge32;
@@ -519,19 +502,20 @@ module ieee802-dot1q-bridge {
               "The number of Dynamic VLAN Registration entries
               currently in the FDB.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.7, 8.8.5";
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.5 of IEEE Std 802.1Q-2018";
           }
           leaf mac-address-registration-entries {
-            if-feature extended-filtering-services;
+            if-feature "extended-filtering-services";
             type yang:gauge32;
             config false;
             description
               "The number of MAC Address Registration entries
               currently in the FDB.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.7, 8.8.4";
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.4 of IEEE Std 802.1Q-2018";
           }
-
           list filtering-entry {
             key "database-id vids address";
             description
@@ -542,7 +526,7 @@ module ieee802-dot1q-bridge {
               description
                 "The identity of this Filtering Database.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf address {
               type ieee:mac-address;
@@ -551,15 +535,15 @@ module ieee802-dot1q-bridge {
                 which the device has forwarding and/or filtering
                 information.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf vids {
               type dot1qtypes:vid-range-type;
               description
                 "The set of VLAN identifiers to which this entry
-              	applies.";
+                applies.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf entry-type {
               type enumeration {
@@ -574,14 +558,14 @@ module ieee802-dot1q-bridge {
               }
               description
                 "The type of filtering entry. Whether static or
-                dynamic. Static entries can be created, deleted, and 
-              	retrieved. However, dynamic entries can only be
-              	deleted or retrieved by the management entity.
-              	Consequently, a Bridge is not required to accept a
-              	command that can alter the dynamic entries except
-              	delete a dynamic entry.";
+                dynamic. Static entries can be created, deleted, and
+                retrieved. However, dynamic entries can only be
+                deleted or retrieved by the management entity.
+                Consequently, a Bridge is not required to accept a
+                command that can alter the dynamic entries except
+                delete a dynamic entry.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             uses dot1qtypes:port-map-grouping;
             leaf status {
@@ -589,10 +573,10 @@ module ieee802-dot1q-bridge {
                 enum other {
                   description
                     "None of the following. This may include the case
-                    where some other object is being used to
-                    determine if and how frames addressed to the
-                    value of the corresponding instance of 'address'
-                  	are being forwarded.";
+                    where some other object is being used to determine
+                    if and how frames addressed to the value of the
+                    corresponding instance of 'address' are being
+                    forwarded.";
                 }
                 enum invalid {
                   description
@@ -614,8 +598,8 @@ module ieee802-dot1q-bridge {
                 enum mgmt {
                   description
                     "The value of the corresponding instance of
-                    address node that is also the value of an
-                    existing instance.";
+                    address node that is also the value of an existing
+                    instance.";
                 }
               }
               config false;
@@ -623,31 +607,30 @@ module ieee802-dot1q-bridge {
                 "The status of this entry.";
             }
           }
-
           list vlan-registration-entry {
             key "database-id vids";
             description
               "The VLAN Registration Entries models the operations
               that can be performed on a single VLAN Registration
               Entry in the FDB. The set of VLAN Registration Entries
-              within the FDB changes under management control and
-              also as a result of MVRP exchanges";
+              within the FDB changes under management control and also
+              as a result of MVRP exchanges";
             reference
-              "IEEE 802.1Q-2017 Clause 12.7.5";
+              "12.7.5 of IEEE Std 802.1Q-2018";
             leaf database-id {
               type uint32;
               description
                 "The identity of this Filtering Database.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf vids {
               type dot1qtypes:vid-range-type;
               description
-              	"The set of VLAN identifiers to which this entry
-              	applies.";
+                "The set of VLAN identifiers to which this entry
+                applies.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf entry-type {
               type enumeration {
@@ -662,51 +645,50 @@ module ieee802-dot1q-bridge {
               }
               description
                 "The type of filtering entry. Whether static or
-                dynamic. Static entries can be created, deleted, and 
-              	retrieved. However, dynamic entries can only be
-              	deleted or retrieved by the management entity.
-              	Consequently, a Bridge is not required to accept a
-              	command that can alter the dynamic entries except
-              	delete a dynamic entry.";
+                dynamic. Static entries can be created, deleted, and
+                retrieved. However, dynamic entries can only be
+                deleted or retrieved by the management entity.
+                Consequently, a Bridge is not required to accept a
+                command that can alter the dynamic entries except
+                delete a dynamic entry.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             uses dot1qtypes:port-map-grouping;
           }
         }
-
         container permanent-database {
           description
             "The Permanent Database container models the operations
             that can be performed on, or affect, the Permanent
             Database. There is a single Permanent Database per FDB.";
           leaf size {
-	          type yang:gauge32;
-	          config false;
-	          description
-	            "The maximum number of entries that can be held in the
-	            FDB.";
-	          reference
-	            "IEEE 802.1Q-2017 Clause 12.7.6";
-	        }
-	        leaf static-entries {
-	          type yang:gauge32;
-	          config false;
-	          description
-	            "The number of Static Filtering entries currently in
-	            the FDB.";
-	          reference
-	            "IEEE 802.1Q-2017 Clause 12.7.6";
-	        }
-	        leaf static-vlan-registration-entries {
-	          type yang:gauge32;
-	          config false;
-	          description
-	            "The number of Static VLAN Registration entries
-	            currently in the FDB.";
-	          reference
-	            "IEEE 802.1Q-2017 Clause 12.7.6";
-	        }
+            type yang:gauge32;
+            config false;
+            description
+              "The maximum number of entries that can be held in the
+              FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q-2018";
+          }
+          leaf static-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static Filtering entries currently in the
+              FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q-2018";
+          }
+          leaf static-vlan-registration-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static VLAN Registration entries
+              currently in the FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q-2018";
+          }
           list filtering-entry {
             key "database-id vids address";
             description
@@ -717,7 +699,7 @@ module ieee802-dot1q-bridge {
               description
                 "The identity of this Filtering Database.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf address {
               type ieee:mac-address;
@@ -726,25 +708,25 @@ module ieee802-dot1q-bridge {
                 which the device has forwarding and/or filtering
                 information.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf vids {
               type dot1qtypes:vid-range-type;
               description
-              	"The set of VLAN identifiers to which this entry
-              	applies.";
+                "The set of VLAN identifiers to which this entry
+                applies.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf status {
               type enumeration {
                 enum other {
                   description
                     "None of the following. This may include the case
-                    where some other object is being used to
-                    determine if and how frames addressed to the
-                    value of the corresponding instance of 'address'
-                  	are being forwarded.";
+                    where some other object is being used to determine
+                    if and how frames addressed to the value of the
+                    corresponding instance of 'address' are being
+                    forwarded.";
                 }
                 enum invalid {
                   description
@@ -766,8 +748,8 @@ module ieee802-dot1q-bridge {
                 enum mgmt {
                   description
                     "The value of the corresponding instance of
-                    address node that is also the value of an
-                    existing instance.";
+                    address node that is also the value of an existing
+                    instance.";
                 }
               }
               config false;
@@ -777,11 +759,10 @@ module ieee802-dot1q-bridge {
             uses dot1qtypes:port-map-grouping;
           }
         }
-
         container bridge-vlan {
-        	when "../../bridge-type != 'two-port-mac-relay-bridge'" {
+          when "../../bridge-type != 'two-port-mac-relay-bridge'" {
             description
-              "Applies to non TPMR Bridges.";
+              "Applies to non TPMRs.";
           }
           description
             "The Bridge VLAN container models configuration
@@ -790,14 +771,14 @@ module ieee802-dot1q-bridge {
             single Bridge VLAN Configuration managed object per
             Bridge.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.10";
+            "12.10 of IEEE Std 802.1Q-2018";
           leaf version {
             type uint16;
             config false;
             description
               "The version number supported.";
             reference
-              "IEEE 802.1Q-2017, Clause 12.10.1.3";
+              "12.10.1.3 of IEEE Std 802.1Q-2018";
           }
           leaf max-vids {
             type uint16;
@@ -805,7 +786,7 @@ module ieee802-dot1q-bridge {
             description
               "The maximum number of VIDs supported.";
             reference
-              "IEEE 802.1Q-2017, Clause 12.10.1.3";
+              "12.10.1.3 of IEEE Std 802.1Q-2018";
           }
           leaf override-default-pvid {
             type boolean;
@@ -816,29 +797,29 @@ module ieee802-dot1q-bridge {
               its egress status (VLAN-tagged or untagged) on each
               port.";
             reference
-              "IEEE 802.1Q-2017, Clause 12.10.1.3";
+              "12.10.1.3 of IEEE Std 802.1Q-2018";
           }
           leaf protocol-template {
-            if-feature port-and-protocol-based-vlan;
+            if-feature "port-and-protocol-based-vlan";
             type dot1qtypes:protocol-frame-format-type;
             config false;
             description
               "The data-link encapsulation format or the
               detagged_frame_type in a Protocol Template";
             reference
-              "IEEE 802.1Q-2017 Clause 12.10.1.7";
+              "12.10.1.7 of IEEE Std 802.1Q-2018";
           }
           leaf max-msti {
             type uint16;
             config false;
             description
               "The maximum number of MSTIs supported within an MST
-              region (i.e., the number of spanning tree instances
-              that can be supported in addition to the CIST), for MST
+              region (i.e., the number of spanning tree instances that
+              can be supported in addition to the CIST), for MST
               Bridges. For SST Bridges, this parameter may be either
               omitted or reported as 0.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.10.1.7";
+              "12.10.1.7 of IEEE Std 802.1Q-2018";
           }
           list vlan {
             key "vid";
@@ -846,13 +827,13 @@ module ieee802-dot1q-bridge {
               "List of VLAN related configuration nodes associated
               with the Bridge.";
             reference
-              "IEEE 802.1Q-2017 Clause 12.10.2";
+              "12.10.2 of IEEE Std 802.1Q-2018";
             leaf vid {
               type dot1qtypes:vlan-index-type;
               description
                 "The VLAN identifier to which this entry applies.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.2";
+                "12.10.2 of IEEE Std 802.1Q-2018";
             }
             leaf name {
               type dot1qtypes:name-type;
@@ -860,7 +841,7 @@ module ieee802-dot1q-bridge {
                 "A text string of up to 32 characters of locally
                 determined significance.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.2";
+                "12.10.2 of IEEE Std 802.1Q-2018";
             }
             leaf-list untagged-ports {
               type if:interface-ref;
@@ -868,8 +849,8 @@ module ieee802-dot1q-bridge {
               description
                 "The set of ports in the untagged set for this VID.";
               reference
-                "IEEE 802.1Q-2017 Clause 8.8.2 and
-                Clause 12.10.2.1.3";
+                "12.10.2.1.3 of IEEE Std 802.1Q-2018
+                8.8.2 of IEEE Std 802.1Q-2018";
             }
             leaf-list egress-ports {
               type if:interface-ref;
@@ -878,92 +859,90 @@ module ieee802-dot1q-bridge {
                 "The set of egress ports in the member set for this
                 VID.";
               reference
-                "IEEE 802.1Q-2017 Clause 8.8.10 and
-                Clause 12.10.2.1.3";
+                "12.10.2.1.3 of IEEE Std 802.1Q-2018
+                8.8.10 of IEEE Std 802.1Q-2018";
             }
           }
-          
           list protocol-group-database {
-          	if-feature port-and-protocol-based-vlan;
-          	key "db-index";
-          	description
-          		"List of the protocol group database entries.";
-          	reference
-          		"IEEE 802.1Q-2017 Clause 12.10.1.7, 6.12.3";
-          	leaf db-index {
-          		type uint16;
-          		description
-          			"The protocol group database index.";
-          	}
-          	leaf frame-format-type {
+            if-feature "port-and-protocol-based-vlan";
+            key "db-index";
+            description
+              "List of the protocol group database entries.";
+            reference
+              "12.10.1.7 of IEEE Std 802.1Q-2018
+              6.12.3 of IEEE Std 802.1Q-2018";
+            leaf db-index {
+              type uint16;
+              description
+                "The protocol group database index.";
+            }
+            leaf frame-format-type {
               type dot1qtypes:protocol-frame-format-type;
               description
                 "The data-link encapsulation format or the
                 detagged_frame_type in a Protocol Template";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.1.7";
+                "12.10.1.7 of IEEE Std 802.1Q-2018";
             }
             choice frame-format {
               description
                 "The identification of the protocol above the
                 data-link layer in a Protocol Template. Depending on
-                the frame type, the octet string will have one of
-                the following values:
-                  - For ethernet, rfc1042 and snap8021H, this is the
-                    16-bit (2-octet) IEEE 802 Clause 9.3 EtherType
-                    field.
-                  - For snapOther, this is the 40-bit (5-octet) PID.
-                  - For llcOther, this is the 2-octet IEEE 802.2
-                    Link Service Access Point (LSAP) pair: first
-                    octet for Destination Service Access Point (DSAP)
-                    and second octet for Source Service Access Point
-                    (SSAP).";
+                the frame type, the octet string will have one of the
+                following values: - For ethernet, rfc1042 and
+                snap8021H, this is the 16-bit (2-octet) IEEE 802
+                Clause 9.3 EtherType field. - For snapOther, this is
+                the 40-bit (5-octet) PID. - For llcOther, this is the
+                2-octet IEEE 802.2 Link Service Access Point (LSAP)
+                pair: first octet for Destination Service Access Point
+                (DSAP) and second octet for Source Service Access
+                Point (SSAP).";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.1.7";
+                "12.10.1.7 of IEEE Std 802.1Q-2018";
               case ethernet-rfc1042-snap8021H {
-              	when "frame-format-type = 'Ethernet' or
-              		    frame-format-type = 'rfc1042' or
-              		    frame-format-type = 'snap8021H'" {
-              		description
-              			"Applies to Ethernet, RFC 1042, SNAP 8021H
-              			frame formats.";
-              	}
-                description
-                  "Identifier used if Ethenet, RFC1042, or SNAP
-                  8021H.";
-                leaf ethertype {
-                	type dot1qtypes:ethertype-type;
+                when
+                  "frame-format-type = 'Ethernet' or "+
+                  "frame-format-type = 'rfc1042' or "+
+                  "frame-format-type = 'snap8021H'" {
                   description
-                    "Format containing the 16-bit IEEE 802
-                    EtherType field.";
+                    "Applies to Ethernet, RFC 1042, SNAP 8021H frame
+                    formats.";
+                }
+                description
+                  "Identifier used if Ethenet, RFC1042, or SNAP 8021H.";
+                leaf ethertype {
+                  type dot1qtypes:ethertype-type;
+                  description
+                    "Format containing the 16-bit IEEE 802 EtherType
+                    field.";
                   reference
-                    "IEEE 802-2014 Clause 9.3";
+                    "9.3 of IEEE Std 802-2014";
                 }
               }
               case snap-other {
-              	when "frame-format-type = 'snapOther'" {
-		          		description
-		          			"Applies to Snap Other frame formats.";
-		          	}
+                when "frame-format-type = 'snapOther'" {
+                  description
+                    "Applies to Snap Other frame formats.";
+                }
                 description
                   "Identifier used if SNAP other.";
                 leaf protocol-id {
                   type string {
-                    pattern '[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){4}';
+                    pattern "[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){4}";
                   }
                   description
                     "Format containing the 40-bit protocol identifier
-                    (PID). The canonical representation uses
-                  	uppercase characters.";
+                    (PID). The canonical representation uses uppercase
+                    characters.";
                   reference
-                    "IEEE 802.1Q-2017 Clause 12.10.1.7.1";
+                    "12.10.1.7.1 of IEEE Std 802.1Q-2018";
                 }
               }
               case llc-other {
-              	when "frame-format-type = 'llcOther'" {
-		          		description
-		          			"Applies to LLC Other frame formats ";
-		          	}
+                when "frame-format-type = 'llcOther'" {
+                  description
+                    "Applies to LLC Other frame formats";
+                }
                 description
                   "Identifier used if LLC other.";
                 container dsap-ssap-pairs {
@@ -973,15 +952,15 @@ module ieee802-dot1q-bridge {
                     LLC_Other.";
                   leaf llc-address {
                     type string {
-                      pattern '[0-9a-fA-F]{2}-[0-9a-fA-F]{2}';
+                      pattern "[0-9a-fA-F]{2}-[0-9a-fA-F]{2}";
                     }
                     description
-                      "A pair of ISO/IEC 8802-2 DSAP and SSAP
-                      address field values, for matching frame
-                      formats of LLC_Other. The canonical 
-                    	representation uses uppercase characters.";
+                      "A pair of ISO/IEC 8802-2 DSAP and SSAP address
+                      field values, for matching frame formats of
+                      LLC_Other. The canonical representation uses
+                      uppercase characters.";
                     reference
-                      "IEEE 802.1Q-2017 Clause 12.10.1.7.1";
+                      "12.10.1.7.1 of IEEE Std 802.1Q-2018";
                   }
                 }
               }
@@ -989,24 +968,23 @@ module ieee802-dot1q-bridge {
             leaf group-id {
               type uint32;
               description
-                "Designates a group of protocols in the Protocol
-                Group Database.";
+                "Designates a group of protocols in the Protocol Group
+                Database.";
               reference
-                "IEEE 802.1Q-2017 Clause 6.12.2";
-            }    		
+                "6.12.2 of IEEE Std 802.1Q-2018";
+            }
           }
-
           list vid-to-fid-allocation {
             key "vids";
             description
               "This list allows inquiries about VID to FID
-            	allocations.";
+              allocations.";
             leaf vids {
               type dot1qtypes:vid-range-type;
               description
                 "Range of VLAN identifiers.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.3";
+                "12.10.3 of IEEE Std 802.1Q-2018";
             }
             leaf fid {
               type uint32;
@@ -1014,7 +992,7 @@ module ieee802-dot1q-bridge {
               description
                 "The Filtering Database used by a set of VIDs.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.3";
+                "12.10.3 of IEEE Std 802.1Q-2018";
             }
             leaf allocation-type {
               type enumeration {
@@ -1035,22 +1013,20 @@ module ieee802-dot1q-bridge {
               description
                 "The type of allocation used";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.3";
+                "12.10.3 of IEEE Std 802.1Q-2018";
             }
           }
-          
           list fid-to-vid-allocation {
             key "fid";
             description
               "The FID to VID allocations managed object models
-              operations that inquire about FID to VID
-              allocations.";
+              operations that inquire about FID to VID allocations.";
             leaf fid {
               type uint32;
               description
                 "The Filtering Database used by a set of VIDs.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.3";
+                "12.10.3 of IEEE Std 802.1Q-2018";
             }
             leaf allocation-type {
               type enumeration {
@@ -1071,7 +1047,7 @@ module ieee802-dot1q-bridge {
               description
                 "The type of allocation used";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.3";
+                "12.10.3 of IEEE Std 802.1Q-2018";
             }
             leaf-list vid {
               type dot1qtypes:vlan-index-type;
@@ -1079,104 +1055,102 @@ module ieee802-dot1q-bridge {
               description
                 "The VLAN identifier to which this entry applies.";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
           }
-          
           list vid-to-fid {
-          	key "vid";
+            key "vid";
             description
               "Fixed allocation of a VID to an FID. The underlying
-            	system will ensure that subsequent commands that
-            	make changes to the VID to FID mapping can
-            	override previous associations.";
+              system will ensure that subsequent commands that make
+              changes to the VID to FID mapping can override previous
+              associations.";
             reference
-            	"IEEE 802.1Q-2017 Clause 12.10.3.4, 12.10.3.5";
+              "12.10.3.4 of IEEE Std 802.1Q-2018
+              12.10.3.5 of IEEE Std 802.1Q-2018";
             leaf vid {
               type dot1qtypes:vlan-index-type;
               description
                 "A list of VLAN identifier associated with a given
-              	database identifier (i.e., FID).";
+                database identifier (i.e., FID).";
               reference
-                "IEEE 802.1Q-2017 Clause 12.7.7";
+                "12.7.7 of IEEE Std 802.1Q-2018";
             }
             leaf fid {
               type uint32;
               description
                 "The Filtering Database used by this VLAN";
               reference
-                "IEEE 802.1Q-2017 Clause 12.10.3";
+                "12.10.3 of IEEE Std 802.1Q-2018";
             }
           }
         }
-        
-				container bridge-mst {
-					when "../../bridge-type != 'two-port-mac-relay-bridge'" {
-				    description
-				      "Applies to non TPMR Bridges.";
-				  }
-				  description
-				    "The Bridge MST container models configuration
-				    information that modify, or inquire about, the overall
-				    configuration of the Bridges MST resources.";
-				  reference
-				    "IEEE 802.1Q-2017 Clause 12.12";
-			    leaf-list mstid {
-					  type dot1qtypes:mstid-type;
-						description
-						  "The list of MSTID values that are currently supported
-							by the Bridge";
-					}
-					list fid-to-mstid {
-					  key "fid";
-						description
-						  "The FID to MSTID allocation table.";
-						reference
-						  "IEEE 802.1Q-2017 Clause 12.12.2";
-						leaf fid {
-						  type uint32;
-							description
-							  "The Filtering Database identifier.";
-							reference
-							  "IEEE 802.1Q-2017 Clause 12.12.2";
-						}
-						leaf mstid {
-						  type dot1qtypes:mstid-type;
-						  description
-						    "The MSTID to which the FID is to be allocated.";
-						  reference
-						  "IEEE 802.1Q-2017 Clause 12.12.2";
-						}
-			  	}
-					list fid-to-mstid-allocation {
-						key "fids";
-						description
-						  "The FID to MSTID allocation table";
-						leaf fids {
-						  type dot1qtypes:vid-range-type;
-						  description
-						    "Range of FIDs.";
-						reference
-						  "IEEE 802.1Q-2017 Clause 12.12.2";
-						}
-						leaf mstid {
-						  type dot1qtypes:mstid-type;
-						  description
-						    "The MSTID to which the FID is allocated.";
-						  reference
-						  "IEEE 802.1Q-2017 Clause 12.12.2";
-						}
-				  }
-				}  
+        container bridge-mst {
+          when "../../bridge-type != 'two-port-mac-relay-bridge'" {
+            description
+              "Applies to non TPMRs.";
+          }
+          description
+            "The Bridge MST container models configuration information
+            that modify, or inquire about, the overall configuration
+            of the Bridges MST resources.";
+          reference
+            "12.12 of IEEE Std 802.1Q-2018";
+          leaf-list mstid {
+            type dot1qtypes:mstid-type;
+            description
+              "The list of MSTID values that are currently supported
+              by the Bridge";
+          }
+          list fid-to-mstid {
+            key "fid";
+            description
+              "The FID to MSTID allocation table.";
+            reference
+              "12.12.2 of IEEE Std 802.1Q-2018";
+            leaf fid {
+              type uint32;
+              description
+                "The Filtering Database identifier.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q-2018";
+            }
+            leaf mstid {
+              type dot1qtypes:mstid-type;
+              description
+                "The MSTID to which the FID is to be allocated.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q-2018";
+            }
+          }
+          list fid-to-mstid-allocation {
+            key "fids";
+            description
+              "The FID to MSTID allocation table";
+            leaf fids {
+              type dot1qtypes:vid-range-type;
+              description
+                "Range of FIDs.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q-2018";
+            }
+            leaf mstid {
+              type dot1qtypes:mstid-type;
+              description
+                "The MSTID to which the FID is allocated.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q-2018";
+            }
+          }
+        }
       }
     }
   }
-  
   augment "/if:interfaces/if:interface" {
-    when "if:type = 'ianaif:bridge' or
-          if:type = 'ianaif:ethernetCsmacd' or
-          if:type = 'ianaif:ieee8023adLag' or
-          if:type = 'ianaif:ilan'" {
+    when
+      "if:type = 'ianaif:bridge' or if:type ="+
+      "'ianaif:ethernetCsmacd' or if:type = 'ianaif:ieee8023adLag'"+
+      "or if:type = 'ianaif:ilan'" {
       description
         "Applies when a Bridge interface.";
     }
@@ -1198,12 +1172,12 @@ module ieee802-dot1q-bridge {
         description
           "The port type. Indicates the capabilities of this port.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.4.2.1";
+          "12.4.2.1 of IEEE Std 802.1Q-2018";
       }
       leaf pvid {
-    	  when "../component-name != 'd-bridge-component'" {
+        when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
         type dot1qtypes:vlan-index-type;
         default "1";
@@ -1211,7 +1185,8 @@ module ieee802-dot1q-bridge {
           "The primary (default) VID assigned to a specific Bridge
           Port.";
         reference
-          "IEEE 802.1Q-2017 Clause 5.4 m), 12.10.1";
+          "12.10.1 of IEEE Std 802.1Q-2018
+          5.4, item m) of IEEE Std 802.1Q-2018";
       }
       leaf default-priority {
         type dot1qtypes:priority-type;
@@ -1219,20 +1194,21 @@ module ieee802-dot1q-bridge {
         description
           "The default priority assigned to a specific Bridge Port.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.6.2";
+          "12.6.2 of IEEE Std 802.1Q-2018";
       }
       container priority-regeneration {
         description
           "The Priority Regeneration Table parameters associated with
           a specific Bridge Port. A list of Regenerated User
           Priorities for each received priority on each port of a
-          Bridge. The regenerated priority value may be used to
-          index the Traffic Class Table for each input port. This
-          only has effect on media that support native priority. The
-          default values for Regenerated User Priorities are the
-          same as the User Priorities";
+          Bridge. The regenerated priority value may be used to index
+          the Traffic Class Table for each input port. This only has
+          effect on media that support native priority. The default
+          values for Regenerated User Priorities are the same as the
+          User Priorities";
         reference
-          "IEEE 802.1Q-2017 Clause 12.6.2, 6.9.4";
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.9.4 of IEEE Std 802.1Q-2018";
         uses dot1qtypes:priority-regeneration-table-grouping;
       }
       leaf pcp-selection {
@@ -1241,10 +1217,11 @@ module ieee802-dot1q-bridge {
         description
           "The Priority Code Point selection assigned to a specific
           Bridge Port. This object identifies the rows in the PCP
-          encoding and decoding tables that are used to remark
-          frames on this port if this remarking is enabled";
+          encoding and decoding tables that are used to remark frames
+          on this port if this remarking is enabled";
         reference
-          "IEEE 802.1Q-2017 Clause 12.6.2, 6.9.3";
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
       }
       container pcp-decoding-table {
         description
@@ -1262,16 +1239,16 @@ module ieee802-dot1q-bridge {
         type boolean;
         default "false";
         description
-          "The Drop Eligible Indicator. If it is set to True, then
-          the drop_eligible parameter is encoded in the DEI of
-          transmitted frames, and the drop_eligible parameter shall
-          be true(1) for a received frame if the DEI is set in the
-          VLAN tag or the Priority Code Point Decoding Table
-          indicates drop_eligible True for the received PCP value.
-          If this parameter is False, the DEI shall be transmitted
-          as zero and ignored on receipt.";
+          "The Drop Eligible Indicator. If it is set to True, then the
+          drop_eligible parameter is encoded in the DEI of transmitted
+          frames, and the drop_eligible parameter shall be true(1) for
+          a received frame if the DEI is set in the VLAN tag or the
+          Priority Code Point Decoding Table indicates drop_eligible
+          True for the received PCP value. If this parameter is False,
+          the DEI shall be transmitted as zero and ignored on receipt.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.6.2, 6.9.3";
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
       }
       leaf drop-encoding {
         type boolean;
@@ -1280,37 +1257,38 @@ module ieee802-dot1q-bridge {
           "The Drop Encoding parameter. If a Bridge supports encoding
           or decoding of drop_eligible from the PCP field of a VLAN
           tag (6.7.3) on any of its Ports, then it shall implement a
-          Boolean parameter Require Drop Encoding on each of its
-          Ports with default value False. If Require Drop Encoding
-          is True and the Bridge Port cannot encode particular
-          priorities with drop_eligible, then frames queued with
-          those priorities and drop_eligible True shall be discarded
-          and not transmitted.";
+          Boolean parameter Require Drop Encoding on each of its Ports
+          with default value False. If Require Drop Encoding is True
+          and the Bridge Port cannot encode particular priorities with
+          drop_eligible, then frames queued with those priorities and
+          drop_eligible True shall be discarded and not transmitted.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.6.2, 8.6.6";
+          "12.6.2 of IEEE Std 802.1Q-2018
+          8.6.6 of IEEE Std 802.1Q-2018";
       }
       leaf service-access-priority-selection {
-      	type boolean;
-      	default "false";
+        type boolean;
+        default "false";
         description
           "The Service Access Priority selection. Indication of
           whether the Service Access Priority Selection function is
           supported on the Customer Bridge Port to request priority
-          handling of the frame from a Port-based service
-          interface.";
+          handling of the frame from a Port-based service interface.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.6.2, 6.13";
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.13 of IEEE Std 802.1Q-2018";
       }
       container service-access-priority {
         description
-          "The Service Access Priority table parameters. A table
-          that contains information about the Service Access
-          Priority Selection function for a Provider Bridge. The use
-          of this table enables a mechanism for a Customer Bridge
-          attached to a Provider Bridged Network to request priority
-          handling of frames.";
+          "The Service Access Priority table parameters. A table that
+          contains information about the Service Access Priority
+          Selection function for a Provider Bridge. The use of this
+          table enables a mechanism for a Customer Bridge attached to
+          a Provider Bridged Network to request priority handling of
+          frames.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.6.2, 6.13.1";
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.13.1 of IEEE Std 802.1Q-2018";
         uses dot1qtypes:service-access-priority-table-grouping;
       }
       container traffic-class {
@@ -1319,13 +1297,14 @@ module ieee802-dot1q-bridge {
           evaluated priority to Traffic Class, for forwarding by the
           Bridge";
         reference
-          "IEEE 802.1Q-2017 Clause 12.6.3, 8.6.6";
+          "12.6.3 of IEEE Std 802.1Q-2018
+          8.6.6 of IEEE Std 802.1Q-2018";
         uses dot1qtypes:traffic-class-table-grouping;
       }
       leaf acceptable-frame {
         when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
         type enumeration {
           enum admit-only-VLAN-tagged-frames {
@@ -1346,121 +1325,126 @@ module ieee802-dot1q-bridge {
           "To configure the Acceptable Frame Types parameter
           associated with one or more Ports";
         reference
-          "IEEE 802.1Q-2017 Clause 12.10.1.3, 6.9";
+          "12.10.1.3 of IEEE Std 802.1Q-2018
+          6.9 of IEEE Std 802.1Q-2018";
       }
       leaf enable-ingress-filtering {
-    	  when "../component-name != 'd-bridge-component'" {
-    		  description
-    			  "Applies to non TPMR Bridges";
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
         }
         type boolean;
         default "false";
         description
-          "To enable the Ingress Filtering feature
-          associated with one or more Ports.";
+          "To enable the Ingress Filtering feature associated with one
+          or more Ports.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.10.1.4, 8.6.2";
+          "12.10.1.4 of IEEE Std 802.1Q-2018
+          8.6.2 of IEEE Std 802.1Q-2018";
       }
       leaf enable-restricted-vlan-registration {
-    	  when "../component-name != 'd-bridge-component'" {
+        when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
         type boolean;
         default "false";
         description
-          "To enable the Restricted VLAN Registration
-          associated with one or more Ports.";
+          "To enable the Restricted VLAN Registration associated with
+          one or more Ports.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.10.1.6, 11.2.3.2.3";
+          "11.2.3.2.3 of IEEE Std 802.1Q-2018
+          12.10.1.6 of IEEE Std 802.1Q-2018";
       }
       leaf enable-vid-translation-table {
-    	  when "../component-name != 'd-bridge-component'" {
+        when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
         type boolean;
         default "false";
         description
-          "To enable VID Translation table associated with a 
-        	Bridge Port. This is not applicable to Bridge Ports that
-        	do no support a VID Translation Table.";
+          "To enable VID Translation table associated with a Bridge
+          Port. This is not applicable to Bridge Ports that do no
+          support a VID Translation Table.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.10.1.8, 6.9";
+          "12.10.1.8 of IEEE Std 802.1Q-2018
+          6.9 of IEEE Std 802.1Q-2018";
       }
       leaf enable-egress-vid-translation-table {
-    	  when "../component-name != 'd-bridge-component'" {
+        when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
         type boolean;
         default "false";
         description
-          "To enable Egress VID Translation table associated with
-        	a Bridge Port. This is not applicable to Ports that do 
-        	not support an Egress VID Translation table.";
+          "To enable Egress VID Translation table associated with a
+          Bridge Port. This is not applicable to Ports that do not
+          support an Egress VID Translation table.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.10.1.9, 6.9";
+          "12.10.1.9 of IEEE Std 802.1Q-2018
+          6.9 of IEEE Std 802.1Q-2018";
       }
       list protocol-group-vid-set {
-      	when "../component-name != 'd-bridge-component'" {
+        when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
-        if-feature port-and-protocol-based-vlan;
+        if-feature "port-and-protocol-based-vlan";
         key "group-id";
         description
-        	"The list of VID values associated with the Protocol
-        	Group Identifer for this port.";
+          "The list of VID values associated with the Protocol Group
+          Identifier for this port.";
         reference
-        	"IEEE 802.1Q-2017 Clause 12.10.1.1.3";
+          "12.10.1.1.3 of IEEE Std 802.1Q-2018";
         leaf group-id {
           type uint32;
           description
             "The protocol group identifier";
           reference
-            "IEEE 802.1Q-2017 Clause 12.10.1.7";
+            "12.10.1.7 of IEEE Std 802.1Q-2018";
         }
         leaf-list vid {
-        	type dot1qtypes:vlanid;
-        	description
+          type dot1qtypes:vlanid;
+          description
             "The VLAN identifier to which this entry applies.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.10.2";
+            "12.10.2 of IEEE Std 802.1Q-2018";
         }
       }
       leaf admin-point-to-point {
-      	type enumeration {
-      		enum force-true {
-      			value 1;
-      			description
-      				"Indicates that this port should always be treated
-      				as if it is connected to a point-to-point link.";
-      		}
-      		enum force-false {
-      			value 2;
-      			description
-      				"Indicates that this port should be treated as
-      				having a shared media connection.";
-      		}
-      		enum auto {
-      			value 3;
-      			description 
-      				"Indicates that this port is considered to have a
-      				point-to-point link if it is an Aggregator and all
-      				of its members are aggregatable, or if the MAC entity
-      				is configured for full duplex operation, either
-      				through auto-negotiation or by management means.";
-      		}
-      	}
+        type enumeration {
+          enum force-true {
+            value 1;
+            description
+              "Indicates that this port should always be treated as if
+              it is connected to a point-to-point link.";
+          }
+          enum force-false {
+            value 2;
+            description
+              "Indicates that this port should be treated as having a
+              shared media connection.";
+          }
+          enum auto {
+            value 3;
+            description
+              "Indicates that this port is considered to have a
+              point-to-point link if it is an Aggregator and all of
+              its members are aggregatable, or if the MAC entity is
+              configured for full duplex operation, either through
+              auto-negotiation or by management means.";
+          }
+        }
         description
           "For a port running spanning tree, this object represents
-          the administrative point-to-point status of the LAN
-          segment attached to this port, using the enumeration values
-          of IEEE Std 802.1AC. A value of forceTrue(1) indicates that
-          this port should always be treated as if it is connected to
-          a point-to-point link. A value of forceFalse(2) indicates
-          that this port should be treated as having a shared media
+          the administrative point-to-point status of the LAN segment
+          attached to this port, using the enumeration values of IEEE
+          Std 802.1AC. A value of forceTrue(1) indicates that this
+          port should always be treated as if it is connected to a
+          point-to-point link. A value of forceFalse(2) indicates that
+          this port should be treated as having a shared media
           connection. A value of auto(3) indicates that this port is
           considered to have a point-to-point link if it is an
           Aggregator and all of its members are aggregatable, or if
@@ -1469,44 +1453,45 @@ module ieee802-dot1q-bridge {
           Manipulating this object changes the underlying
           adminPointToPointMAC.";
         reference
-          "IEEE 802.1Q-2017 Clause 6.8.2, 12.4.2";
+          "12.4.2 of IEEE Std 802.1Q-2018
+          6.8.2 of IEEE Std 802.1Q-2018";
       }
       leaf protocol-based-vlan-classification {
-  	    when "../component-name != 'd-bridge-component'" {
-            description
-              "Applies to non TPMR Bridges";
-          }
-        if-feature port-and-protocol-based-vlan;
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        if-feature "port-and-protocol-based-vlan";
         type boolean;
         config false;
         description
-          "A boolean indication indicating if
-          Port-and-Protocol-based VLAN classification is supported
-          on a given Port.";
+          "A boolean indication indicating if Port-and-Protocol-based
+          VLAN classification is supported on a given Port.";
         reference
-          "IEEE 802.1Q-2017 Clause 5.4.1.2";
+          "5.4.1.2 of IEEE Std 802.1Q-2018";
       }
       leaf max-vid-set-entries {
-	      when "../component-name != 'd-bridge-component'" {
+        when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
-        if-feature port-and-protocol-based-vlan;
+        if-feature "port-and-protocol-based-vlan";
         type uint16;
         config false;
         description
-          "The maximum number of entries suppored in the VID set on
-          a given Port.";
+          "The maximum number of entries supported in the VID set on a
+          given Port.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.10.1.1.3";
+          "12.10.1.1.3 of IEEE Std 802.1Q-2018";
       }
       leaf port-number {
-      	type dot1qtypes:port-number-type;
-      	config false;
-      	description
-      		"An integer that uniquely identifies a Bridge Port.";
-      	reference
-      		"IEEE 802.1Q-2017 Clause 12.3 i), 17.3.2.2";
+        type dot1qtypes:port-number-type;
+        config false;
+        description
+          "An integer that uniquely identifies a Bridge Port.";
+        reference
+          "12.3, item i) of IEEE Std 802.1Q-2018
+          17.3.2.2 of IEEE Std 802.1Q-2018";
       }
       leaf address {
         type ieee:mac-address;
@@ -1515,127 +1500,129 @@ module ieee802-dot1q-bridge {
           "The specific MAC address of the individual MAC Entity
           associated with the Port.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.4.2, 12.4.2.1.1.3 a)";
+          "12.4.2 of IEEE Std 802.1Q-2018
+          12.4.2.1.1.3, item a) of IEEE Std 802.1Q-2018";
       }
       leaf capabilities {
-      	type bits {
-      		bit tagging {
-      			position 0;
-      			description
-      				"Supports 802.1Q VLAN taggging of frames and MVRP.";
-      		}
-      		bit configurable-acceptable-frame-type {
-      			position 1;
-      			description
-      				"Allows modified values of acceptable frame types";
-      		}
-      		bit ingress-filtering {
-      			position 2;
-      			description
-      				"Supports the discarding of any frame received on
-      				a Port whose VLAN classification does not include
-      				that Port in its member set.";
-      		}
-      	}
-      	config false;
+        type bits {
+          bit tagging {
+            position "0";
+            description
+              "Supports 802.1Q VLAN tagging of frames and MVRP.";
+          }
+          bit configurable-acceptable-frame-type {
+            position "1";
+            description
+              "Allows modified values of acceptable frame types";
+          }
+          bit ingress-filtering {
+            position "2";
+            description
+              "Supports the discarding of any frame received on a Port
+              whose VLAN classification does not include that Port in
+              its member set.";
+          }
+        }
+        config false;
         description
           "The feature capabilities associated with port. Indicates
-        	the parts of IEEE 802.1Q that are optional on a per-port
-        	basis, that are implemented by this device, and that are
-        	manageable.";
+          the parts of IEEE 802.1Q that are optional on a per-port
+          basis, that are implemented by this device, and that are
+          manageable.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.4.2, 12.10.1.1.3 c)";
+          "12.10.1.1.3, item c) of IEEE Std 802.1Q-2018
+          12.4.2 of IEEE Std 802.1Q-2018";
       }
       leaf type-capabilties {
-      	type bits {
-      		bit customer-vlan-port {
-      			position 0;
-      			description
-      				"Indicates the port can be a C-TAG aware port of
-      				an enterprise VLAN aware Bridge";
-      		}
-      		bit provider-network-port {
-      			position 1;
-      			description
-      				"Indicates the port can be an S-TAG aware port of
-      				a Provider Bridge or Backbone Edge Bridge used for
-      				connections within a PBN or PBBN.";
-      		}
-      		bit customer-network-port {
-      			position 2;
-      			description
-      				"Indicates the port can be an S-TAG aware port of a
-      				Provider Bridge or Backbone Edge Bridge used for
-      				connections to the exterior of a PBN or PBBN.";
-      		}
-      		bit customer-edge-port {
-      			position 3;
-      			description
-      				"Indicates the port can be a C-TAG aware port of a 
-      				Provider Bridge used for connections to the exterior
-      				of a PBN or PBBN.";
-      		}
-      		bit customer-backbone-port {
-      			position 4;
-      			description
-      				"Indicates the port can be a I-TAG aware port of a 
-      				Backbone Edge Bridge's B-component.";
-      		}
-      		bit virtual-instance-port {
-      			position 5;
-      			description
-      				"Indicates the port can be a virtual S-TAG aware port
-      				within a Backbone Edge Bridge's I-component which is
-      				responsible for handling S-tagged traffic for a 
-      				specific backbone service instance.";
-      		}
-      		bit d-bridge-port {
-      			position 6;
-      			description
-      				"Indicates the port can be a VLAN-unaware member of 
-      				an 802.1Q Bridge.";
-      		}
-      		bit remote-customer-access-port {
-      			position 7;
-      			description
-      				"Indicates the port can be an S-TAG aware port of a 
-      				Provider Bridge capable of providing Remote Customer
-      				Service Interfaces.";
-      		}
-      		bit station-facing-bridge-port {
-      			position 8;
-      			description
-      				"Indicates the station-facing Bridge Port in a EVB
-      				Bridge.";
-      		}
-      		bit uplink-access-port {
-      			position 9;
-      			description
-      				"Indicates the uplink access port in an EVB Bridge or
-      				EVB station.";
-      		}
-      		bit uplink-relay-port {
-      			position 10;
-      			description
-      				"Indicates the uplink relay port in an EVB station.";
-      		}
-      	}
-      	config false;
+        type bits {
+          bit customer-vlan-port {
+            position "0";
+            description
+              "Indicates the port can be a C-TAG aware port of an
+              enterprise VLAN aware Bridge";
+          }
+          bit provider-network-port {
+            position "1";
+            description
+              "Indicates the port can be an S-TAG aware port of a
+              Provider Bridge or Backbone Edge Bridge used for
+              connections within a PBN or PBBN.";
+          }
+          bit customer-network-port {
+            position "2";
+            description
+              "Indicates the port can be an S-TAG aware port of a
+              Provider Bridge or Backbone Edge Bridge used for
+              connections to the exterior of a PBN or PBBN.";
+          }
+          bit customer-edge-port {
+            position "3";
+            description
+              "Indicates the port can be a C-TAG aware port of a
+              Provider Bridge used for connections to the exterior of
+              a PBN or PBBN.";
+          }
+          bit customer-backbone-port {
+            position "4";
+            description
+              "Indicates the port can be a I-TAG aware port of a
+              Backbone Edge Bridge's B-component.";
+          }
+          bit virtual-instance-port {
+            position "5";
+            description
+              "Indicates the port can be a virtual S-TAG aware port
+              within a Backbone Edge Bridge's I-component which is
+              responsible for handling S-tagged traffic for a specific
+              backbone service instance.";
+          }
+          bit d-bridge-port {
+            position "6";
+            description
+              "Indicates the port can be a VLAN-unaware member of an
+              802.1Q Bridge.";
+          }
+          bit remote-customer-access-port {
+            position "7";
+            description
+              "Indicates the port can be an S-TAG aware port of a
+              Provider Bridge capable of providing Remote Customer
+              Service Interfaces.";
+          }
+          bit station-facing-bridge-port {
+            position "8";
+            description
+              "Indicates the station-facing Bridge Port in a EVB
+              Bridge.";
+          }
+          bit uplink-access-port {
+            position "9";
+            description
+              "Indicates the uplink access port in an EVB Bridge or
+              EVB station.";
+          }
+          bit uplink-relay-port {
+            position "10";
+            description
+              "Indicates the uplink relay port in an EVB station.";
+          }
+        }
+        config false;
         description
           "The type of feature capabilities supported with port.
-        	Indicates the capabilities of this port.";
+          Indicates the capabilities of this port.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.4.2";
+          "12.4.2 of IEEE Std 802.1Q-2018";
       }
       leaf external {
         type boolean;
         config false;
         description
-          "A boolean indicating whether the port is external. A
-          value of True means the port is external. A value of 
-        	False means the port is internal.";
+          "A boolean indicating whether the port is external. A value
+          of True means the port is external. A value of False means
+          the port is internal.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.4.2";
+          "12.4.2 of IEEE Std 802.1Q-2018";
       }
       leaf oper-point-to-point {
         type boolean;
@@ -1644,90 +1631,91 @@ module ieee802-dot1q-bridge {
           "For a port running spanning tree, this object represents
           the operational point-to-point status of the LAN segment
           attached to this port. It indicates whether a port is
-          considered to have a point-to-point connection. 
-        	
-        	If admin-point-to-point is set to auto(2), then the value
-        	of oper-point-to-point is determined in accordance with 
-        	the specific procedures defined for the MAC entity 
-        	concerned, as defined in IEEE Std 802.1AC. 
-        	
-        	The value is determined dynamically; that is, it is 
-        	re-evaluated whenever the value of admin-point-to-point
-        	changes, and whenever the specific procedures defined for
-        	the MAC entity evaluate a change in its point-to-point
-        	status.";
+          considered to have a point-to-point connection.
+          
+          If admin-point-to-point is set to auto(2), then the value of
+          oper-point-to-point is determined in accordance with the
+          specific procedures defined for the MAC entity concerned, as
+          defined in IEEE Std 802.1AC.
+          
+          The value is determined dynamically; that is, it is
+          re-evaluated whenever the value of admin-point-to-point
+          changes, and whenever the specific procedures defined for
+          the MAC entity evaluate a change in its point-to-point
+          status.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.4.2, IEEE 802.1AC";
+          "IEEE Std 802.1AC
+          12.4.2 of IEEE Std 802.1Q-2018";
       }
       container statistics {
-      	config false;
+        config false;
         description
-          "Container of operational state node information
-          associated with the bridge port.";
+          "Container of operational state node information associated
+          with the bridge port.";
         uses dot1qtypes:bridge-port-statistics-grouping;
         leaf discard-on-ingress-filtering {
-    	  when "../../component-name != 'd-bridge-component'" {
+          when "../../component-name != 'd-bridge-component'" {
             description
-              "Applies to non TPMR Bridges";
+              "Applies to non TPMRs";
           }
-          if-feature ingress-filtering;
+          if-feature "ingress-filtering";
           type yang:counter64;
           description
-            "The number of frames that were discarded as a result
-          	of Ingress Filtering being enabled.
-          	
-          	Discontinuities in the value of this counter can occur
-            at re-initialization of the management system, and at
-            other times as indicated by the value of
-            'discontinuity-time'.";
+            "The number of frames that were discarded as a result of
+            Ingress Filtering being enabled.
+            
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of 'discontinuity-time'.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+            "12.6.1.1.3 of IEEE Std 802.1Q-2018";
         }
       }
       list vid-translations {
-	      when "../component-name != 'd-bridge-component'" {
+        when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
         key "local-vid";
         description
           "To configure the VID Translation Table (6.9) associated
-          with a Port. This object is not applicable to Ports that
-          do not support a VID Translation Table. The default
+          with a Port. This object is not applicable to Ports that do
+          not support a VID Translation Table. The default
           configuration of the table has the value of the Relay VID
           equal to the value of the Local VID. If no local VID is
-        	configured, then it is assumed that the relay VID is
-        	the same value as the local VID.
-        	
-        	If the port supports an Egress VID translation
-          table, the VID Translation Configuration object configures
-          the Local VID to Relay VID mapping on ingress only. If an
-          Egress VID translation is not supported, the VID
-          Translation Configuration object defines a single
-          bidirectional mapping. In this case, the Bridge should
-        	not allow multiple keys ('local-vid') mapped to the same
-        	'relay-vid' value.";
+          configured, then it is assumed that the relay VID is the
+          same value as the local VID.
+          
+          If the port supports an Egress VID translation table, the
+          VID Translation Configuration object configures the Local
+          VID to Relay VID mapping on ingress only. If an Egress VID
+          translation is not supported, the VID Translation
+          Configuration object defines a single bidirectional mapping.
+          In this case, the Bridge should not allow multiple keys
+          ('local-vid') mapped to the same 'relay-vid' value.";
         leaf local-vid {
           type dot1qtypes:vlanid;
           description
             "The Local VID after translation received at the ISS or
             EISS.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.10.1.8, 6.9";
+            "12.10.1.8 of IEEE Std 802.1Q-2018
+            6.9 of IEEE Std 802.1Q-2018";
         }
         leaf relay-vid {
           type dot1qtypes:vlanid;
           description
-            "The Relay VID received before translation received at
-            ISS or EISS.";
+            "The Relay VID received before translation received at ISS
+            or EISS.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.10.1.8, 6.9";
+            "12.10.1.8 of IEEE Std 802.1Q-2018
+            6.9 of IEEE Std 802.1Q-2018";
         }
       }
       list egress-vid-translations {
-	      when "../component-name != 'd-bridge-component'" {
+        when "../component-name != 'd-bridge-component'" {
           description
-            "Applies to non TPMR Bridges";
+            "Applies to non TPMRs";
         }
         key "relay-vid";
         description
@@ -1736,15 +1724,16 @@ module ieee802-dot1q-bridge {
           Ports that do not support an Egress VID Translation Table.
           The default configuration of the table has the value of the
           Local VID equal to the value of the Relay VID. If no Relay
-        	VID is configured, then it is assumed that the local VID
-        	is the same value as the relay VID.";
+          VID is configured, then it is assumed that the local VID is
+          the same value as the relay VID.";
         leaf relay-vid {
           type dot1qtypes:vlanid;
           description
-            "The Relay VID received before translation received at
-            ISS or EISS.";
+            "The Relay VID received before translation received at ISS
+            or EISS.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.10.1.9, 6.9";
+            "12.10.1.9 of IEEE Std 802.1Q-2018
+            6.9 of IEEE Std 802.1Q-2018";
         }
         leaf local-vid {
           type dot1qtypes:vlanid;
@@ -1752,9 +1741,11 @@ module ieee802-dot1q-bridge {
             "The Local VID after translation received at the ISS or
             EISS.";
           reference
-            "IEEE 802.1Q-2017 Clause 12.10.1.9, 6.9";
+            "12.10.1.9 of IEEE Std 802.1Q-2018
+            6.9 of IEEE Std 802.1Q-2018";
         }
       }
     }
   }
 }
+

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -10,11 +10,11 @@ module ieee802-dot1q-cfm {
   import ieee802-dot1q-bridge { prefix "dot1q"; }
 
   organization
-    "Institute of Electrical and Electronics Engineers";
+    "IEEE 802.1 Working Group";
 
   contact
-  	"WG-URL: http://grouper.ieee.org/groups/802/1/
-    WG-EMail: stds-802-1@ieee.org
+  	"WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
 
     Contact: IEEE 802.1 Working Group Chair
     Postal: C/O IEEE 802.1 Working Group
@@ -25,7 +25,7 @@ module ieee802-dot1q-cfm {
             NJ 08855-1331
             USA
  	
-    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
+    E-mail: STDS-802-1-L@IEEE.ORG";
 
   description
     "Connectivity Fault Management (CFM) comprises capabilities
@@ -39,8 +39,7 @@ module ieee802-dot1q-cfm {
     description
       "Initial creation for Task Group review.";
     reference
-      "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
-      Virtual Bridged Local Area Networks.";
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
   
   /* --------------------------------------------------
@@ -1315,7 +1314,7 @@ module ieee802-dot1q-cfm {
   	
   	container cfm-stacks {
   		description 
-  			"he CFM Stack contains information about the Maintenance
+  			"The CFM Stack contains information about the Maintenance
     		Points configured on a particular Bridge Port (or
     		aggregated port). It contains all CFM Stack specific related
     		configuration and operational data.";
@@ -1343,14 +1342,14 @@ module ieee802-dot1q-cfm {
       			aggregated port on which MEPs or MHFs might be 
       			configured.";
       		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2a";
+      			"12.14.2.1.2a of IEEE Std 802.1Q-2018";
       	}
       	leaf md-level {
       		type md-level-type;
       		description
       			"The MD level of the maintenance point";
       		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2b";
+      			"12.14.2.1.2b  of IEEE Std 802.1Q-2018";
       	}
       	leaf direction {
       		type mp-direction-type;
@@ -1358,7 +1357,7 @@ module ieee802-dot1q-cfm {
       			"The direction in which the maintenance point faces on the 
       			Bridge Port.";
       		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.2c";  		
+      			"12.14.2.1.2c of IEEE Std 802.1Q-2018";  		
       	}
       	container service-id {
     			description 
@@ -1383,7 +1382,7 @@ module ieee802-dot1q-cfm {
       			Points Maintenance Association is associated. If none,
       			then 0.";
       		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.3b";
+      			"12.14.2.1.3b of IEEE Std 802.1Q-2018";
       	}
       	leaf maintenance-association-index {
       		type uint32;
@@ -1392,7 +1391,7 @@ module ieee802-dot1q-cfm {
       			"The Maintenance Association reference to which the 
       			Maintenance Point is associated. If none, then 0.";
       		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.3c";
+      			"12.14.2.1.3c of IEEE Std 802.1Q-2018";
       	}
       	leaf mep-id {
       		type mep-id-or-zero-type;
@@ -1400,7 +1399,7 @@ module ieee802-dot1q-cfm {
       		description
       			"The MEP identifier is a MEP is configured. Otherwise is 0.";
       		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.3d";
+      			"12.14.2.1.3d of IEEE Std 802.1Q-2018";
       	}
       	leaf mac-address {
       		type ieee:mac-address;
@@ -1408,7 +1407,7 @@ module ieee802-dot1q-cfm {
       		description
       			"The MAC address of the maintenance point.";
       		reference
-      			"IEEE 802.1Q-2017 Clause 12.14.2.1.3e";
+      			"12.14.2.1.3e of IEEE Std 802.1Q-2018";
       	}
     	}	 // cfm-stack
   	} // cfm-stacks
@@ -1454,14 +1453,14 @@ module ieee802-dot1q-cfm {
     				Bridge, or if only one component is present in the Bridge,
     				then this variable (index) MUST be equal to 1.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 12.3l";
+    				"12.3l of IEEE Std 802.1Q-2018";
     		}
     		container primary-service-id {
     			description
     				"A vid or isid in an I or B component.";
     			uses service-id;
     			reference
-      			"IEEE 802.1Q-2017 Clause 12.14.3.1.2a";
+      			"12.14.3.1.2a of IEEE Std 802.1Q-2018";
     		}
     		container associated-service-ids {
     			description
@@ -1473,7 +1472,7 @@ module ieee802-dot1q-cfm {
       			List is empty if no primary VID specified.";
     			uses service-id;
     			reference
-      			"IEEE 802.1Q-2017 Clause 12.14.3.1.3a";
+      			"12.14.3.1.3a of IEEE Std 802.1Q-2018";
     		}
     		leaf md-status {
     			type boolean;
@@ -1484,7 +1483,7 @@ module ieee802-dot1q-cfm {
     				an MA for the same VLAN ID and MD Level as this tables
     				entry, and on which MA an Up MEP is defined, else false.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 12.14.3.1.3b";
+    				"12.14.3.1.3b of IEEE Std 802.1Q-2018";
     		}
     		leaf md-level {
     			type md-level-or-none-type;
@@ -1495,7 +1494,7 @@ module ieee802-dot1q-cfm {
     				be controlled, for the VLAN to which this entry's objects
     				apply.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 12.14.3.1.3c, 12.14.3.2.2b";
+    				"12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
     		}
     		leaf mhf-creation {
     			type mhf-creation-type;
@@ -1507,7 +1506,7 @@ module ieee802-dot1q-cfm {
     				is controlled by md-mhf-creation. The value of this variable
     				is meaningless if the values of md-status is false.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 12.14.3.1.3d";
+    				"12.14.3.1.3d of IEEE Std 802.1Q-2018";
     			
     		}
     		leaf id-permission {
@@ -1522,7 +1521,7 @@ module ieee802-dot1q-cfm {
     				value of this variable is meaningless if the values of
     				md-status is false.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 12.14.3.1.3e, 12.14.3.2.2a";
+    				"12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
     		}
     	} // default-md-level
   	} // default-md-levels
@@ -1536,7 +1535,7 @@ module ieee802-dot1q-cfm {
 					"The interface index of the interface (i.e., Bridge 
 					Port) to which the MEP is attached.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+					"12.14.7.1.3b of IEEE Std 802.1Q-2018";
 			}
   		container service-ids {
   			description
@@ -1555,7 +1554,7 @@ module ieee802-dot1q-cfm {
   				be controlled, for the VLAN to which this entry's objects
   				apply.";
   			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3c, 12.14.3.2.2b";
+  				"12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
   		}
   		leaf id-permission {
   			type sender-id-permission-type;
@@ -1567,7 +1566,7 @@ module ieee802-dot1q-cfm {
   				has the value send-if-defer, Sender ID TLV transmission 
   				for this VLAN is controlled by md-id-permission-type.";
   			reference
-  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3e, 12.14.3.2.2a";
+  				"12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
   		}
   	} // mip
   	
@@ -1596,7 +1595,7 @@ module ieee802-dot1q-cfm {
   					delete any entries in config-error-list indexed by that
   					interface-ref.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.4.1.2b";
+  					"12.14.4.1.2b of IEEE Std 802.1Q-2018";
   			}
   			container service-id {
   				description 
@@ -1604,7 +1603,7 @@ module ieee802-dot1q-cfm {
     				interfaces in error.";
   				uses service-id;
   				reference
-    				"IEEE 802.1Q-2017 Clause 12.14.4.1.2a";
+    				"12.14.4.1.2a of IEEE Std 802.1Q-2018";
   			}
   			leaf error-type {
   				type config-errors;
@@ -1612,7 +1611,7 @@ module ieee802-dot1q-cfm {
   				description
   					"vector of Boolean error conditions from 22.2.4.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.4.1.3b";
+  					"12.14.4.1.3b of IEEE Std 802.1Q-2018";
   			}
   		} // config-error
   	} // config-errors
@@ -1647,7 +1646,7 @@ module ieee802-dot1q-cfm {
     			description
     				"The type (or format) of the Maintenance Domain name.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 21.6.5.1";
+    				"21.6.5.1 of IEEE Std 802.1Q-2018";
     		}
     		leaf name {
     			type md-name-type;
@@ -1659,7 +1658,7 @@ module ieee802-dot1q-cfm {
     				of administrative responsibility for each Maintenance
     				Domain.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 3.122, 21.6.5.3";
+    				"3.122, 21.6.5.3 of IEEE Std 802.1Q-2018";
     		}
     		leaf md-level {
     			type md-level-type;
@@ -1667,7 +1666,7 @@ module ieee802-dot1q-cfm {
     			description
     				"The Maintenance Domain level.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3b";
+    				"3.122, 12.14.5.1.3b of IEEE Std 802.1Q-2018";
     		}
     		leaf mhf-creation {
     			type mhf-creation-type;
@@ -1678,7 +1677,7 @@ module ieee802-dot1q-cfm {
     				Domain. Since there is no encompassing Maintenance
     				Domain, the value mhf-defer is not allowed.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
+    				"3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
     		}
     		leaf id-permission {
     			type sender-id-permission-type;
@@ -1690,7 +1689,7 @@ module ieee802-dot1q-cfm {
     				encompassing Maintenance Domain, the value send-id-defer
     				is not allowed.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3d";
+    				"3.122, 12.14.5.1.3d of IEEE Std 802.1Q-2018";
     		}
     		leaf fault-alarm-address {
     			type fault-alarm-address-type;
@@ -1699,7 +1698,7 @@ module ieee802-dot1q-cfm {
     				"A value indicating whether Fault Alarms are to be 
     				transmitted or not. The default is not transmit.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3e";
+    				"3.122, 12.14.5.1.3e of IEEE Std 802.1Q-2018";
     		}
     		
     		list maintenance-association {
@@ -1724,14 +1723,14 @@ module ieee802-dot1q-cfm {
     					is determined by the value of ma-name-format. This name
     					must be unique within a maintenance domain.";
     				reference
-    					"IEEE 802.1Q-2017 Clause 21.6.5.6";
+    					"21.6.5.6 of IEEE Std 802.1Q-2018";
     			}
     			leaf name-format {
     				type ma-name-format-type;
     				description
     					"The type (format) of the Maintenance Association name.";
     				reference
-    					"IEEE 802.1Q-2017 Clause 21.6.5.4";
+    					"21.6.5.4 of IEEE Std 802.1Q-2018";
     			}
     			leaf md-index {
     				type uint32;
@@ -1739,7 +1738,7 @@ module ieee802-dot1q-cfm {
     					"An index reference to the Maintenance Domain that this
     					Maintenance Association belongs to.";
     				reference
-    					"IEEE 802.1Q-2017 Clause 12.14.5.3.2a";
+    					"12.14.5.3.2a of IEEE Std 802.1Q-2018";
     			}
     			leaf ccm-interval {
     				type cfm-interval-type;
@@ -1748,7 +1747,7 @@ module ieee802-dot1q-cfm {
     					"The interval between CCM transmissions to be used by all
     					MEPs in the Maintenance Association.";
     				reference
-    					"IEEE 802.1Q-2017 Clause 12.14.6.1.3e";
+    					"12.14.6.1.3e of IEEE Std 802.1Q-2018";
     			}
     			leaf fault-alarm-address {
       			type fault-alarm-address-type;
@@ -1759,7 +1758,7 @@ module ieee802-dot1q-cfm {
       				which implies that the disposition of the fault-alarm
       				used by the MD should be used.";
       			reference
-      				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3e";
+      				"3.122, 12.14.5.1.3e of IEEE Std 802.1Q-2018";
       		}  				
   				leaf maintenance-group {
         		type maintenance-group-type;
@@ -1782,7 +1781,7 @@ module ieee802-dot1q-cfm {
     						if only one component is present in the Bridge, then
     						this variable (index) MUST be equal to 1";
     					reference
-    						"IEEE 802.1Q-2017 Clause 12.3l";
+    						"12.3l of IEEE Std 802.1Q-2018";
     				}
     				container service-id {
     					description
@@ -1795,7 +1794,7 @@ module ieee802-dot1q-cfm {
       	  			only in the case that PBB-TE is supported.";
     					uses service-id;
       	  		reference
-      	  			"IEEE 802.1Q-2017 Clause 12.14.5.3.2c, 12.14.6.1.3b";
+      	  			"12.14.5.3.2c, 12.14.6.1.3b of IEEE Std 802.1Q-2018";
     				}
     				leaf mhf-creation {
         			type mhf-creation-type;
@@ -1806,7 +1805,7 @@ module ieee802-dot1q-cfm {
         				Domain. Since there is no encompassing Maintenance
         				Domain, the value mhf-defer is not allowed.";
         			reference
-        				"IEEE 802.1Q-2017 Clause 3.122, 12.14.5.1.3c";
+        				"3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
         		}
     				leaf id-permission {
     					type sender-id-permission-type;
@@ -1816,7 +1815,7 @@ module ieee802-dot1q-cfm {
     	  				be included in the Sender ID TLV (21.5.3) transmitted
     	  				by MPs configured in this MA.";
     	  			reference
-    	  				"IEEE 802.1Q-2017 Clause 12.14.3.1.3d";
+    	  				"12.14.3.1.3d of IEEE Std 802.1Q-2018";
     				}
     			} // maintenance-association-component
     		} // maintenance-association
@@ -1843,7 +1842,7 @@ module ieee802-dot1q-cfm {
   					"Integer that is unique among all the MEPs in the
   					same Maintenance Association.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+  					"3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
   			}
   			leaf maintenance-group {
       		type maintenance-group-type;
@@ -1857,7 +1856,7 @@ module ieee802-dot1q-cfm {
   					"An index reference to the particular Maintenance
   					Association that this MEP belongs to.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.6.3.2a";
+  					"12.14.6.3.2a of IEEE Std 802.1Q-2018";
   			}
   			leaf port {
   				type if:interface-ref;
@@ -1865,7 +1864,7 @@ module ieee802-dot1q-cfm {
   					"The interface index of the interface (e.g., Bridge 
   					Port) to which the MEP is attached.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+  					"12.14.7.1.3b of IEEE Std 802.1Q-2018";
   			}
   			leaf direction {
   				type mp-direction-type;
@@ -1873,7 +1872,7 @@ module ieee802-dot1q-cfm {
   					"The direction in which the MEP faces on the Bridge
   					Port. Example, up or down.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3c, 19.2";
+  					"12.14.7.1.3c, 19.2 of IEEE Std 802.1Q-2018";
   			}
   			leaf primary-vid {
   				type uint32 {
@@ -1887,7 +1886,7 @@ module ieee802-dot1q-cfm {
   					that of the MEPs MA, or that the MEPs MA is 
   					associated with no VID.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3d";	
+  					"12.14.7.1.3d of IEEE Std 802.1Q-2018";	
   			}
   			leaf admin-state {
   				type boolean;
@@ -1897,7 +1896,7 @@ module ieee802-dot1q-cfm {
   					that the MEP is to functional normally, and FALSE
   					indicates that it is to cease functioning.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3e, 20.9.1";
+  					"12.14.7.1.3e, 20.9.1 of IEEE Std 802.1Q-2018";
   			}
   			leaf fng-state {
   				type fng-state-type;
@@ -1907,7 +1906,7 @@ module ieee802-dot1q-cfm {
   					"The current state of the MEP Fault Notification 
   					Generator state machine.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3f, 20.35";
+  					"12.14.7.1.3f, 20.35 of IEEE Std 802.1Q-2018";
   			}
   			leaf ccm-ltm-priority {
   				type dot1q-types:priority-type;
@@ -1917,7 +1916,7 @@ module ieee802-dot1q-cfm {
   					allowed to pass through the Bridge Port for any of
   					the MEPs VID(s).";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+  					"12.14.7.1.3h of IEEE Std 802.1Q-2018";
   			}
   			leaf mac-address {
   				type ieee:mac-address;
@@ -1925,7 +1924,7 @@ module ieee802-dot1q-cfm {
   				description
   					"The MAC address of the MEP.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3i, 19.4";
+  					"12.14.7.1.3i, 19.4 of IEEE Std 802.1Q-2018";
   			}
   			leaf fault-alarm-address {
     			type fault-alarm-address-type;
@@ -1936,7 +1935,7 @@ module ieee802-dot1q-cfm {
     				which implies that the disposition of the fault-alarm
     				used by the MD should be used.";
     			reference
-    				"IEEE 802.1Q-2017 Clause 3.122, 12.14.7.1.3j";
+    				"3.122, 12.14.7.1.3j of IEEE Std 802.1Q-2018";
     		}
   			leaf lowest-priority-defect {
   				type lowest-alarm-priority-type;
@@ -1945,7 +1944,7 @@ module ieee802-dot1q-cfm {
   					"The lowest priority defect that is allowed to
   					generate fault alarms.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3k, 20.9.5";
+  					"12.14.7.1.3k, 20.9.5 of IEEE Std 802.1Q-2018";
   			}
   			leaf fng-alarm-time {
   				type yang:zero-based-counter32 {
@@ -1957,7 +1956,7 @@ module ieee802-dot1q-cfm {
   					"The time that defect must be present before a Fault
   					Alarm is issued.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3l, 20.35.3";
+  					"12.14.7.1.3l, 20.35.3 of IEEE Std 802.1Q-2018";
   			}
   			leaf fng-reset-time {
   				type yang:zero-based-counter32 {
@@ -1969,7 +1968,7 @@ module ieee802-dot1q-cfm {
   					"The time that defects must be absent before 
   					resetting a Fault Alarm.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3m, 20.35.4";
+  					"12.14.7.1.3m, 20.35.4 of IEEE Std 802.1Q-2018";
   			}
   			leaf highest-priority-defect {
   				type highest-defect-priority-type;
@@ -1979,7 +1978,7 @@ module ieee802-dot1q-cfm {
   					sicne the MEPs Fault Notification Generator state
   					machine was last in the FNG_RESET state.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3n, 20.35.9";
+  					"12.14.7.1.3n, 20.35.9 of IEEE Std 802.1Q-2018";
   			}
   			leaf defects {
   				type mep-defects-type;
@@ -1987,8 +1986,8 @@ module ieee802-dot1q-cfm {
   				description
   					"Vector of boolean error conditions";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3o-s, 20.21.3,
-  					20.23.3, 20.35.5, 20.35.6, 20.35.7";
+  					"12.14.7.1.3o-s, 20.21.3,
+  					20.23.3, 20.35.5, 20.35.6, 20.35.7 of IEEE Std 802.1Q-2018";
   			}
   			leaf error-ccm-last-failure {
   				type string {
@@ -1999,7 +1998,7 @@ module ieee802-dot1q-cfm {
   					"The last received CCM that triggered a def-error-ccm
   					fault.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3t, 20.21.2";
+  					"12.14.7.1.3t, 20.21.2 of IEEE Std 802.1Q-2018";
   			}
   			leaf xcon-ccm-last-failure {
   				type string {
@@ -2010,7 +2009,7 @@ module ieee802-dot1q-cfm {
   					"The last received CCM that triggered a def-xcon-ccm
   					fault.";
   				reference
-  					"IEEE 802.1Q-2017 Clause 12.14.7.1.3u, 20.23.2";
+  					"12.14.7.1.3u, 20.23.2 of IEEE Std 802.1Q-2018";
   			}
   			
   			list linktrace-reply {
@@ -2028,7 +2027,7 @@ module ieee802-dot1q-cfm {
   						transmit linktrace message command, indicating
   						which LTMs response is going to be returned.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.2b";
+  						"12.14.7.5.2b of IEEE Std 802.1Q-2018";
   				}
   				leaf ltr-receive-order {
   					type uint32 {
@@ -2048,7 +2047,7 @@ module ieee802-dot1q-cfm {
   					description
   						"TTL field value for a returned LTR.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5, 20.41.2.2";
+  						"12.14.7.5, 20.41.2.2 of IEEE Std 802.1Q-2018";
   				}
   				leaf ltr-forwarded {
   					type boolean;
@@ -2058,7 +2057,7 @@ module ieee802-dot1q-cfm {
   						MP, as returned in the FwdYes flag of the flags 
   						field.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3c, 20.41.2.1";
+  						"12.14.7.5.3c, 20.41.2.1 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-terminal-mep {
   					type boolean;
@@ -2068,7 +2067,7 @@ module ieee802-dot1q-cfm {
   						reached a MEP enclosing its MA, as returned in the
   						Terminal MEP flag of the Flags field";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3d, 20.41.2.1";
+  						"12.14.7.5.3d, 20.41.2.1 of IEEE Std 802.1Q-2018";
   				}
   				leaf ltr-last-egress-identifier {
   					type string {
@@ -2084,7 +2083,7 @@ module ieee802-dot1q-cfm {
   						which this LTR is the response. This is the same
   						value as the Egress Identifier TLV of that LTM.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3e, 20.41.2.3";
+  						"12.14.7.5.3e, 20.41.2.3 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-next-egress-identifier {
   					type string {
@@ -2103,7 +2102,7 @@ module ieee802-dot1q-cfm {
   						are undefined, i.e., any value can be transmitted,
   						and the field is ignored by the receiver.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3f, 20.41.2.4";
+  						"12.14.7.5.3f, 20.41.2.4 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-relay {
   					type relay-action-field-value;
@@ -2111,7 +2110,7 @@ module ieee802-dot1q-cfm {
   					description
   						"Value returned in the Relay Action field.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3g, 20.41.2.5";
+  						"12.14.7.5.3g, 20.41.2.5 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-chassis-id-subtype {
   					type lldp-chassis-id-subtype;
@@ -2122,7 +2121,7 @@ module ieee802-dot1q-cfm {
   						is meaningless if the ltr-chassis-id has a length
   						of 0.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3h, 21.5.3.2";
+  						"12.14.7.5.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-chassis-id {
   					type lldp-chassis-id;
@@ -2133,7 +2132,7 @@ module ieee802-dot1q-cfm {
   						determined by the value of the 
   						ltr-chassis-id-subtype object.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3i, 21.5.3.2";
+  						"12.14.7.5.3i, 21.5.3.2 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-man-address-domain {
   					type transport-service-domain;
@@ -2145,8 +2144,8 @@ module ieee802-dot1q-cfm {
   						transmitting the LTR. Received in the LTR Sender ID
   						TLV from that system.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.5,
-  						21.9.6";
+  						"12.14.7.5.3j, 21.5.3.5,
+  						21.9.6 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-man-address {
   					type transport-service-address;
@@ -2162,8 +2161,8 @@ module ieee802-dot1q-cfm {
   						ltr-man-address MUST have a zero-length OCTET 
   						STRING as a value.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3j, 21.5.3.7,
-  						21.9.6";
+  						"12.14.7.5.3j, 21.5.3.7,
+  						21.9.6 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-ingress {
   					type ingress-action-field-value;
@@ -2173,7 +2172,7 @@ module ieee802-dot1q-cfm {
   						the LTM. The value ingress-no-tlv indicates that no
   						Reply Ingress TLV was returned in the LTM.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3k, 20.41.2.6";
+  						"12.14.7.5.3k, 20.41.2.6 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-ingress-mac {
   					type ieee:mac-address;
@@ -2184,7 +2183,7 @@ module ieee802-dot1q-cfm {
   						ingress-no-tlv, then the contents of this object
   						are meaningless.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3l, 20.41.2.7";
+  						"12.14.7.5.3l, 20.41.2.7 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-ingress-port-id-subtype {
   					type lldp-port-id-subtype;
@@ -2197,7 +2196,7 @@ module ieee802-dot1q-cfm {
   						ingress-no-tlv, then the contents of this object
   						are meaningless.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3n, 20.41.2.9";
+  						"12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-egress {
   					type egress-action-field-value;
@@ -2207,7 +2206,7 @@ module ieee802-dot1q-cfm {
   						the LTM. The value egress-no-tlv indicates that 
   						no Reply Egress TLV was returned in the LTM.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3o, 20.41.2.10";
+  						"12.14.7.5.3o, 20.41.2.10 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-egress-mac {
   					type ieee:mac-address;
@@ -2218,7 +2217,7 @@ module ieee802-dot1q-cfm {
   						egress-no-tlv, then the contents of this object are
   						meaningless.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3p, 20.41.2.11";
+  						"12.14.7.5.3p, 20.41.2.11 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-egress-port-id-subtype {
   					type lldp-port-id-subtype;
@@ -2228,7 +2227,7 @@ module ieee802-dot1q-cfm {
   						object contains the value egress-no-tlv, then the
   						contents of this object are meaningless.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3q, 20.41.2.12";
+  						"12.14.7.5.3q, 20.41.2.12 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-egress-port-id {
   					type lldp-port-id;
@@ -2240,7 +2239,7 @@ module ieee802-dot1q-cfm {
   						ltr-egress object contains the value egress-no-tlv,
   						then the contents of this object are meaningless.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3r, 20.41.2.13";
+  						"12.14.7.5.3r, 20.41.2.13 of IEEE Std 802.1Q-2018";
   				}  					
   				leaf ltr-organization-specific-tlv {
   					type string {
@@ -2253,7 +2252,7 @@ module ieee802-dot1q-cfm {
   						following the TLV Length field of each TLV, 
   						concatenated together.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.5.3s, 21.5.2";
+  						"12.14.7.5.3s, 21.5.2 of IEEE Std 802.1Q-2018";
   				}
   			} // linktrace-reply
   			
@@ -2270,7 +2269,7 @@ module ieee802-dot1q-cfm {
   						remote MEP whose information from the MEP Database
   						is to be returned.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.2b";  						
+  						"12.14.7.6.2b of IEEE Std 802.1Q-2018";  						
   				}
   				leaf rmep-state {
   					type remote-mep-state-type;
@@ -2279,7 +2278,7 @@ module ieee802-dot1q-cfm {
   						"The operational state of the remote MEP  state
   						machine";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3b, 20.20";
+  						"12.14.7.6.3b, 20.20 of IEEE Std 802.1Q-2018";
   				}
   				leaf rmep-failed-ok-time {
   					type yang:zero-based-counter32;
@@ -2290,7 +2289,7 @@ module ieee802-dot1q-cfm {
   						machine last entered either the RMEP_FAILED or
   						RMEP_OK state";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3c";
+  						"12.14.7.6.3c of IEEE Std 802.1Q-2018";
   				}
   				leaf mac-address {
   					type ieee:mac-address;
@@ -2298,7 +2297,7 @@ module ieee802-dot1q-cfm {
   					description
   						"The MAC address of the remote MEP.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3d, 20.19.7";
+  						"12.14.7.6.3d, 20.19.7 of IEEE Std 802.1Q-2018";
   				}
   				leaf rdi {
   					type boolean;
@@ -2308,7 +2307,7 @@ module ieee802-dot1q-cfm {
   						(true for RDI=1), or false if none has been 
   						received.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3e, 20.19.2";
+  						"12.14.7.6.3e, 20.19.2 of IEEE Std 802.1Q-2018";
   				}
   				leaf port-status-tlv {
   					type port-status-tlv-value;
@@ -2321,7 +2320,7 @@ module ieee802-dot1q-cfm {
   						either no CCM has been received, or that no port
   						status TLV was received in the last CCM.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3f, 20.19.3";
+  						"12.14.7.6.3f, 20.19.3 of IEEE Std 802.1Q-2018";
   				}
   				leaf interface-status-tlv {
   					type interface-status-tlv-value;
@@ -2335,7 +2334,7 @@ module ieee802-dot1q-cfm {
   						interface status TLV was received in the last 
   						CCM.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3g, 20.19.4";
+  						"12.14.7.6.3g, 20.19.4 of IEEE Std 802.1Q-2018";
   				}
   				leaf chassis-id-subtype {
   					type lldp-chassis-id-subtype;
@@ -2344,7 +2343,7 @@ module ieee802-dot1q-cfm {
   						"This object specifies the format of the Chassis ID
   						received in the last CCM.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.2";
+  						"12.14.7.6.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
   				}
   				leaf chassis-id {
   					type lldp-chassis-id;
@@ -2354,7 +2353,7 @@ module ieee802-dot1q-cfm {
   						determined by the value of the 
   						ltr-chassis-id-subtype object.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.3";
+  						"12.14.7.6.3h, 21.5.3.3 of IEEE Std 802.1Q-2018";
   				}
   				leaf man-address-domain {
   					type transport-service-domain;
@@ -2371,8 +2370,8 @@ module ieee802-dot1q-cfm {
   						case the related mep-db-man-address object MUST
   						have a zero-length OCTET STRING as a value.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.5,
-  						21.6.7";
+  						"12.14.7.6.3h, 21.5.3.5,
+  						21.6.7 of IEEE Std 802.1Q-2018";
   				}
   				leaf man-address {
   					type transport-service-address;
@@ -2386,8 +2385,8 @@ module ieee802-dot1q-cfm {
   						value zeroDotZero, this object mep-db-man-address
   						MUST have a zero-length OCTET STRING as a value.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.6.3h, 21.5.3.7,
-  						21.6.7";
+  						"12.14.7.6.3h, 21.5.3.7,
+  						21.6.7 of IEEE Std 802.1Q-2018";
   				}
   				leaf rmep-is-active {
   					type boolean;
@@ -2395,7 +2394,7 @@ module ieee802-dot1q-cfm {
   						"A Boolean value statign if the remote MEP is 
   						active.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ae";
+  						"12.14.7.1.3ae";
   				}
   			} // mep-db
   			
@@ -2409,14 +2408,14 @@ module ieee802-dot1q-cfm {
   						"The total number of out-of-sequence CCMs received
   						from all remote MEPs.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3v, 20.16.12";
+  						"12.14.7.1.3v, 20.16.12 of IEEE Std 802.1Q-2018";
   				}
   				leaf mep-ccms-sent {
   					type yang:counter64;
   					description
   						"Total number of CCMs transmitted";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3w, 20.10.2";
+  						"12.14.7.1.3w, 20.10.2 of IEEE Std 802.1Q-2018";
   				}
   				leaf mep-lbr-in {
   					type yang:counter64;
@@ -2424,7 +2423,7 @@ module ieee802-dot1q-cfm {
   						"Total number of valid, in-order Loopback Replies
   						received.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3y, 20.31.1";
+  						"12.14.7.1.3y, 20.31.1 of IEEE Std 802.1Q-2018";
   				}
   				leaf mep-lbr-in-out-of-order {
   					type yang:counter64;
@@ -2432,7 +2431,7 @@ module ieee802-dot1q-cfm {
   						"The total number of valid, out-of-order
   						Loopback Replies received";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3z, 20.31.1";
+  						"12.14.7.1.3z, 20.31.1 of IEEE Std 802.1Q-2018";
   				}
   				leaf mep-lbr-bad-msdu {
   					type yang:counter64;
@@ -2441,21 +2440,21 @@ module ieee802-dot1q-cfm {
   						mac_service_data_unit did not match (except for the
   						OpCode) that of the corresponding LBM.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3aa, 20.2.3";
+  						"12.14.7.1.3aa, 20.2.3 of IEEE Std 802.1Q-2018";
   				}
   				leaf mep-unexpected-ltr-in {
   					type yang:counter64;
   					description
   						"The total number of unexpected LTRs received.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ac, 20.44.1";
+  						"12.14.7.1.3ac, 20.44.1 of IEEE Std 802.1Q-2018";
   				}
   				leaf mep-lbr-out {
   					type yang:counter64;
   					description
   						"Total number of Loopback Replies transmitted.";
   					reference
-  						"IEEE 802.1Q-2017 Clause 12.14.7.1.3ad, 20.28.2";
+  						"12.14.7.1.3ad, 20.28.2 of IEEE Std 802.1Q-2018";
   				}
   			} // stats
   		} // mep
@@ -2470,7 +2469,7 @@ module ieee802-dot1q-cfm {
 					"Integer that is unique among all the MEPs in the
 					same Maintenance Association.";
 				reference
-					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+					"3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
   		}
   		leaf maintenance-group {
     		type maintenance-group-type;
@@ -2484,7 +2483,7 @@ module ieee802-dot1q-cfm {
 					"The interface index of the interface (e.g., Bridge 
 					Port) to which the MEP is attached.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+					"12.14.7.1.3b of IEEE Std 802.1Q-2018";
 			}
   		leaf ccm-enabled {
 				type boolean;
@@ -2493,7 +2492,7 @@ module ieee802-dot1q-cfm {
 					"Indicates whether the MEP can generate CCMs. If 
 					TRUE, the MEP will generate CCM PDUs.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3g, 20.10.1";
+					"12.14.7.1.3g, 20.10.1 of IEEE Std 802.1Q-2018";
 			}
 			leaf priority {
 				type dot1q-types:priority-type;
@@ -2503,7 +2502,7 @@ module ieee802-dot1q-cfm {
 					allowed to pass through the Bridge Port for any of
 					the MEPs VID(s).";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+					"12.14.7.1.3h of IEEE Std 802.1Q-2018";
 			}
 			leaf ccm-interval {
 				type cfm-interval-type;
@@ -2511,7 +2510,7 @@ module ieee802-dot1q-cfm {
 					"The interval between CCM transmissions to be used by all
 					MEPs in the Maintenance Association.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.6.1.3e";
+					"12.14.6.1.3e of IEEE Std 802.1Q-2018";
 			}
   	} // continuity-check
   	
@@ -2524,7 +2523,7 @@ module ieee802-dot1q-cfm {
 					"Integer that is unique among all the MEPs in the
 					same Maintenance Association.";
 				reference
-					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+					"3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
   		}
   		leaf maintenance-group {
     		type maintenance-group-type;
@@ -2538,7 +2537,7 @@ module ieee802-dot1q-cfm {
 					"The interface index of the interface (e.g., Bridge 
 					Port) to which the MEP is attached.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+					"12.14.7.1.3b of IEEE Std 802.1Q-2018";
 			}
   		leaf status {
 				type boolean;
@@ -2550,7 +2549,7 @@ module ieee802-dot1q-cfm {
 					transmitted. Reset to FALSE by the MEP Loopback
 					initiator state machine.";
 				reference
-					"IEEE 802.1Q-2017 Clause 20.32, Figure 20-11";
+					"20.32, Figure 20-11 of IEEE Std 802.1Q-2018";
 			}
   		leaf interval {
 				type cfm-interval-type;
@@ -2567,7 +2566,7 @@ module ieee802-dot1q-cfm {
 					is used if node mep-transmit-lbm-dest-is-mep-id
 					is FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+					"12.14.7.3.2b of IEEE Std 802.1Q-2018";
 			}
 			leaf dest-mep-id {
 				type mep-id-or-zero-type;
@@ -2577,7 +2576,7 @@ module ieee802-dot1q-cfm {
 					is used if node mep-transmit-lbm-dest-is-mep-id
 					is TRUE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+					"12.14.7.3.2b of IEEE Std 802.1Q-2018";
 			}
 			leaf dest-is-mep-id {
 				type boolean;
@@ -2588,7 +2587,7 @@ module ieee802-dot1q-cfm {
 					unicast destination MAC address of the target MEP is
 					used for Loopback transmissions.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+					"12.14.7.3.2b of IEEE Std 802.1Q-2018";
 			}
 			leaf message-count {
 				type uint32 {
@@ -2598,7 +2597,7 @@ module ieee802-dot1q-cfm {
 				description
 					"The number of Loopback messages to be transmitted.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2c";
+					"12.14.7.3.2c of IEEE Std 802.1Q-2018";
 			}
 			leaf data-tlv {
 				type string;
@@ -2608,7 +2607,7 @@ module ieee802-dot1q-cfm {
 					intent is to be able to fill the frame carrying the
 					CFM PDU to its maximum length.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
+					"12.14.7.3.2d of IEEE Std 802.1Q-2018";
 			}
 			leaf priority {
 				type dot1q-types:priority-type;
@@ -2617,7 +2616,7 @@ module ieee802-dot1q-cfm {
 					present in the transmitted frame. The default value
 					should be the CCM priority.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+					"12.14.7.3.2e of IEEE Std 802.1Q-2018";
 			}
 			leaf vlan-drop-eligible {
 				type boolean;
@@ -2626,7 +2625,7 @@ module ieee802-dot1q-cfm {
 					"Drop eligible bit value to be used in the VLAN tag,
 					if present in the transmitted frame";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+					"12.14.7.3.2e of IEEE Std 802.1Q-2018";
 			}
 			leaf result-ok {
 				type boolean;
@@ -2637,7 +2636,7 @@ module ieee802-dot1q-cfm {
 					   TRUE - The LBM will be (or has been) sent.
 					   FALSE - The LBM will not be sent.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.3a";
+					"12.14.7.3.3a of IEEE Std 802.1Q-2018";
 			}
 			leaf seq-number {
 				type uint32;
@@ -2647,7 +2646,7 @@ module ieee802-dot1q-cfm {
 					sent. The value returned is undefined if 
 					mep-transmit-lbm-result-ok is FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.3b";
+					"12.14.7.3.3b of IEEE Std 802.1Q-2018";
 			}
 			leaf next-lbm-trans-id {
 				type uint32;
@@ -2657,7 +2656,7 @@ module ieee802-dot1q-cfm {
 					Loopback message. This sequence number can be zero
 					since it can wrap around.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3x, 20.28.2";
+					"12.14.7.1.3x, 20.28.2 of IEEE Std 802.1Q-2018";
 			}
   	} // loopback
   	
@@ -2670,7 +2669,7 @@ module ieee802-dot1q-cfm {
 					"Integer that is unique among all the MEPs in the
 					same Maintenance Association.";
 				reference
-					"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+					"3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
   		}
   		leaf maintenance-group {
     		type maintenance-group-type;
@@ -2684,7 +2683,7 @@ module ieee802-dot1q-cfm {
 					"The interface index of the interface (e.g., Bridge 
 					Port) to which the MEP is attached.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3b";
+					"12.14.7.1.3b of IEEE Std 802.1Q-2018";
 			}
   		leaf status {
 				type boolean;
@@ -2695,7 +2694,7 @@ module ieee802-dot1q-cfm {
 					to FALSE by the MEP Linktrace initiator state 
 					machine.";
 				reference
-					"IEEE 802.1Q-2017 Clause 20.49, Figure 20-17";
+					"20.49, Figure 20-17 of IEEE Std 802.1Q-2018";
 			}
   		leaf interval {
 				type cfm-interval-type;
@@ -2712,7 +2711,7 @@ module ieee802-dot1q-cfm {
 					allowed to pass through the Bridge Port for any of
 					the MEPs VID(s).";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3h";
+					"12.14.7.1.3h of IEEE Std 802.1Q-2018";
 			}
 			leaf flags {
 				type mep-tx-ltm-flags-type;
@@ -2721,7 +2720,7 @@ module ieee802-dot1q-cfm {
 					"The flags field for the LTMs transmitted by the 
 					MEP.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2b, 20.42.1";
+					"12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
 				
 			}
 			leaf target-mac-address {
@@ -2731,7 +2730,7 @@ module ieee802-dot1q-cfm {
 					unicast MAC address. This address will be used if the
 					value of mep-transmit-ltm-target-is-mep-id is FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+					"12.14.7.4.2c of IEEE Std 802.1Q-2018";
 			}
 			leaf target-mep-id {
 				type mep-id-or-zero-type;
@@ -2741,7 +2740,7 @@ module ieee802-dot1q-cfm {
 					address will be used if the value of 
 					mep-transmit-ltm-target-is-mep-id is TRUE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+					"12.14.7.4.2c of IEEE Std 802.1Q-2018";
 			}
 			leaf target-is-mep-id {
 				type boolean;
@@ -2752,7 +2751,7 @@ module ieee802-dot1q-cfm {
 					unicast destination MAC address of the target MEP is
 					used for LinkTrace transmission.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+					"12.14.7.4.2c of IEEE Std 802.1Q-2018";
 			}
 			leaf ttl {
 				type uint32 {
@@ -2768,7 +2767,7 @@ module ieee802-dot1q-cfm {
 					forwarded to the next hop, and if 0, no LTR is 
 					generated.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2d, 21.8.4";
+					"12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
 			}
 			leaf result {
 				type boolean;
@@ -2780,7 +2779,7 @@ module ieee802-dot1q-cfm {
 					          sent.
 					   FALSE - The Linktrace message will not be sent.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.3a";
+					"12.14.7.4.3a of IEEE Std 802.1Q-2018";
 			}
 			leaf seq-number {
 				type uint32;
@@ -2791,7 +2790,7 @@ module ieee802-dot1q-cfm {
 					returned is undefined if mep-transmit-ltm-result is 
 					FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.3b";
+					"12.14.7.4.3b of IEEE Std 802.1Q-2018";
 			}
 			leaf egress-identifier {
 				type string {
@@ -2821,7 +2820,7 @@ module ieee802-dot1q-cfm {
 					The value returned is undefined if 
 					mep-transmit-ltm-result is FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.3c";  					
+					"12.14.7.4.3c of IEEE Std 802.1Q-2018";  					
 			}
   		leaf next-seq-number {
 				type uint32;
@@ -2831,7 +2830,7 @@ module ieee802-dot1q-cfm {
 					LinkTrace message.This sequence number can be zero
 					since it can wrap around.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.1.3ab, 20.41.1";
+					"12.14.7.1.3ab, 20.41.1 of IEEE Std 802.1Q-2018";
 			}
   	} // linktrace
   	
@@ -2858,7 +2857,7 @@ module ieee802-dot1q-cfm {
 					"Integer that is unique among all the MEPs in the same
 					Maintenance Association.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2a";
+					"12.14.7.3.2a of IEEE Std 802.1Q-2018";
   		}
   		leaf interval {
 				type cfm-interval-type;
@@ -2875,7 +2874,7 @@ module ieee802-dot1q-cfm {
 					is used if node mep-transmit-lbm-dest-is-mep-id
 					is FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+					"12.14.7.3.2b of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-lbm-dest-mep-id {
 				type mep-id-or-zero-type;
@@ -2885,7 +2884,7 @@ module ieee802-dot1q-cfm {
 					is used if node mep-transmit-lbm-dest-is-mep-id
 					is TRUE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+					"12.14.7.3.2b of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-lbm-dest-is-mep-id {
 				type boolean;
@@ -2895,7 +2894,7 @@ module ieee802-dot1q-cfm {
 					unicast destination MAC address of the target MEP is
 					used for Loopback transmissions.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2b";
+					"12.14.7.3.2b of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-lbm-messages {
 				type uint32 {
@@ -2905,7 +2904,7 @@ module ieee802-dot1q-cfm {
 				description
 					"The number of Loopback messages to be transmitted.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2c";
+					"12.14.7.3.2c of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-lbm-data-tlv {
 				type string;
@@ -2915,7 +2914,7 @@ module ieee802-dot1q-cfm {
 					intent is to be able to fill the frame carrying the
 					CFM PDU to its maximum length.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2d";
+					"12.14.7.3.2d of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-lbm-vlan-priority {
 				type dot1q-types:priority-type;
@@ -2924,7 +2923,7 @@ module ieee802-dot1q-cfm {
 					present in the transmitted frame. The default value
 					should be the CCM priority.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+					"12.14.7.3.2e of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-lbm-vlan-drop-eligible {
 				type boolean;
@@ -2933,7 +2932,7 @@ module ieee802-dot1q-cfm {
 					"Drop eligible bit value to be used in the VLAN tag, if
 					present in the transmitted frame";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.2e";
+					"12.14.7.3.2e of IEEE Std 802.1Q-2018";
 			}
   	} // input
   	output {
@@ -2945,7 +2944,7 @@ module ieee802-dot1q-cfm {
 					   TRUE - The LBM will be (or has been) sent.
 					   FALSE - The LBM will not be sent.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.3a";
+					"12.14.7.3.3a of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-lbm-seq-number {
 				type uint32;
@@ -2955,7 +2954,7 @@ module ieee802-dot1q-cfm {
 					The value returned is undefined if 
 					mep-transmit-lbm-result-ok is FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.3.3b";
+					"12.14.7.3.3b of IEEE Std 802.1Q-2018";
 			}  		
   	} // output
   } // transmit-loopback-message
@@ -2977,7 +2976,7 @@ module ieee802-dot1q-cfm {
 					"Integer that is unique among all the MEPs in the same
 					Maintenance Association.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2a";
+					"12.14.7.4.2a of IEEE Std 802.1Q-2018";
   		}
   		leaf interval {
 				type cfm-interval-type;
@@ -2992,7 +2991,7 @@ module ieee802-dot1q-cfm {
 				description
 					"The flags field for the LTMs transmitted by the MEP.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2b, 20.42.1";
+					"12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
 				
 			}
 			leaf mep-transmit-ltm-target-mac-address {
@@ -3002,7 +3001,7 @@ module ieee802-dot1q-cfm {
 					unicast MAC address. This address will be used if the
 					value of mep-transmit-ltm-target-is-mep-id is FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+					"12.14.7.4.2c of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-ltm-target-mep-id {
 				type mep-id-or-zero-type;
@@ -3012,7 +3011,7 @@ module ieee802-dot1q-cfm {
 					address will be used if the value of 
 					mep-transmit-ltm-target-is-mep-id is TRUE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+					"12.14.7.4.2c of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-ltm-target-is-mep-id {
 				type boolean;
@@ -3023,7 +3022,7 @@ module ieee802-dot1q-cfm {
 					unicast destination MAC address of the target MEP is
 					used for LinkTrace transmission.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2c";
+					"12.14.7.4.2c of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-ltm-ttl {
 				type uint32 {
@@ -3039,7 +3038,7 @@ module ieee802-dot1q-cfm {
 					forwarded to the next hop, and if 0, no LTR is 
 					generated.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.2d, 21.8.4";
+					"12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
 			}  			
 		} // input
 		output {
@@ -3052,7 +3051,7 @@ module ieee802-dot1q-cfm {
 					          sent.
 					   FALS - The Linktrace message will not be sent.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.3a";
+					"12.14.7.4.3a of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-ltm-seq-number {
 				type uint32;
@@ -3062,7 +3061,7 @@ module ieee802-dot1q-cfm {
 					returned is undefined if mep-transmit-ltm-result is 
 					FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.3b";
+					"12.14.7.4.3b of IEEE Std 802.1Q-2018";
 			}
 			leaf mep-transmit-ltm-egress-identifier {
 				type string {
@@ -3091,7 +3090,7 @@ module ieee802-dot1q-cfm {
 					The value returned is undefined if 
 					mep-transmit-ltm-result is FALSE.";
 				reference
-					"IEEE 802.1Q-2017 Clause 12.14.7.4.3c";  					
+					"12.14.7.4.3c of IEEE Std 802.1Q-2018";  					
 			}
 		} // output
 	} // transmit- linktrace-message
@@ -3122,7 +3121,7 @@ module ieee802-dot1q-cfm {
 				of administrative responsibility for each Maintenance
 				Domain.";
 			reference
-				"IEEE 802.1Q-2017 Clause 3.122, 21.6.5.3";
+				"3.122, 21.6.5.3 of IEEE Std 802.1Q-2018";
 		}
 		leaf md-name-format {
 			type leafref {
@@ -3132,7 +3131,7 @@ module ieee802-dot1q-cfm {
 			description
 				"The type (or format) of the Maintenance Domain name.";
 			reference
-				"IEEE 802.1Q-2017 Clause 21.6.5.1";
+				"21.6.5.1 of IEEE Std 802.1Q-2018";
 		}
 		leaf ma-name {
 			type leafref {
@@ -3144,7 +3143,7 @@ module ieee802-dot1q-cfm {
 				is determined by the value of ma-name-format. This name
 				must be unique within a maintenance domain.";
 			reference
-				"IEEE 802.1Q-2017 Clause 21.6.5.6";
+				"21.6.5.6 of IEEE Std 802.1Q-2018";
 		}
 		leaf ma-name-format {
 			type leafref {
@@ -3154,7 +3153,7 @@ module ieee802-dot1q-cfm {
 			description
 				"The type (format) of the Maintenance Association name.";
 			reference
-				"IEEE 802.1Q-2017 Clause 21.6.5.4";
+				"21.6.5.4 of IEEE Std 802.1Q-2018";
 		}
 		leaf mep-id {
 			type leafref {
@@ -3164,7 +3163,7 @@ module ieee802-dot1q-cfm {
 				"Integer that is unique among all the MEPs in the same
 				Maintenance Association.";
 			reference
-				"IEEE 802.1Q-2017 Clause 3.114, 12.14.7, 19.2";
+				"3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
 		}
 		leaf mep-priority-defect {
 			type leafref {

--- a/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
@@ -1,20 +1,21 @@
 module ieee802-dot1q-pb {
-
-  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-pb";
-  prefix "dot1q-pb";
-
-  import ieee802-dot1q-bridge { prefix dot1q; }
-  import ieee802-dot1q-types { prefix "dot1qtypes"; }
-  //import ieee802-types { prefix "ieee"; }
-  import ietf-interfaces { prefix "if"; }
-
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-pb;
+  prefix dot1q-pb;
+  import ieee802-dot1q-bridge {
+    prefix dot1q;
+  }
+  import ieee802-dot1q-types {
+    prefix dot1qtypes;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
   organization
-    "Institute of Electrical and Electronics Engineers";
-
+    "IEEE 802.1 Working Group";
   contact
-  	"WG-URL: http://grouper.ieee.org/groups/802/1/
-    WG-EMail: stds-802-1@ieee.org
-
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+    
     Contact: IEEE 802.1 Working Group Chair
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
@@ -23,22 +24,19 @@ module ieee802-dot1q-pb {
             Piscataway
             NJ 08855-1331
             USA
- 	
-    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
-
+    
+    E-mail: STDS-802-1-L@IEEE.ORG";
   description
     "This YANG module describes the bridge configuration model for
     Provider Bridges.";
-  
-  revision 2017-09-07 {
+  revision 2018-03-07 {
     description
-      "Updates based upon comment resolution on draft
-      D1.2 of P802.1Qcp.";
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
     reference
-      "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
-      Virtual Bridged Local Area Networks.";
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
-
+  
   augment "/if:interfaces/if:interface/dot1q:bridge-port" {
     description
       "Augment the interface model with 802.1Q Bridge Port
@@ -48,11 +46,12 @@ module ieee802-dot1q-pb {
       description
         "Service VLAN identifier.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.13.2.1";
+        "12.13.2.1 of IEEE Std 802.1Q-2018";
     }
     list cvid-registration {
-      when "../dot1q:component-name = 'dot1q:c-vlan-component' and
-            ../dot1q:port-type = 'dot1q:customer-edge-port'" {
+      when
+        "../dot1q:component-name = 'dot1q:c-vlan-component' and "+
+        "../dot1q:port-type = 'dot1q:customer-edge-port'" {
         description
           "Applies when the component associated with this interface
           is a C-VLAN component and the port-type is a customer edge
@@ -74,17 +73,16 @@ module ieee802-dot1q-pb {
       leaf cvid {
         type dot1qtypes:vlanid;
         description
-          "Customer VLAN identifiers associated with this bridge
-          port.";
+          "Customer VLAN identifiers associated with this bridge port.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.2.1";
+          "12.13.2.1 of IEEE Std 802.1Q-2018";
       }
       leaf svid {
         type dot1qtypes:vlanid;
         description
           "Service VLAN identifier.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.2.1";
+          "12.13.2.1 of IEEE Std 802.1Q-2018";
       }
       leaf untagged-pep {
         type boolean;
@@ -93,7 +91,7 @@ module ieee802-dot1q-pb {
           "A boolean indicating frames for this C-VLAN should be
           forwarded untagged through the Provider Edge Port.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.2.1";
+          "12.13.2.1 of IEEE Std 802.1Q-2018";
       }
       leaf untagged-cep {
         type boolean;
@@ -102,18 +100,18 @@ module ieee802-dot1q-pb {
           "A boolean indicating frames for this C-VLAN should be
           forwarded untagged through the Customer Edge Port.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.2.1";
+          "12.13.2.1 of IEEE Std 802.1Q-2018";
       }
     }
-
     list service-priority-regeneration {
-    	when "../dot1q:component-name = 'dot1q:c-vlan-component' and
-      			../dot1q:port-type = 'dot1q:customer-edge-port'" {
-  			description
-    			"Applies when the component associated with this interface
-			    is a C-VLAN component and the port-type is a customer edge
-			    port.";
-			}
+      when
+        "../dot1q:component-name = 'dot1q:c-vlan-component' and "+
+        "../dot1q:port-type = 'dot1q:customer-edge-port'" {
+        description
+          "Applies when the component associated with this interface
+          is a C-VLAN component and the port-type is a customer edge
+          port.";
+      }
       key "svid";
       description
         "The Service Priority Regeneration Table, which provides the
@@ -124,45 +122,44 @@ module ieee802-dot1q-pb {
         description
           "Service VLAN identifier.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.2.6";
+          "12.13.2.6 of IEEE Std 802.1Q-2018";
       }
       container priority-regeneration {
         description
           "Contains Service Priority Regeneration table nodal
           information.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.2.6";
+          "12.13.2.6 of IEEE Std 802.1Q-2018";
         uses dot1qtypes:priority-regeneration-table-grouping;
       }
     }
-
     list rcap-internal-interface {
-    	when "../dot1q:component-name = 'dot1q:s-vlan-component' and
-     			 ../dot1q:port-type = 'dot1q:remote-customer-access-port'" {
-			  description
-			    "Applies when the component associated with this interface
-			    is a C-VLAN component and the port-type is a customer edge
-			    port.";
-			}
+      when
+        "../dot1q:component-name = 'dot1q:s-vlan-component' and "+
+        "../dot1q:port-type = 'dot1q:remote-customer-access-port'" {
+        description
+          "Applies when the component associated with this interface
+          is a C-VLAN component and the port-type is a customer edge
+          port.";
+      }
       key "external-svid";
       description
-        "Designating an external port as an RCAP automatically 
-      	creates a Port-mapping S-VLAN component associated with that
-      	port. This Port-mapping S-VLAN component includes one internal
-        PNP.";
+        "Designating an external port as an RCAP automatically creates
+        a Port-mapping S-VLAN component associated with that port.
+        This Port-mapping S-VLAN component includes one internal PNP.";
       leaf external-svid {
         type dot1qtypes:vlanid;
         description
           "External Service VLAN identifier.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.3.2";
+          "12.13.3.2 of IEEE Std 802.1Q-2018";
       }
       leaf internal-port-number {
         type dot1qtypes:port-number-type;
         description
           "The number of the RCAP.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.3.2";
+          "12.13.3.2 of IEEE Std 802.1Q-2018";
       }
       leaf internal-svid {
         type dot1qtypes:vlanid;
@@ -170,7 +167,7 @@ module ieee802-dot1q-pb {
           "Internal Service VLAN Identifier (not applicable for a
           C-tagged RCSI).";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.3.2";
+          "12.13.3.2 of IEEE Std 802.1Q-2018";
       }
       leaf internal-interface-type {
         type enumeration {
@@ -196,8 +193,9 @@ module ieee802-dot1q-pb {
           "A value indicating the type of internal interface
           associated with the external S-VID.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.13.3.2";
+          "12.13.3.2 of IEEE Std 802.1Q-2018";
       }
     }
   }
 }
+

--- a/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.yang
@@ -1,19 +1,21 @@
 module ieee802-dot1q-tpmr {
-
-  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-tpmr";
-  prefix "dot1q-tpmr";
-
-  import ieee802-dot1q-bridge { prefix "dot1q"; }
-  import ietf-yang-types { prefix "yang"; }
-  import ietf-interfaces { prefix "if"; }
-
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-tpmr;
+  prefix dot1q-tpmr;
+  import ieee802-dot1q-bridge {
+    prefix dot1q;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
   organization
-    "Institute of Electrical and Electronics Engineers";
-
+    "IEEE 802.1 Working Group";
   contact
-  	"WG-URL: http://grouper.ieee.org/groups/802/1/
-    WG-EMail: stds-802-1@ieee.org
-
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+    
     Contact: IEEE 802.1 Working Group Chair
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
@@ -22,29 +24,26 @@ module ieee802-dot1q-tpmr {
             Piscataway
             NJ 08855-1331
             USA
- 	
-    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
-
+    
+    E-mail: STDS-802-1-L@IEEE.ORG";
   description
-    "This YANG module describes the bridge configuration model for
-    the Two Port MAC Relay Bridges.";
-  
-  revision 2017-09-07 {
+    "This YANG module describes the bridge configuration model for the
+    Two Port MAC Relays.";
+  revision 2018-03-07 {
     description
-      "Updates based upon comment resolution on draft
-      D1.2 of P802.1Qcp.";
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
     reference
-      "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
-      Virtual Bridged Local Area Networks.";
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
-
+  
   augment "/if:interfaces/if:interface/dot1q:bridge-port" {
-  	when "dot1q:port-type = 'dot1q:d-bridge-port'" {
-  		description
-  			"Applies to TPMR Bridges ports";
-  	}
+    when "dot1q:port-type = 'dot1q:d-bridge-port'" {
+      description
+        "Applies to TPMRs ports";
+    }
     description
-      "Augment Interface model with TPMR bridge port configuration
+      "Augment Interface model with TPMR port configuration
       specific nodes.";
     leaf managed-address {
       type boolean;
@@ -52,15 +51,15 @@ module ieee802-dot1q-tpmr {
       description
         "A Boolean value, which is TRUE if the MAC address is the
         management address for the TPMR, and is otherwise FALSE.
-      	
-      	The TPMR management entity may make use of one or both Ports
-      	of a TPMR to transmit and receive management frames. However,
-      	the MAC address used by the TPMR management entity as the 
-      	source MAC address in transmitted management frames (the
-      	management MAC address) is the individual MAC address 
-      	associated with one of the Ports of the TPMR";
+        
+        The TPMR management entity may make use of one or both Ports
+        of a TPMR to transmit and receive management frames. However,
+        the MAC address used by the TPMR management entity as the
+        source MAC address in transmitted management frames (the
+        management MAC address) is the individual MAC address
+        associated with one of the Ports of the TPMR";
       reference
-      	"IEEE 802.1Q-2017 Clause 12.19.1.1.1.3";
+        "12.19.1.1.1.3 of IEEE Std 802.1Q-2018";
     }
     container mac-status-propagation {
       description
@@ -72,29 +71,32 @@ module ieee802-dot1q-tpmr {
           "The current value (Boolean) of LinkNotify (23.5.1) being
           used by the MSP state machines.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
       }
       leaf link-notify-wait {
         type yang:timeticks {
-        	range "20..100";
+          range "20..100";
         }
-        default 40;
+        default "40";
         description
           "The current value, in centiseconds, of LinkNotifyWait
           (23.5.2) being used by the MSP state machines.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
       }
       leaf link-notify-retry {
         type yang:timeticks {
-        	range "10..100";
+          range "10..100";
         }
-        default 100;
+        default "100";
         description
           "The current value, in centiseconds, of LinkNotifyRetry
           (23.5.3) being used by the MSP state machines.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
       }
       leaf mac-notify {
         type boolean;
@@ -103,55 +105,56 @@ module ieee802-dot1q-tpmr {
           "The current value (Boolean) of MACNotify (23.5.4) being
           used by the MSP state machines.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
       }
       leaf mac-notify-time {
         type yang:timeticks {
-        	range "1..50";
+          range "1..50";
         }
-        default 20;
+        default "20";
         description
           "The current value, in centiseconds, of MACNotifyTime
           (23.5.5) being used by the MSP state machines.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
       }
       leaf mac-recover-time {
         type yang:timeticks {
-        	range "2..50";
+          range "2..50";
         }
-        default 10;
+        default "10";
         description
           "The current value, in centiseconds, of MACRecoverTime
           (23.5.6) being used by the MSP state machines.";
         reference
-          "IEEE 802.1Q-2017 Clause 12.19.4.1.1.3, 12.19.4.1.2.2";
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
       }
     }
   }
-
-  augment "/if:interfaces/if:interface"
-        + "/dot1q:bridge-port/dot1q:statistics" {
-  	when "../dot1q:port-type = 'dot1q:d-bridge-port'" {
-  		description
-  			"Applies to TPMR Bridges ports";
-  	}
+  augment
+    "/if:interfaces/if:interface/dot1q:bridge-port/dot1q:statistics" {
+    when "../dot1q:port-type = 'dot1q:d-bridge-port'" {
+      description
+        "Applies to TPMRs ports";
+    }
     description
-      "Augment Interface model with TPMR bridge port
-      operational state specific nodes.";
+      "Augment Interface model with TPMR port operational state
+      specific nodes.";
     leaf acks-tx {
       type yang:counter64;
       config false;
       description
         "The number of acks transmitted (23.6.15) by the Ports
         Transmit Process as a consequence of txAck being set.
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf add-notificatons-tx {
       type yang:counter64;
@@ -159,13 +162,12 @@ module ieee802-dot1q-tpmr {
       description
         "The number of adds transmitted (23.6.16) by the Ports
         Transmit Process as a consequence of txAdd being set.
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf loss-notification-tx {
       type yang:counter64;
@@ -173,28 +175,26 @@ module ieee802-dot1q-tpmr {
       description
         "The number of losses transmitted (23.6.18) by the Ports
         Transmit Process as a consequence of txLoss being set.
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf loss-confirmation-tx {
       type yang:counter64;
       config false;
       description
         "The number of loss confirms transmitted (23.6.19) by the
-        Ports Transmit Process as a consequence of txLossConfirm
-        being set.
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        Ports Transmit Process as a consequence of txLossConfirm being
+        set.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf acks-rx {
       type yang:counter64;
@@ -202,13 +202,12 @@ module ieee802-dot1q-tpmr {
       description
         "The number of acks received (23.6.10) by the Ports Transmit
         Process.
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf add-notificatons-rx {
       type yang:counter64;
@@ -216,13 +215,12 @@ module ieee802-dot1q-tpmr {
       description
         "The number of adds received (23.6.11) by the Ports Receive
         Process.
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf loss-notification-rx {
       type yang:counter64;
@@ -230,13 +228,12 @@ module ieee802-dot1q-tpmr {
       description
         "The number of losses received (23.6.13) by the Ports Receive
         Process.
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf loss-confirmation-rx {
       type yang:counter64;
@@ -244,13 +241,12 @@ module ieee802-dot1q-tpmr {
       description
         "The number of loss confirms received (23.6.14) by the Ports
         Receive Process.
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf add-events {
       type yang:counter64;
@@ -258,40 +254,38 @@ module ieee802-dot1q-tpmr {
       description
         "The number of transitions to STM:ADD directly from STM:DOWN
         or STM:LOSS (23.8).
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf loss-events {
       type yang:counter64;
       config false;
       description
-        "The number of transitions to STM:LOSS directly from STM:UP
-        or STM:ADD (23.8).
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        "The number of transitions to STM:LOSS directly from STM:UP or
+        STM:ADD (23.8).
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
     leaf mac-status-notifications {
       type yang:counter64;
       config false;
       description
         "The number of transitions to SNM:MAC_NOTIFICATION (23.9).
-      	
-      	Discontinuities in the value of this counter can occur
-        at re-initialization of the management system, and at
-        other times as indicated by the value of
-        'discontinuity-time'.";
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.19.4.1.3.3";
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
     }
   }
 }
+

--- a/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
@@ -1,17 +1,15 @@
 module ieee802-dot1q-types {
-
-  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-types";
-  prefix "dot1q-types";
-
-  import ietf-yang-types { prefix "yang"; }
-
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-types;
+  prefix dot1q-types;
+  import ietf-yang-types {
+    prefix yang;
+  }
   organization
-    "Institute of Electrical and Electronics Engineers";
-
+    "IEEE 802.1 Working Group";
   contact
-  	"WG-URL: http://grouper.ieee.org/groups/802/1/
-    WG-EMail: stds-802-1@ieee.org
-
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+    
     Contact: IEEE 802.1 Working Group Chair
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
@@ -20,56 +18,38 @@ module ieee802-dot1q-types {
             Piscataway
             NJ 08855-1331
             USA
- 	
-    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
-
+    
+    E-mail: STDS-802-1-L@IEEE.ORG";
   description
     "Common types used within dot1Q-bridge modules.";
-  
-  revision 2017-10-16 {
+  revision 2018-03-07 {
     description
-      "Updates based upon comment resolution on draft
-      D1.3 of P802.1Qcp.";
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
     reference
-      "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
-      Virtual Bridged Local Area Networks.";
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
-
-  /*
-   * IEEE 802.1Q Identity Definitions.
-   *    Defines the supported IEEE 802.1Q types that can be used
-   *    for VLAN tag matching.
-   */
-
+  
   identity dot1q-vlan-type {
     description
-      "Base identity from which all 802.1Q VLAN tag types are
-      derived from.";
+      "Base identity from which all 802.1Q VLAN tag types are derived
+      from.";
   }
-
   identity c-vlan {
     base dot1q-vlan-type;
     description
-      "An 802.1Q Customer VLAN, normally using the 0x8100
-       Ethertype";
+      "An 802.1Q Customer VLAN, using the 81-00 EtherType";
     reference
-      "IEEE 802.1Q-2017, Clause 5.5";
+      "5.5 of IEEE Std 802.1Q-2018";
   }
-
   identity s-vlan {
     base dot1q-vlan-type;
     description
-      "An 802.1Q Service VLAN, using the 0x88a8 Ethertype
-       originally introduced in 802.1ad, and incorporated into
-       802.1Q (2011)";
+      "An 802.1Q Service VLAN, using the 88-A8 EtherType originally
+      introduced in 802.1ad, and incorporated into 802.1Q (2011)";
     reference
-      "IEEE 802.1Q-2017, Clause 5.6";
+      "5.6 of IEEE Std 802.1Q-2018";
   }
-
-  /*
-   * IEEE 802.1Q Type Definitions.
-   */
-
   typedef name-type {
     type string {
       length "0..32";
@@ -78,105 +58,81 @@ module ieee802-dot1q-types {
       "A text string of up to 32 characters, of locally determined
       significance.";
   }
-
   typedef port-number-type {
-  	type uint32 {
-  		range "1..65535";
-  	}
+    type uint32 {
+      range "1..65535";
+    }
     description
       "The port number of the Bridge port for which this entry
-    	contains Bridge management information.";
+      contains Bridge management information.";
   }
-
   typedef priority-type {
     type uint8 {
       range "0..7";
     }
     description
       "A range of priorities from 0 to 7 (inclusive). The Priority
-    	Code Point (PCP) is a 3-bit field that refers to the
-      class of service associated with an 802.1Q VLAN tagged frame.
-      The field specifies a priority value between 0 and 7, these
-      values can be used by quality of service (QoS) to prioritize
-      different classes of traffic.";
+      Code Point (PCP) is a 3-bit field that refers to the class of
+      service associated with an 802.1Q VLAN tagged frame. The field
+      specifies a priority value between 0 and 7, these values can be
+      used by quality of service (QoS) to prioritize different classes
+      of traffic.";
   }
-
-  //typedef PCP {
-  //  type priority-type;
-  //  description
-  //    "Priority Code Point (PCP) is a 3-bit field that refers to 
-  //    the class of service associated with an 802.1Q VLAN tagged
-  //    frame. The field specifies a priority value between 0 and 7,
-  //    these values can be used by quality of service (QoS) to
-  //    prioritize different classes of traffic.";
-  //}
-
   typedef vid-range-type {
-    /*
-     * Defines the type used to represent ranges of VLAN Ids.
-     *
-     * Ideally we would model that as a list of VLAN Ids in YANG,
-     * but the model is easier to use if this is just represented
-     * as a string.
-     *
-     */
     type string {
-      pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?" +
-              "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+      pattern
+        "([1-9]"+
+        "[0-9]{0,3}"+
+        "(-[1-9][0-9]{0,3})?"+
+        "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
     }
     description
       "A list of VLAN Ids, or non overlapping VLAN ranges, in
       ascending order, between 1 and 4094.
-    	
-    	This type is used to match an ordered list of VLAN Ids, or
-    	contiguous ranges of VLAN Ids. Valid VLAN Ids must be in the 
-    	range 1 to 4094, and included in the list in non overlapping
-    	ascending order.
-    	
-    	For example: 1,10-100,250,500-1000";
+      
+      This type is used to match an ordered list of VLAN Ids, or
+      contiguous ranges of VLAN Ids. Valid VLAN Ids must be in the
+      range 1 to 4094, and included in the list in non overlapping
+      ascending order.
+      
+      For example: 1,10-100,250,500-1000";
   }
-  
   typedef vlanid {
     type uint16 {
       range "1..4094";
     }
     description
       "The vlanid type uniquely identifies a VLAN. This is the 12-bit
-      VLAN-ID used in the VLAN Tag header. The range is defined by
-      the referenced specification. This type is in the value set and
-      its semantics equivalent to the VlanId textual convention of
-      the SMIv2.";
-    reference
-      "IEEE Std 802.1Q-2017: Virtual Bridged Local Area Networks.";
+      VLAN-ID used in the VLAN Tag header. The range is defined by the
+      referenced specification. This type is in the value set and its
+      semantics equivalent to the VlanId textual convention of the
+      SMIv2.";
   }
-
   typedef vlan-index-type {
     type uint32 {
       range "1..4094 | 4096..4294967295";
     }
     description
-      "A value used to index per-VLAN tables. Values of 0 and 4095
-      are not permitted. The range of valid VLAN indices. If the
-      value is greater than 4095, then it represents a VLAN with
-      scope local to the particular agent, i.e., one without a
-      global VLAN-ID assigned to it. Such VLANs are outside the
-      scope of IEEE 802.1Q, but it is convenient to be able to
-      manage them in the same way using this YANG module.";
+      "A value used to index per-VLAN tables. Values of 0 and 4095 are
+      not permitted. The range of valid VLAN indices. If the value is
+      greater than 4095, then it represents a VLAN with scope local to
+      the particular agent, i.e., one without a global VLAN-ID
+      assigned to it. Such VLANs are outside the scope of IEEE 802.1Q,
+      but it is convenient to be able to manage them in the same way
+      using this YANG module.";
     reference
-      "IEEE Std 802.1Q-2017: Virtual Bridged Local Area Networks.";
+      "9.6 of IEEE Std 802.1Q-2018";
   }
-  
   typedef mstid-type {
-  	type uint32 {
-  		range "1..4094";
-  	}
-  	description
-  		"In an MSTP Bridge, an MSTID, i.e., a value used to identify
-  		a spanning tree (or MST) instance";
-  	reference
-  		"IEEE Std 802.1Q-2017: Virtual Bridged Local Area Networks.";
+    type uint32 {
+      range "1..4094";
+    }
+    description
+      "In an MSTP Bridge, an MSTID, i.e., a value used to identify a
+      spanning tree (or MST) instance";
+    reference
+      "13.8 of IEEE Std 802.1Q-2018";
   }
-
   typedef pcp-selection-type {
     type enumeration {
       enum 8P0D {
@@ -199,9 +155,9 @@ module ieee802-dot1q-types {
     description
       "Priority Code Point selection types.";
     reference
-      "IEEE 802.1Q-2017 Clause 12.6.2.5.3, 6.9.3";
+      "12.6.2.5.3 of IEEE Std 802.1Q-2018
+      6.9.3 of IEEE Std 802.1Q-2018";
   }
-
   typedef protocol-frame-format-type {
     type enumeration {
       enum Ethernet {
@@ -228,51 +184,43 @@ module ieee802-dot1q-types {
     description
       "A value representing the frame format to be matched.";
     reference
-      "IEEE 802.1Q-2017 Clause 12.10.1.7.1";
+      "12.10.1.7.1 of IEEE Std 802.1Q-2018";
   }
-
   typedef ethertype-type {
     type string {
-      pattern '[0-9a-fA-F]{2}-[0-9a-fA-F]{2}';
+      pattern "[0-9a-fA-F]{2}-[0-9a-fA-F]{2}";
     }
     description
       "The EtherType value represented in the canonical order defined
-    	by IEEE 802. The canonical representation uses uppercase 
-    	characters.";
+      by IEEE 802. The canonical representation uses uppercase
+      characters.";
     reference
-      "IEEE 802-2014 Clause 9.2";
+      "9.2 of IEEE Std 802-2014";
   }
-
   typedef dot1q-tag-type {
     type identityref {
-      base "dot1q-vlan-type";
+      base dot1q-vlan-type;
     }
     description
       "Identifies a specific 802.1Q tag type";
     reference
-      "IEEE 802.1Q (2014)";
+      "IEEE Std 802.1Q-2018";
   }
-
   typedef traffic-class-type {
     type uint8 {
       range "0..7";
     }
     description
-      "This is the numerical value associated with a traffic
-      class in a Bridge. Larger values are associated with
-      higher priority traffic classes.";
+      "This is the numerical value associated with a traffic class in
+      a Bridge. Larger values are associated with higher priority
+      traffic classes.";
     reference
-      "IEEE Std 802.1Q-2014, Clause 3.239";
+      "3.239 of IEEE Std 802.1Q-2018";
   }
-
-  /*
-   * IEEE 802.1Q Bridge Group definitions.
-   */
-
   grouping dot1q-tag-classifier-grouping {
     description
-      "A grouping which represents an 802.1Q VLAN, matching both
-      the Ethertype and a single VLAN Id.";
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id.";
     leaf tag-type {
       type dot1q-tag-type;
       mandatory true;
@@ -286,12 +234,10 @@ module ieee802-dot1q-types {
         "VLAN Id";
     }
   }
-
   grouping dot1q-tag-or-any-classifier-grouping {
     description
-      "A grouping which represents an 802.1Q VLAN, matching both
-      the  Ethertype and a single VLAN Id or 'any' to match on
-      any VLAN Id.";
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id or 'any' to match on any VLAN Id.";
     leaf tag-type {
       type dot1q-tag-type;
       mandatory true;
@@ -302,11 +248,11 @@ module ieee802-dot1q-types {
       type union {
         type vlanid;
         type enumeration {
-          enum "any" {
+          enum any {
             value 4095;
             description
-              "Matches 'any' VLAN in the range 1 to 4094 that
-               is not matched by a more specific VLAN Id match";
+              "Matches 'any' VLAN in the range 1 to 4094 that is not
+              matched by a more specific VLAN Id match";
           }
         }
       }
@@ -315,11 +261,10 @@ module ieee802-dot1q-types {
         "VLAN Id or any";
     }
   }
-
   grouping dot1q-tag-ranges-classifier-grouping {
     description
-      "A grouping which represents an 802.1Q VLAN that matches a
-      range of VLAN Ids.";
+      "A grouping which represents an 802.1Q VLAN that matches a range
+      of VLAN Ids.";
     leaf tag-type {
       type dot1q-tag-type;
       mandatory true;
@@ -333,12 +278,11 @@ module ieee802-dot1q-types {
         "VLAN Ids";
     }
   }
-
   grouping dot1q-tag-ranges-or-any-classifier-grouping {
     description
-      "A grouping which represents an 802.1Q VLAN, matching
-      both the Ethertype and a single VLAN Id, ordered list of
-      ranges, or 'any' to match on any VLAN Id.";
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id, ordered list of ranges, or 'any'
+      to match on any VLAN Id.";
     leaf tag-type {
       type dot1q-tag-type;
       mandatory true;
@@ -349,8 +293,8 @@ module ieee802-dot1q-types {
       type union {
         type vid-range-type;
         type enumeration {
-          enum "any" {
-          	value 4095;
+          enum any {
+            value 4095;
             description
               "Matches 'any' VLAN in the range 1 to 4094.";
           }
@@ -361,259 +305,279 @@ module ieee802-dot1q-types {
         "VLAN Ids or any";
     }
   }
-
   grouping priority-regeneration-table-grouping {
     description
       "The priority regeneration table provides the ability to map
-    	incoming priority values on a per-Port basis, under management
-    	control.";
+      incoming priority values on a per-Port basis, under management
+      control.";
     reference
-      "IEEE 802.1Q-2017 Clause 6.9.4";
+      "6.9.4 of IEEE Std 802.1Q-2018";
     leaf priority0 {
       type priority-type;
-      default 0;
+      default "0";
       description
         "Priority 0";
       reference
-        "IEEE 802.1Q-2017 Clause 6.9.4, 12.6.2.3";
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
     }
     leaf priority1 {
       type priority-type;
-      default 1;
+      default "1";
       description
         "Priority 1";
       reference
-        "IEEE 802.1Q-2017 Clause 6.9.4, 12.6.2.3";
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
     }
     leaf priority2 {
       type priority-type;
-      default 2;
+      default "2";
       description
         "Priority 2";
       reference
-        "IEEE 802.1Q-2017 Clause 6.9.4, 12.6.2.3";
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
     }
     leaf priority3 {
       type priority-type;
-      default 3;
+      default "3";
       description
         "Priority 3";
       reference
-        "IEEE 802.1Q-2017 Clause 6.9.4, 12.6.2.3";
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
     }
     leaf priority4 {
       type priority-type;
-      default 4;
+      default "4";
       description
         "Priority 4";
       reference
-        "IEEE 802.1Q-2017 Clause 6.9.4, 12.6.2.3";
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
     }
     leaf priority5 {
       type priority-type;
-      default 5;
+      default "5";
       description
         "Priority 5";
       reference
-        "IEEE 802.1Q-2017 Clause 6.9.4, 12.6.2.3";
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
     }
     leaf priority6 {
       type priority-type;
-      default 6;
+      default "6";
       description
         "Priority 6";
       reference
-        "IEEE 802.1Q-2017 Clause 6.9.4, 12.6.2.3";
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
     }
     leaf priority7 {
       type priority-type;
-      default 7;
+      default "7";
       description
         "Priority 7";
       reference
-        "IEEE 802.1Q-2017 Clause 6.9.4, 12.6.2.3";
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
     }
   }
-
   grouping pcp-decoding-table-grouping {
     description
       "The Priority Code Point decoding table enables the decoding of
-    	the priority and drop-eligible parameters from the PCP.";
+      the priority and drop-eligible parameters from the PCP.";
     reference
-      "IEEE 802.1Q-2017 Clause 6.9.3";
+      "6.9.3 of IEEE Std 802.1Q-2018";
     list pcp-decoding-map {
-    	key "pcp";
-    	description
-	    	"This map associates the priority code point field found
-				in the VLAN to a priority and drop eligible value based
-				upon the priority code point selection type.";
-    	leaf pcp {
-    		type pcp-selection-type;
-    		description
-    			"The priority code point selection type.";
-    		reference
-    			"IEEE 802.1Q-2017 Clause 12.6.2.7, 6.9.3";
-    	}
-    	list priority-map {
-    		key "priority-code-point";
-    		description
-      		"This map associated a priority code point value
-    			to priority and drop eligible parameters.";
-    		leaf priority-code-point {
-    			type priority-type;
-    			description
-    				"Priority associated with the pcp.";
-    			reference
-            "IEEE 802.1Q-2017 Clause 12.6.2.7, 6.9.3";
-    		}
-    		leaf priority {
-    			type priority-type;
-    			description
-    				"Priority associated with the pcp.";
-    			reference
-            "IEEE 802.1Q-2017 Clause 12.6.2.7, 6.9.3";
-    		}
-    		leaf drop-eligible {
+      key "pcp";
+      description
+        "This map associates the priority code point field found in
+        the VLAN to a priority and drop eligible value based upon the
+        priority code point selection type.";
+      leaf pcp {
+        type pcp-selection-type;
+        description
+          "The priority code point selection type.";
+        reference
+          "12.6.2.7 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
+      }
+      list priority-map {
+        key "priority-code-point";
+        description
+          "This map associated a priority code point value to priority
+          and drop eligible parameters.";
+        leaf priority-code-point {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf priority {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf drop-eligible {
           type boolean;
           description
             "Drop eligible value for pcp";
           reference
-            "IEEE 802.1Q-2017 Clause 12.6.2.7, 6.9.3";
-        } 		
-    	}   	
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+      }
     }
   }
-
   grouping pcp-encoding-table-grouping {
     description
-      "The Priority Code Point encoding table encodes the priority 
-    	and drop-eligible parameters in the PCP field of the VLAN tag.";
+      "The Priority Code Point encoding table encodes the priority and
+      drop-eligible parameters in the PCP field of the VLAN tag.";
     reference
-      "IEEE 802.1Q-2017 Clause 12.6.2.9, 6.9.3";
+      "12.6.2.9 of IEEE Std 802.1Q-2018
+      6.9.3 of IEEE Std 802.1Q-2018";
     list pcp-encoding-map {
-    	key "pcp";
-    	description
-    		"This map associated the priority and drop-eligible 
-    		parameters to the priority used to encode the PCP of
-    		the VLAN based upon the priority code point selection 
-    		type.";
-    	leaf pcp {
-    		type pcp-selection-type;
-    		description
-    			"The priority code point selection type.";
-    		reference
-    			"IEEE 802.1Q-2017 Clause 12.6.2.7, 6.9.3";
-    	}
-    	list priority-map {
-    		key "priority dei";
-    		description
-    			"This map associated the priority and drop-eligible 
-      		parameters to the priority code point field of the VLAN 
-    			tag.";
-    		leaf priority {
-    			type priority-type;
-    			description
-    				"Priority associated with the pcp.";
-    			reference
-            "IEEE 802.1Q-2017 Clause 12.6.2.7, 6.9.3";
-    		}
-    		leaf dei {
-    			type boolean;
-    			description
-    				"The drop eligible value.";
-    			reference
-            "IEEE 802.1Q-2017 Clause 12.6.2, 8.6.6";
-    		}
-    		leaf priority-code-point {
+      key "pcp";
+      description
+        "This map associated the priority and drop-eligible parameters
+        to the priority used to encode the PCP of the VLAN based upon
+        the priority code point selection type.";
+      leaf pcp {
+        type pcp-selection-type;
+        description
+          "The priority code point selection type.";
+        reference
+          "12.6.2.7 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
+      }
+      list priority-map {
+        key "priority dei";
+        description
+          "This map associated the priority and drop-eligible
+          parameters to the priority code point field of the VLAN tag.";
+        leaf priority {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf dei {
+          type boolean;
+          description
+            "The drop eligible value.";
+          reference
+            "12.6.2 of IEEE Std 802.1Q-2018
+            8.6.6 of IEEE Std 802.1Q-2018";
+        }
+        leaf priority-code-point {
           type priority-type;
           description
             "PCP value for priority when DEI value";
           reference
-            "IEEE 802.1Q-2017 Clause 12.6.2.9, 6.9.3";
-        }	
-    	}    	
+            "12.6.2.9 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+      }
     }
   }
-
   grouping service-access-priority-table-grouping {
     description
       "The Service Access Priority Table associates a received
-    	priority with a serice access priority.";
+      priority with a serice access priority.";
     reference
-      "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+      "12.6.2.17 of IEEE Std 802.1Q-2018
+      6.13.1 of IEEE Std 802.1Q-2018";
     leaf priority0 {
       type priority-type;
-      default 0;
+      default "0";
       description
         "Service access priority value for priority 0";
       reference
-        "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
     }
     leaf priority1 {
       type priority-type;
-      default 1;
+      default "1";
       description
         "Service access priority value for priority 1";
       reference
-        "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
     }
     leaf priority2 {
       type priority-type;
-      default 2;
+      default "2";
       description
         "Service access priority value for priority 2";
       reference
-        "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
     }
     leaf priority3 {
       type priority-type;
-      default 3;
+      default "3";
       description
         "Service access priority value for priority 3";
       reference
-        "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
     }
     leaf priority4 {
       type priority-type;
-      default 4;
+      default "4";
       description
         "Service access priority value for priority 4";
       reference
-        "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
     }
     leaf priority5 {
       type priority-type;
-      default 5;
+      default "5";
       description
         "Service access priority value for priority 5";
       reference
-        "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
     }
     leaf priority6 {
       type priority-type;
-      default 6;
+      default "6";
       description
         "Service access priority value for priority 6";
       reference
-        "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
     }
     leaf priority7 {
       type priority-type;
-      default 7;
+      default "7";
       description
         "Service access priority value for priority 7";
       reference
-        "IEEE 802.1Q-2017 Clause 6.13.1, 12.6.2.17";
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
     }
   }
-
   grouping traffic-class-table-grouping {
     description
       "The Traffic Class Table models the operations that can be
       performed on, or inquire about, the current contents of the
       Traffic Class Table (8.6.6) for a given Port.";
     reference
-      "IEEE 802.1Q-2017 Clause 12.6.3, 8.6.6";
+      "12.6.3 of IEEE Std 802.1Q-2018
+      8.6.6 of IEEE Std 802.1Q-2018";
     list traffic-class-map {
       key "priority";
       description
@@ -623,7 +587,7 @@ module ieee802-dot1q-types {
         description
           "The priority of the traffic class entry.";
         reference
-          "IEEE 802.1Q-2017 Clause 8.6.6";
+          "8.6.6 of IEEE Std 802.1Q-2018";
       }
       list available-traffic-class {
         key "num-traffic-class";
@@ -631,15 +595,15 @@ module ieee802-dot1q-types {
           "The traffic class index associated with a given priority
           within the traffic class table.";
         reference
-          "IEEE 802.1Q-2017 Clause 8.6.6";
+          "8.6.6 of IEEE Std 802.1Q-2018";
         leaf num-traffic-class {
           type uint8 {
-          	range "1..8";
+            range "1..8";
           }
           description
             "The available number of traffic classes.";
           reference
-            "IEEE 802.1Q-2017 Clause 8.6.6";
+            "8.6.6 of IEEE Std 802.1Q-2018";
         }
         leaf traffic-class {
           type traffic-class-type;
@@ -647,18 +611,18 @@ module ieee802-dot1q-types {
             "The traffic class index associated with a given traffic
             class entry.";
           reference
-            "IEEE 802.1Q-2017 Clause 8.6.6";
+            "8.6.6 of IEEE Std 802.1Q-2018";
         }
       }
     }
   }
-
   grouping port-map-grouping {
     description
       "A set of control indicators, one for each Port. A Port Map,
-    	containing a control element for each outbound Port";
+      containing a control element for each outbound Port";
     reference
-      "IEEE 802.1Q-2017 Clause 8.8.1, 8.8.2";
+      "8.8.1 of IEEE Std 802.1Q-2018
+      8.8.2 of IEEE Std 802.1Q-2018";
     list port-map {
       key "port-ref";
       description
@@ -668,7 +632,7 @@ module ieee802-dot1q-types {
         description
           "The interface port reference associated with this map.";
         reference
-          "IEEE 802.1Q-2017 Clause 8.8.1";
+          "8.8.1 of IEEE Std 802.1Q-2018";
       }
       choice map-type {
         description
@@ -703,18 +667,18 @@ module ieee802-dot1q-types {
               and in the case of VLAN Bridge components, VID that
               meets this specification.";
             reference
-              "IEEE 802.1Q-2017 Clause 8.8.1";
+              "8.8.1 of IEEE Std 802.1Q-2018";
           }
           leaf connection-identifier {
             type port-number-type;
             description
-              "A Port MAP may contain a connection identifier
-              (8.8.12) for each outbound port. The connection
-              identifier may be associated with the Bridge Port value
-              maintained in a Dynamic Filtering Entry of the FDB for
-              Bridge Ports.";
+              "A Port MAP may contain a connection identifier (8.8.12)
+              for each outbound port. The connection identifier may be
+              associated with the Bridge Port value maintained in a
+              Dynamic Filtering Entry of the FDB for Bridge Ports.";
             reference
-              "IEEE 802.1Q-2017, Clause 8.8.1, 8.8.12";
+              "8.8.1 of IEEE Std 802.1Q-2018
+              8.8.12 of IEEE Std 802.1Q-2018";
           }
         }
         container static-vlan-registration-entries {
@@ -743,7 +707,7 @@ module ieee802-dot1q-types {
               "The Registrar Administrative Control values for MVRP
               and MIRP for the VID.";
             reference
-              "IEEE 802.1Q-2017 Clause 8.8.2";
+              "8.8.2 of IEEE Std 802.1Q-2018";
           }
           leaf vlan-transmitted {
             type enumeration {
@@ -760,7 +724,7 @@ module ieee802-dot1q-types {
               "Whether frames are to be VLAN-tagged or untagged when
               transmitted.";
             reference
-              "IEEE 802.1Q-2017 Clause 8.8.2";
+              "8.8.2 of IEEE Std 802.1Q-2018";
           }
         }
         container mac-address-registration-entries {
@@ -785,7 +749,7 @@ module ieee802-dot1q-types {
               and in the case of VLAN Bridge components, VID that
               meets this specification.";
             reference
-              "IEEE 802.1Q-2017 Clause 8.8.4";
+              "8.8.4 of IEEE Std 802.1Q-2018";
           }
         }
         container dynamic-vlan-registration-entries {
@@ -805,7 +769,7 @@ module ieee802-dot1q-types {
               and in the case of VLAN Bridge components, VID that
               meets this specification.";
             reference
-              "IEEE 802.1Q-2017 Clause 8.8.5";
+              "8.8.5 of IEEE Std 802.1Q-2018";
           }
         }
         container dynamic-reservation-entries {
@@ -830,7 +794,7 @@ module ieee802-dot1q-types {
               and in the case of VLAN Bridge components, VID that
               meets this specification.";
             reference
-              "IEEE 802.1Q-2017 Clause 8.8.7";
+              "8.8.7 of IEEE Std 802.1Q-2018";
           }
         }
         container dynamic-filtering-entries {
@@ -850,118 +814,113 @@ module ieee802-dot1q-types {
               and in the case of VLAN Bridge components, VID that
               meets this specification.";
             reference
-              "IEEE 802.1Q-2017 Clause 8.8.3";
+              "8.8.3 of IEEE Std 802.1Q-2018";
           }
         }
       }
     }
   }
-
   grouping bridge-port-statistics-grouping {
     description
       "Grouping of bridge port statistics.";
     reference
-      "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+      "12.6.1.1.3 of IEEE Std 802.1Q-2018";
     leaf delay-exceeded-discards {
       type yang:counter64;
       description
-        "The number of frames discarded by this port due to
-        excessive transit delay through the Bridge. It is
-        incremented by both transparent and source route
-        Bridges.";
+        "The number of frames discarded by this port due to excessive
+        transit delay through the Bridge. It is incremented by both
+        transparent and source route Bridges.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3, 8.6.6";
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018
+        8.6.6 of IEEE Std 802.1Q-2018";
     }
     leaf mtu-exceeded-discards {
       type yang:counter64;
       description
         "The number of frames discarded by this port due to an
-        excessive size. It is incremented by both transparent
-        and source route Bridges.";
+        excessive size. It is incremented by both transparent and
+        source route Bridges.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3 g)";
+        "12.6.1.1.3, item g) of IEEE Std 802.1Q-2018";
     }
     leaf frame-rx {
       type yang:counter64;
       description
-        "The number of frames that have been received by this
-        port from its segment. Note that a frame received on the
-        interface corresponding to this port is only counted by
-        this object if and only if it is for a protocol being
-        processed by the local bridging function, including
-        Bridge management frames.";
+        "The number of frames that have been received by this port
+        from its segment. Note that a frame received on the interface
+        corresponding to this port is only counted by this object if
+        and only if it is for a protocol being processed by the local
+        bridging function, including Bridge management frames.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
     }
     leaf octets-rx {
       type yang:counter64;
       description
         "The total number of octets in all valid frames received
-        (including BPDUs, frames addressed to the Bridge as an
-        end station, and frames that were submitted to the
-        Forwarding Process).";
+        (including BPDUs, frames addressed to the Bridge as an end
+        station, and frames that were submitted to the Forwarding
+        Process).";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
     }
     leaf frame-tx {
       type yang:counter64;
       description
-        "The number of frames that have been transmitted by this
-        port to its segment. Note that a frame transmitted on the
-        interface corresponding to this port is only counted by
-        this object if and only if it is for a protocol being
-        processed by the local bridging function, including
-        Bridge management frames.";
+        "The number of frames that have been transmitted by this port
+        to its segment. Note that a frame transmitted on the interface
+        corresponding to this port is only counted by this object if
+        and only if it is for a protocol being processed by the local
+        bridging function, including Bridge management frames.";
     }
     leaf octets-tx {
       type yang:counter64;
       description
-        "The total number of octets that have been transmitted
-        by this port to its segment.";
+        "The total number of octets that have been transmitted by this
+        port to its segment.";
     }
     leaf discard-inbound {
       type yang:counter64;
       description
-        "Count of received valid frames that were discarded
-        (i.e., filtered) by the Forwarding Process.";
+        "Count of received valid frames that were discarded (i.e.,
+        filtered) by the Forwarding Process.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
     }
     leaf forward-outbound {
       type yang:counter64;
       description
-        "The number of frames forwarded to the associated MAC
-        Entity (8.5).";
+        "The number of frames forwarded to the associated MAC Entity
+        (8.5).";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
     }
     leaf discard-lack-of-buffers {
       type yang:counter64;
       description
-        "The count of frames that were to be transmitted through
-        the associated Port but were discarded due to lack of
-        buffers.";
+        "The count of frames that were to be transmitted through the
+        associated Port but were discarded due to lack of buffers.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
     }
     leaf discard-transit-delay-exceeded {
       type yang:counter64;
       description
-        "The number of frames discarded by this port due to
-        excessive transit delay through the Bridge. It is
-        incremented by both transparent and source route
-        Bridges.";
+        "The number of frames discarded by this port due to excessive
+        transit delay through the Bridge. It is incremented by both
+        transparent and source route Bridges.";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
     }
     leaf discard-on-error {
       type yang:counter64;
       description
         "The number of frames that were to be forwarded on the
-        associated MAC but could not be transmitted
-        (e.g., frame would be too large, 6.5.8).";
+        associated MAC but could not be transmitted (e.g., frame would
+        be too large, 6.5.8).";
       reference
-        "IEEE 802.1Q-2017 Clause 12.6.1.1.3";
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
     }
   }
 }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.yang
@@ -1,15 +1,12 @@
 module ieee802-dot1q-vlan-bridge {
-
-  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-vlan-bridge";
-  prefix "dot1q-vlan-bridge";
-
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-vlan-bridge;
+  prefix dot1q-vlan-bridge;
   organization
-    "Institute of Electrical and Electronics Engineers";
-
+    "IEEE 802.1 Working Group";
   contact
-  	"WG-URL: http://grouper.ieee.org/groups/802/1/
-    WG-EMail: stds-802-1@ieee.org
-
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+    
     Contact: IEEE 802.1 Working Group Chair
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
@@ -18,20 +15,17 @@ module ieee802-dot1q-vlan-bridge {
             Piscataway
             NJ 08855-1331
             USA
- 	
-    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
-
+    
+    E-mail: STDS-802-1-L@IEEE.ORG";
   description
     "This YANG module describes the bridge configuration model for
     Customer VLAN Bridges.";
-  
-  revision 2017-09-07 {
+  revision 2018-03-07 {
     description
-      "Updates based upon comment resolution on draft
-      D1.2 of P802.1Qcp.";
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
     reference
-      "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
-      Virtual Bridged Local Area Networks.";
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
-
 }
+

--- a/standard/ieee/draft/ieee802-types.yang
+++ b/standard/ieee/draft/ieee802-types.yang
@@ -1,15 +1,12 @@
 module ieee802-types {
-
-  namespace "urn:ieee:std:802.1Q:yang:ieee802-types";
-  prefix "ieee";
-
+  namespace urn:ieee:std:802.1Q:yang:ieee802-types;
+  prefix ieee;
   organization
-    "Institute of Electrical and Electronics Engineers";
-
+    "IEEE 802.1 Working Group";
   contact
-  	"WG-URL: http://grouper.ieee.org/groups/802/1/
-    WG-EMail: stds-802-1@ieee.org
-
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+    
     Contact: IEEE 802.1 Working Group Chair
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
@@ -18,40 +15,30 @@ module ieee802-types {
             Piscataway
             NJ 08855-1331
             USA
- 	
-    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
-
+    
+    E-mail: STDS-802-1-L@IEEE.ORG";
   description
     "This module contains a collection of generally useful derived
     data types for IEEE YANG models.";
-
-  revision 2017-10-16 {
+  revision 2018-03-07 {
     description
-      "Updates based upon comment resolution on draft
-      D1.3 of P802.1Qcp.";
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
     reference
-      "IEEE 802.1Q-2017, Media Access Control (MAC) Bridges and
-      Virtual Bridged Local Area Networks.";
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
-
-  /*
-   * Collection of IEEE address type definitions
-   */
-
+  
   typedef mac-address {
     type string {
-      pattern '[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){5}';
+      pattern "[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){5}";
     }
     description
       "The mac-address type represents a MAC address in the canonical
-      format and hexadecimal format specified by IEEE Std 802.
-    	The hexidecimal representation uses uppercase characters.";
+      format and hexadecimal format specified by IEEE Std 802. The
+      hexidecimal representation uses uppercase characters.";
     reference
-      "IEEE 802-2014, Clauses 3.1, 8.1";
+      "3.1 of IEEE Std 802-2014
+      8.1 of IEEE Std 802-2014";
   }
-
-  /*
-   * Collection of IEEE 802 related identifier types
-   */
-
 }
+


### PR DESCRIPTION
Hopefully final YANG modules for IEEE 802.1Qcp YANG Data model for Bridges project. Clean YANG Validation.

**ieee802-dot1q-types.yang**
Pyang Validation
ieee802-dot1q-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-bridge.yang**
Pyang Validation
ieee802-dot1q-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-bridge
    +--rw bridges
       +--rw bridge* [name]
          +--rw name           dot1qtypes:name-type
          +--rw address        ieee:mac-address
          +--rw bridge-type    identityref
          +--ro ports?         uint16
          +--ro up-time?       yang:zero-based-counter32
          +--ro components?    uint32
          +--rw component* [name]
             +--rw name                     string
             +--rw id?                      uint32
             +--rw type                     identityref
             +--rw address?                 ieee:mac-address
             +--rw traffic-class-enabled?   boolean
             +--ro ports?                   uint16
             +--ro bridge-port*             if:interface-ref
             +--ro capabilities
             |  +--ro extended-filtering?             boolean
             |  +--ro traffic-classes?                boolean
             |  +--ro static-entry-individual-port?   boolean
             |  +--ro ivl-capable?                    boolean
             |  +--ro svl-capable?                    boolean
             |  +--ro hybrid-capable?                 boolean
             |  +--ro configurable-pvid-tagging?      boolean
             |  +--ro local-vlan-capable?             boolean
             +--rw filtering-database
             |  +--rw aging-time?                          uint32
             |  +--ro size?                                yang:gauge32
             |  +--ro static-entries?                      yang:gauge32
             |  +--ro dynamic-entries?                     yang:gauge32
             |  +--ro static-vlan-registration-entries?    yang:gauge32
             |  +--ro dynamic-vlan-registration-entries?   yang:gauge32
             |  +--ro mac-address-registration-entries?    yang:gauge32 {extended-filtering-services}?
             |  +--rw filtering-entry* [database-id vids address]
             |  |  +--rw database-id    uint32
             |  |  +--rw address        ieee:mac-address
             |  |  +--rw vids           dot1qtypes:vid-range-type
             |  |  +--rw entry-type?    enumeration
             |  |  +--rw port-map* [port-ref]
             |  |  |  +--rw port-ref                             port-number-type
             |  |  |  +--rw (map-type)?
             |  |  |     +--:(static-filtering-entries)
             |  |  |     |  +--rw static-filtering-entries
             |  |  |     |     +--rw control-element?         enumeration
             |  |  |     |     +--rw connection-identifier?   port-number-type
             |  |  |     +--:(static-vlan-registration-entries)
             |  |  |     |  +--rw static-vlan-registration-entries
             |  |  |     |     +--rw registrar-admin-control?   enumeration
             |  |  |     |     +--rw vlan-transmitted?          enumeration
             |  |  |     +--:(mac-address-registration-entries)
             |  |  |     |  +--rw mac-address-registration-entries
             |  |  |     |     +--rw control-element?   enumeration
             |  |  |     +--:(dynamic-vlan-registration-entries)
             |  |  |     |  +--rw dynamic-vlan-registration-entries
             |  |  |     |     +--rw control-element?   enumeration
             |  |  |     +--:(dynamic-reservation-entries)
             |  |  |     |  +--rw dynamic-reservation-entries
             |  |  |     |     +--rw control-element?   enumeration
             |  |  |     +--:(dynamic-filtering-entries)
             |  |  |        +--rw dynamic-filtering-entries
             |  |  |           +--rw control-element?   enumeration
             |  |  +--ro status?        enumeration
             |  +--rw vlan-registration-entry* [database-id vids]
             |     +--rw database-id    uint32
             |     +--rw vids           dot1qtypes:vid-range-type
             |     +--rw entry-type?    enumeration
             |     +--rw port-map* [port-ref]
             |        +--rw port-ref                             port-number-type
             |        +--rw (map-type)?
             |           +--:(static-filtering-entries)
             |           |  +--rw static-filtering-entries
             |           |     +--rw control-element?         enumeration
             |           |     +--rw connection-identifier?   port-number-type
             |           +--:(static-vlan-registration-entries)
             |           |  +--rw static-vlan-registration-entries
             |           |     +--rw registrar-admin-control?   enumeration
             |           |     +--rw vlan-transmitted?          enumeration
             |           +--:(mac-address-registration-entries)
             |           |  +--rw mac-address-registration-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-vlan-registration-entries)
             |           |  +--rw dynamic-vlan-registration-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-reservation-entries)
             |           |  +--rw dynamic-reservation-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-filtering-entries)
             |              +--rw dynamic-filtering-entries
             |                 +--rw control-element?   enumeration
             +--rw permanent-database
             |  +--ro size?                               yang:gauge32
             |  +--ro static-entries?                     yang:gauge32
             |  +--ro static-vlan-registration-entries?   yang:gauge32
             |  +--rw filtering-entry* [database-id vids address]
             |     +--rw database-id    uint32
             |     +--rw address        ieee:mac-address
             |     +--rw vids           dot1qtypes:vid-range-type
             |     +--ro status?        enumeration
             |     +--rw port-map* [port-ref]
             |        +--rw port-ref                             port-number-type
             |        +--rw (map-type)?
             |           +--:(static-filtering-entries)
             |           |  +--rw static-filtering-entries
             |           |     +--rw control-element?         enumeration
             |           |     +--rw connection-identifier?   port-number-type
             |           +--:(static-vlan-registration-entries)
             |           |  +--rw static-vlan-registration-entries
             |           |     +--rw registrar-admin-control?   enumeration
             |           |     +--rw vlan-transmitted?          enumeration
             |           +--:(mac-address-registration-entries)
             |           |  +--rw mac-address-registration-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-vlan-registration-entries)
             |           |  +--rw dynamic-vlan-registration-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-reservation-entries)
             |           |  +--rw dynamic-reservation-entries
             |           |     +--rw control-element?   enumeration
             |           +--:(dynamic-filtering-entries)
             |              +--rw dynamic-filtering-entries
             |                 +--rw control-element?   enumeration
             +--rw bridge-vlan
             |  +--ro version?                   uint16
             |  +--ro max-vids?                  uint16
             |  +--ro override-default-pvid?     boolean
             |  +--ro protocol-template?         dot1qtypes:protocol-frame-format-type {port-and-protocol-based-vlan}?
             |  +--ro max-msti?                  uint16
             |  +--rw vlan* [vid]
             |  |  +--rw vid               dot1qtypes:vlan-index-type
             |  |  +--rw name?             dot1qtypes:name-type
             |  |  +--ro untagged-ports*   if:interface-ref
             |  |  +--ro egress-ports*     if:interface-ref
             |  +--rw protocol-group-database* [db-index] {port-and-protocol-based-vlan}?
             |  |  +--rw db-index             uint16
             |  |  +--rw frame-format-type?   dot1qtypes:protocol-frame-format-type
             |  |  +--rw (frame-format)?
             |  |  |  +--:(ethernet-rfc1042-snap8021H)
             |  |  |  |  +--rw ethertype?           dot1qtypes:ethertype-type
             |  |  |  +--:(snap-other)
             |  |  |  |  +--rw protocol-id?         string
             |  |  |  +--:(llc-other)
             |  |  |     +--rw dsap-ssap-pairs
             |  |  |        +--rw llc-address?   string
             |  |  +--rw group-id?            uint32
             |  +--rw vid-to-fid-allocation* [vids]
             |  |  +--rw vids               dot1qtypes:vid-range-type
             |  |  +--ro fid?               uint32
             |  |  +--ro allocation-type?   enumeration
             |  +--rw fid-to-vid-allocation* [fid]
             |  |  +--rw fid                uint32
             |  |  +--ro allocation-type?   enumeration
             |  |  +--ro vid*               dot1qtypes:vlan-index-type
             |  +--rw vid-to-fid* [vid]
             |     +--rw vid    dot1qtypes:vlan-index-type
             |     +--rw fid?   uint32
             +--rw bridge-mst
                +--rw mstid*                     dot1qtypes:mstid-type
                +--rw fid-to-mstid* [fid]
                |  +--rw fid      uint32
                |  +--rw mstid?   dot1qtypes:mstid-type
                +--rw fid-to-mstid-allocation* [fids]
                   +--rw fids     dot1qtypes:vid-range-type
                   +--rw mstid?   dot1qtypes:mstid-type
  augment /if:interfaces/if:interface:
    +--rw bridge-port
       +--rw component-name?                        string
       +--rw port-type?                             identityref
       +--rw pvid?                                  dot1qtypes:vlan-index-type
       +--rw default-priority?                      dot1qtypes:priority-type
       +--rw priority-regeneration
       |  +--rw priority0?   priority-type
       |  +--rw priority1?   priority-type
       |  +--rw priority2?   priority-type
       |  +--rw priority3?   priority-type
       |  +--rw priority4?   priority-type
       |  +--rw priority5?   priority-type
       |  +--rw priority6?   priority-type
       |  +--rw priority7?   priority-type
       +--rw pcp-selection?                         dot1qtypes:pcp-selection-type
       +--rw pcp-decoding-table
       |  +--rw pcp-decoding-map* [pcp]
       |     +--rw pcp             pcp-selection-type
       |     +--rw priority-map* [priority-code-point]
       |        +--rw priority-code-point    priority-type
       |        +--rw priority?              priority-type
       |        +--rw drop-eligible?         boolean
       +--rw pcp-encoding-table
       |  +--rw pcp-encoding-map* [pcp]
       |     +--rw pcp             pcp-selection-type
       |     +--rw priority-map* [priority dei]
       |        +--rw priority               priority-type
       |        +--rw dei                    boolean
       |        +--rw priority-code-point?   priority-type
       +--rw use-dei?                               boolean
       +--rw drop-encoding?                         boolean
       +--rw service-access-priority-selection?     boolean
       +--rw service-access-priority
       |  +--rw priority0?   priority-type
       |  +--rw priority1?   priority-type
       |  +--rw priority2?   priority-type
       |  +--rw priority3?   priority-type
       |  +--rw priority4?   priority-type
       |  +--rw priority5?   priority-type
       |  +--rw priority6?   priority-type
       |  +--rw priority7?   priority-type
       +--rw traffic-class
       |  +--rw traffic-class-map* [priority]
       |     +--rw priority                   priority-type
       |     +--rw available-traffic-class* [num-traffic-class]
       |        +--rw num-traffic-class    uint8
       |        +--rw traffic-class?       traffic-class-type
       +--rw acceptable-frame?                      enumeration
       +--rw enable-ingress-filtering?              boolean
       +--rw enable-restricted-vlan-registration?   boolean
       +--rw enable-vid-translation-table?          boolean
       +--rw enable-egress-vid-translation-table?   boolean
       +--rw protocol-group-vid-set* [group-id] {port-and-protocol-based-vlan}?
       |  +--rw group-id    uint32
       |  +--rw vid*        dot1qtypes:vlanid
       +--rw admin-point-to-point?                  enumeration
       +--ro protocol-based-vlan-classification?    boolean {port-and-protocol-based-vlan}?
       +--ro max-vid-set-entries?                   uint16 {port-and-protocol-based-vlan}?
       +--ro port-number?                           dot1qtypes:port-number-type
       +--ro address?                               ieee:mac-address
       +--ro capabilities?                          bits
       +--ro type-capabilties?                      bits
       +--ro external?                              boolean
       +--ro oper-point-to-point?                   boolean
       +--ro statistics
       |  +--ro delay-exceeded-discards?          yang:counter64
       |  +--ro mtu-exceeded-discards?            yang:counter64
       |  +--ro frame-rx?                         yang:counter64
       |  +--ro octets-rx?                        yang:counter64
       |  +--ro frame-tx?                         yang:counter64
       |  +--ro octets-tx?                        yang:counter64
       |  +--ro discard-inbound?                  yang:counter64
       |  +--ro forward-outbound?                 yang:counter64
       |  +--ro discard-lack-of-buffers?          yang:counter64
       |  +--ro discard-transit-delay-exceeded?   yang:counter64
       |  +--ro discard-on-error?                 yang:counter64
       |  +--ro discard-on-ingress-filtering?     yang:counter64 {ingress-filtering}?
       +--rw vid-translations* [local-vid]
       |  +--rw local-vid    dot1qtypes:vlanid
       |  +--rw relay-vid?   dot1qtypes:vlanid
       +--rw egress-vid-translations* [relay-vid]
          +--rw relay-vid    dot1qtypes:vlanid
          +--rw local-vid?   dot1qtypes:vlanid
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-types.yang**
Pyang Validation
ieee802-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-tpmr.yang**
Pyang Validation
ieee802-dot1q-tpmr.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-tpmr
  augment /if:interfaces/if:interface/dot1q:bridge-port:
    +--rw managed-address?          boolean
    +--rw mac-status-propagation
       +--rw link-notify?         boolean
       +--rw link-notify-wait?    yang:timeticks
       +--rw link-notify-retry?   yang:timeticks
       +--rw mac-notify?          boolean
       +--rw mac-notify-time?     yang:timeticks
       +--rw mac-recover-time?    yang:timeticks
  augment /if:interfaces/if:interface/dot1q:bridge-port/dot1q:statistics:
    +--ro acks-tx?                    yang:counter64
    +--ro add-notificatons-tx?        yang:counter64
    +--ro loss-notification-tx?       yang:counter64
    +--ro loss-confirmation-tx?       yang:counter64
    +--ro acks-rx?                    yang:counter64
    +--ro add-notificatons-rx?        yang:counter64
    +--ro loss-notification-rx?       yang:counter64
    +--ro loss-confirmation-rx?       yang:counter64
    +--ro add-events?                 yang:counter64
    +--ro loss-events?                yang:counter64
    +--ro mac-status-notifications?   yang:counter64
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-pb.yang**
Pyang Validation
ieee802-dot1q-pb.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-pb
  augment /if:interfaces/if:interface/dot1q:bridge-port:
    +--rw svid?                            dot1qtypes:vlanid
    +--rw cvid-registration* [cvid]
    |  +--rw cvid            dot1qtypes:vlanid
    |  +--rw svid?           dot1qtypes:vlanid
    |  +--rw untagged-pep?   boolean
    |  +--rw untagged-cep?   boolean
    +--rw service-priority-regeneration* [svid]
    |  +--rw svid                     dot1qtypes:vlanid
    |  +--rw priority-regeneration
    |     +--rw priority0?   priority-type
    |     +--rw priority1?   priority-type
    |     +--rw priority2?   priority-type
    |     +--rw priority3?   priority-type
    |     +--rw priority4?   priority-type
    |     +--rw priority5?   priority-type
    |     +--rw priority6?   priority-type
    |     +--rw priority7?   priority-type
    +--rw rcap-internal-interface* [external-svid]
       +--rw external-svid              dot1qtypes:vlanid
       +--rw internal-port-number?      dot1qtypes:port-number-type
       +--rw internal-svid?             dot1qtypes:vlanid
       +--rw internal-interface-type?   enumeration
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-vlan-bridge.yang**
Pyang Validation
ieee802-dot1q-vlan-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
