### PR TITLE
Changes from IEEE P802.1Qcc D2.1 to D2.2

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-tsn-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-tsn-types.yang
@@ -9,7 +9,7 @@ module ieee802-dot1q-tsn-types {
     "Institute of Electrical and Electronics Engineers";
 
   contact
-  	"WG-URL: http://grouper.ieee.org/groups/802/1/
+    "WG-URL: http://grouper.ieee.org/groups/802/1/
     WG-EMail: stds-802-1@ieee.org
 
     Contact: IEEE 802.1 Working Group Chair
@@ -852,35 +852,38 @@ module ieee802-dot1q-tsn-types {
       reference
         "46.2.3.2 of IEEE Std 802.1Qcc-2018";
       leaf rank {
-        type boolean;
+        type uint8;
         description
-          "The boolean rank is used by the network
-          to decide which Streams can and cannot
-          exist when TSN resources reach
-          their limit. If a Bridge’s Port becomes
-          oversubscribed (e.g. network reconfiguration,
-          IEEE Std 802.11 bandwidth reduction), the rank is
-          used to help determine which Streams can be
+          "The Rank is used by the network to decide which Streams
+          can and cannot exist when TSN resources reach their limit.
+          If a Bridge’s Port becomes oversubscribed (e.g. network
+          reconfiguration, IEEE 802.11 bandwidth reduction), the
+          Rank is used to help determine which Streams can be
           dropped (i.e. removed from Bridge configuration).
           
-          The false value is more important than the true value
-          (i.e. Streams with true rank are dropped first).
+          The only valid values for Rank shall be zero and one.
+          The configuration of a Stream with Rank zero is more
+          important than the configuration of a Stream with 
+          Rank one. The Rank value of zero is intended for 
+          emergency traffic, and the Rank value of one is 
+          intended for non-emergency traffic.
           
-          NOTE - It is expected that higher layer applications
-          and protocols can use the rank to indicate
-          the relative importance of Streams based on user
+          NOTE — It is expected that higher layer applications
+          and protocols can use the Rank to indicate the
+          relative importance of Streams based on user
           preferences. Those user preferences are expressed
           by means beyond the scope of this standard. When
           multiple applications exist in a network
-          (e.g. audio/video along with industrial control),
-          it can be challenging for the varied applications and
-          vendors to agree on multiple rank values. To mitigate
-          such challenges, this rank uses a simple concept of
-          emergency (false) and non-emergency (true) that
-          can be applied over all applications. For example,
-          in a network that carries audio Streams for
-          fire safety announcements, all applications are
-          likely to agree that those Streams use rank of false.";
+          (e.g. audio/video along with industrial control), 
+          it can be challenging for the varied applications
+          and vendors to agree on multiple Rank values.
+          To mitigate such challenges, this Rank uses
+          a simple concept of emergency (zero) and 
+          non-emergency (one) that can be applied 
+          over all applications. For example, in a network
+          that carries audio Streams for fire safety
+          announcements, all applications are likely to
+          agree that those Streams use Rank of zero.";        
         reference
           "46.2.3.2.1 of IEEE Std 802.1Qcc-2018";
       }
@@ -1414,7 +1417,7 @@ module ieee802-dot1q-tsn-types {
       "46.2.5 of IEEE Std 802.1Qcc-2018";
     
     leaf accumulated-latency {
-      type uint8;
+      type uint32;
       description
         "accumulated-latency provides the worst-case maximum 
         latency that a single frame of the Stream


### PR DESCRIPTION
For IEEE-SA sponsor ballot recirculation 2.

This module provides types for a UNI (northbound interface) used for TSN configuration.