### PR TITLE
Ciena YANG models

### DIFF
--- a/vendor/ciena/ciena-bw-calculation-mode.yang
+++ b/vendor/ciena/ciena-bw-calculation-mode.yang
@@ -1,0 +1,97 @@
+module ciena-bw-calculation-mode {
+  namespace "http://www.ciena.com/ns/yang/ciena-bw-calculation-mode";
+  prefix "ciena-bw-calculation-mode";
+
+  organization
+    "Ciena Corporation";
+
+  contact
+    "Web URL: http://www.ciena.com/
+    E-mail:  yang@ciena.com
+    Postal:  7035 Ridge Road
+             Hanover, Maryland 21076
+             U.S.A.
+    Phone:   +1 800-921-1144
+    Fax:     +1 410-694-5750";
+
+  description
+    "This YANG module defines the nodes for
+     BW Calculation Mode.
+
+     Copyright (c) 2017 Ciena Corporation.  All rights
+     reserved.
+
+     All information contained herein is, and remains
+     the property of Ciena Corporation. Dissemination of this
+     information or reproduction of this material is strictly
+     forbidden unless prior written permission is obtained from
+     Ciena Corporation.";
+
+  revision "2017-10-23" {
+      description
+          "Added missed references and descriptions";
+      reference
+          "RFC 6020: YANG - A Data Modeling Language for
+           the Network Configuration Protocol (NETCONF).
+           No specific reference; standard not available.";
+  }
+
+  revision "2016-12-08" {
+      description
+          "Initial version";
+      reference
+          "RFC 6020: YANG - A Data Modeling Language for
+           the Network Configuration Protocol (NETCONF).
+           No specific reference; standard not available.";
+  }
+
+  /*
+   * Type definitions
+   */
+
+   identity bw-calculation-modes {
+      description
+         "Modes of bandwidth calculation.";
+   }
+
+   identity transport {
+       base bw-calculation-modes;
+       description
+          "Bandwidth calculation mode is transport.";
+   }
+
+   identity payload {
+      base bw-calculation-modes;
+      description
+         "Bandwidth calculation mode is payload.";
+   }
+
+  /*
+   * Configuration data nodes
+   */
+   
+   container bw-calculation-mode {
+       description
+           "Mode configuration for bandwidth calculations."; 
+
+           leaf eqos-bw-calculation-mode {
+               type identityref {
+                   base bw-calculation-modes;
+               }
+               default transport;  
+
+               description
+                   "Egress QoS Bandwidth calculation mode selection. (Egress Shaping)";
+           }
+           leaf iqos-bw-calculation-mode {
+               type identityref {
+                   base bw-calculation-modes;
+               }
+               default transport;  
+
+               description
+                   "Ingress QoS Bandwidth calculation mode selection. (Ingress Metering)";
+          }
+    }    
+}
+

--- a/vendor/ciena/ciena-ietf-twamp.yang
+++ b/vendor/ciena/ciena-ietf-twamp.yang
@@ -1,0 +1,638 @@
+module ciena-ietf-twamp {
+   namespace "urn:ciena:params:xml:ns:yang:ciena-pn:ciena-ietf-twamp";
+    //namespace need to be assigned by IANA
+   prefix "twamp";
+
+   import ietf-inet-types {
+     prefix inet;
+   }
+
+   organization
+     "IETF IPPM (IP Performance Metrics) Working Group";
+
+   contact
+     "draft-cmzrjp-ippm-twamp-yang@tools.ietf.org";
+
+   description "TWAMP Data Model";
+
+   revision "2015-03-06" {
+     description "Initial version. RFC5357 is covered.
+       RFC5618, RFC5938 and RFC6038 are not covered.";
+     reference "RFC5357 A Two-Way Active Measurement Protocol, October 2008";
+   }
+
+   feature controlClient {
+     description "This feature relates to the device functions as the
+       TWAMP Control-Client.";
+   }
+
+   feature server {
+     description "This feature relates to the device functions as the
+       TWAMP Server.";
+   }
+
+   feature sessionSender {
+     description "This feature relates to the device functions as the
+       TWAMP Session-Sender.";
+   }
+
+   feature sessionReflector {
+     description "This feature relates to the device functions as the
+       TWAMP Session-Reflector.";
+   }
+
+   grouping maintenanceStatistics {
+     leaf sentPackets {
+       config "false";
+       type uint32;
+     }
+     leaf rcvPackets {
+       config "false";
+       type uint32;
+     }
+     leaf lastSentSeq {
+       config "false";
+       type uint32;
+     }
+     leaf lastRcvSeq {
+       config "false";
+       type uint32;
+     }
+   }
+
+   container twamp {
+     container twampClient {
+       presence "twampClient";
+       if-feature controlClient;
+       leaf clientAdminState {
+         mandatory "true";
+         type boolean;
+         description "Indicates whether this device is allowed to run
+           TWAMP to initiate control/test sessions";
+       }
+
+       list modePreferenceChain {
+         key "priority";
+         unique "mode";
+
+         leaf priority {
+           type uint16;
+         }
+
+         leaf mode {
+           type enumeration {
+             enum unauthenticated {
+               value "1";
+             }
+             enum authenticated {
+               value "2";
+               }
+             enum encrypted {
+               value "4";
+             }
+             enum unauthtestencrpytcontrol {
+               value "8";
+             }
+             enum individualsessioncontrol {
+               value "16";
+               }
+             enum reflectoctets {
+               value "32";
+             }
+             enum symmetricalsize {
+               value "64";
+             }
+           }
+         }
+       }
+
+       list keyChain {
+         key "keyId";
+         leaf keyId {
+           type string {
+           }
+         }
+         leaf secretKey {
+           type string;
+         }
+       }
+
+       list twampClientCtrlConnection {
+         key "ctrlConnectionName";
+         leaf ctrlConnectionName {
+           type "string";
+           description "A unique name used as a key to identify this
+             individual TWAMP control connection on the
+             Control-Client device.";
+         }
+         leaf clientIp {
+           type inet:ip-address;
+         }
+         leaf serverIp {
+           config "true";
+           type inet:ip-address;
+         }
+         leaf serverTcpPort {
+           type inet:port-number;
+         }
+         leaf dscp{
+           type inet:dscp;
+           description "The DSCP value to be placed in the IP header
+             of the TWAMP TCP Control packets generated
+             by the Control-Client";
+         }
+         leaf keyId {
+           type string {
+           }
+         }
+         leaf dkLen {
+           type uint32;
+         }
+         leaf clientTcpPort {
+           config "false";
+           type inet:port-number;
+         }
+         leaf serverStartTime {
+           config "false";
+           type uint64;
+         }
+         leaf ctrlConnectionState {
+           config "false";
+           type enumeration {
+             enum active {
+               description "Control session is active.";
+             }
+             enum idle {
+               description "Control session is idle.";
+             }
+           }
+         }
+         leaf selectedMode {
+           config "false";
+           type enumeration {
+             enum unauthenticated {
+               value "1";
+             }
+             enum authenticated {
+               value "2";
+               }
+             enum encrypted {
+               value "4";
+             }
+             enum unauthtestencrpytcontrol {
+               value "8";
+             }
+             enum individualsessioncontrol {
+               value "16";
+               }
+             enum reflectoctets {
+               value "32";
+             }
+             enum symmetricalsize {
+               value "64";
+             }
+           }
+         }
+         leaf token {
+           config "false";
+           type string {
+             length "1..64";
+           }
+           description "64 octets, containing the concatenation of a
+             16-octet challenge, a 16-octet AES Session-key used
+             for encryption, and a 32-octet HMAC-SHA1 Session-key
+             used for authentication";
+         }
+         leaf clientIv{
+           config "false";
+           type string {
+             length "1..16";
+           }
+           description "16 octets, Client-IV is generated randomly
+             by the Control-Client.";
+         }
+
+         list twampSessionRequest {
+           key "testSessionName";
+           leaf testSessionName {
+             type "string";
+           }
+           leaf senderIp {
+             type inet:ip-address;
+           }
+           leaf senderUdpPort {
+             type inet:port-number;
+           }
+           leaf reflectorIp {
+             type inet:ip-address;
+           }
+           leaf reflectorUdpPort {
+             type inet:port-number;
+           }
+           leaf timeout {
+             type uint64;
+             description "The time Session-Reflector MUST wait after
+                 receiving a Stop-Session message";
+           }
+           leaf paddingLength {
+             type uint32{
+               range "64..1500";
+             }
+             description "The number of bytes of padding that should
+                 be added to the UDP test packets generated by the
+                 sender.";
+           }
+           leaf startTime {
+             type uint64;
+           }
+           leaf repeat  {
+             type boolean;
+           }
+           leaf repeatInterval  {
+             type uint32;
+             when "../repeat='true'";
+             description "Repeat interval (in minutes)";
+           }
+           leaf pmIndex {
+             type uint16;
+             description "Numerical index value of a Registered
+                 Metric in the Performance Metric Registry";
+           }
+           leaf testSessionState {
+             config "false";
+             type enumeration {
+               enum ok {
+                 value 0;
+                 description "Test session is accepted.";
+               }
+               enum failed {
+                 value 1;
+                 description "Failure, reason unspecified
+                     (catch-all).";
+               }
+               enum internalError {
+                 value 2;
+                 description "Internal error.";
+               }
+               enum notSupported {
+                 value 3;
+                 description "Some aspect of request is not
+                     supported.";
+               }
+               enum permanentResLimit {
+                 value 4;
+                 description "Cannot perform request due to
+                     permanent resource limitations.";
+               }
+               enum tempResLimit {
+                 value 5;
+                 description "Cannot perform request due to
+                     temporary resource limitations.";
+               }
+             }
+           }
+           leaf sid{
+             config "false";
+             type string;
+           }
+         }
+       }
+     }
+
+     container twampServer {
+       presence "twampServer";
+       if-feature server;
+       leaf serverAdminState{
+         type boolean;
+         mandatory "true";
+         description "Indicates whether this device is allowed to run
+           TWAMP to respond to control/test sessions";
+       }
+       leaf serverTcpPort {
+         type inet:port-number;
+         default "862";
+       }
+       leaf servwait {
+         type uint32 {
+           range 1..604800;
+         }
+         default 900;
+         description "SERVWAIT (TWAMP Control (TCP) session timeout),
+           default value is 900";
+       }
+       leaf dscp {
+         type inet:dscp;
+         description "The DSCP value to be placed in the IP header
+           of the TWAMP TCP Control packets generated by the Server";
+       }
+       leaf count {
+         type uint32 {
+           range 1024..4294967295;
+         }
+       }
+       leaf maxCount {
+         type uint32 {
+           range 1024..4294967295;
+         }
+         default 32768;
+       }
+       leaf modes {
+         type bits {
+           bit unauthenticated {
+             position 0;
+           }
+           bit authenticated {
+             position 1;
+           }
+           bit encrypted {
+             position 2;
+           }
+           bit unauthtestencryptcontrol {
+             position 3;
+           }
+           bit individualsessioncontrol {
+             position 4;
+           }
+           bit reflectoctets {
+             position 5;
+           }
+           bit symmetricalsize {
+             position 6;
+           }
+         }
+       }
+       leaf salt{
+         config "false";
+         type string {
+         }
+           description "Salt MUST be generated pseudo-randomly";
+       }
+       leaf serverIv {
+         config "false";
+         type string {
+           length "1..16";
+         }
+         description "16 octets, Server-IV is generated randomly
+           by the Control-Client.";
+       }
+       leaf challenge {
+         config "false";
+         type string {
+         }
+         description "Challenge is a random sequence of octets
+           generated by the Server";
+       }
+
+       list keyChain {
+         key "keyId";
+         leaf keyId {
+           type string {
+           }
+         }
+         leaf secretKey {
+           type string;
+         }
+       }
+
+       list twampServerCtrlConnection {
+         key "clientIp clientTcpPort serverIp serverTcpPort";
+         config "false";
+         leaf clientIp {
+           type inet:ip-address;
+         }
+         leaf clientTcpPort {
+           type inet:port-number;
+         }
+         leaf serverIp {
+           type inet:ip-address;
+         }
+         leaf serverTcpPort {
+           type inet:port-number;
+         }
+         leaf serverCtrlConnectionState {
+           type enumeration {
+             enum "active";
+             enum "servwait";
+           }
+         }
+         leaf dscp {
+           type inet:dscp;
+           description "The DSCP value used in the header of the TCP
+             control packets sent by the Server for this control
+             connection. This will usually be the same value as is
+             configured for twampServer:dscp under the twampServer.
+             However, in the event that the user re-configures
+             twampServer:dscp after this control connection is already
+             in progress, this read-only value will show the actual
+             dscp value in use by this control connection.";
+         }
+         leaf selectedMode {
+           type enumeration {
+             enum unauthenticated {
+               value "1";
+             }
+             enum authenticated {
+               value "2";
+               }
+             enum encrypted {
+               value "4";
+             }
+             enum unauthtestencrpytcontrol {
+               value "8";
+             }
+             enum individualsessioncontrol {
+               value "16";
+               }
+             enum reflectoctets {
+               value "32";
+             }
+             enum symmetricalsize {
+               value "64";
+             }
+           }
+           description "The mode that was chosen for this control
+             connection as set in the Mode field of the Set-Up-Response
+             message.";
+         }
+         leaf keyId {
+           type string {
+           }
+           description "The keyId value that is in use by this control
+             connection.";
+         }
+         leaf dkLen {
+           type uint32;
+           description "The dkLen value that is in use by this control
+             connection. This will usually be the same value as is
+             configured under twampServer. In the event that the user
+             re-configured twampServer:dkLen after this control
+             connection is already in progress, this read-only value
+             will show the actual dkLen that is in use for this
+             control connection.";
+         }
+         leaf count {
+           type uint32 {
+             range 1024..4294967295;
+           }
+           description "The count value that is in use by this control
+             connection. This will usually be the same value as is
+             configured under twampServer. However, in the event that
+             the user re-configured twampServer:count after this control
+             connection is already in progress, this read-only value
+             will show the actual count that is in use for this
+             control connection.";
+         }
+         leaf maxCount {
+           type uint32 {
+             range 1024..4294967295;
+           }
+           description "The maxCount value that is in use by this
+             control connection. This will usually be the same value
+             as is configured under twampServer. However, in the event
+             that the user re-configured twampServer:maxCount after
+             this control connection is already in progress, this
+             read-only value will show the actual maxCount that is
+             in use for this control connection.";
+         }
+       }
+     }
+
+     container twampSessionSender {
+       if-feature sessionSender;
+       list twampSenderTestSession {
+         key "testSessionName";
+         leaf testSessionName {
+           type string;
+           description "A unique name for this test session to be used
+             as a key for this test session by the Session-Sender
+             logical entity.";
+         }
+         leaf ctrlConnectionName {
+           config "false";
+             type "string";
+             description "The name of the parent control connection
+               that is responsible for negotiating this test session.";
+         }
+         leaf dscp {
+           type inet:dscp;
+           description "The DSCP value to be placed in the header of
+             TWAMP UDP test packets generated by the sender.";
+         }
+         leaf dot1dPriority {
+           type uint8 {
+             range "0..7";
+           }
+         }
+         leaf fillMode {
+           type enumeration {
+             enum zero;
+             enum random;
+           }
+           default zero;
+         }
+         leaf numberOfPackets {
+           type uint32;
+           description "The overall number of UDP test packets to be
+             transmitted by the sender for this test session.";
+         }
+         choice packetDistribution {
+           case fixed {
+             leaf fixedInterval {
+               type uint32;
+             }
+             leaf fixedIntervalUnits  {
+               type enumeration {
+                 enum seconds;
+                 enum milliseconds;
+                 enum microseconds;
+                 enum nanoseconds;
+               }
+             }
+           }
+           case poisson {
+             leaf lambda {
+               type uint32;
+             }
+             leaf lambdaUnits {
+               type uint32;
+             }
+             leaf maxInterval {
+               type uint32;
+             }
+             leaf truncationPointUnits {
+               type enumeration {
+                 enum seconds;
+                 enum milliseconds;
+                 enum microseconds;
+                 enum nanoseconds;
+               }
+             }
+           }
+         }
+         leaf senderSessionState {
+           config "false";
+           type enumeration {
+             enum setup {
+               description "Test session is active.";
+             }
+             enum failure {
+               description "Test session is idle.";
+             }
+           }
+         }
+         uses maintenanceStatistics;
+       }
+     }
+
+     container twampSessionReflector {
+       if-feature sessionReflector;
+       leaf refwait {
+         config "true";
+         type uint32 {
+           range 1..604800;
+         }
+         default 900;
+         description "REFWAIT(TWAMP test session timeout),
+           the default value is 900";
+       }
+
+       list twampReflectorTestSession {
+         key "senderIp senderUdpPort reflectorIp reflectorUdpPort";
+         config "false";
+         leaf sid {
+           type string;
+         }
+         leaf senderIp {
+           type inet:ip-address;
+         }
+         leaf senderUdpPort {
+           type inet:port-number;
+         }
+         leaf reflectorIp {
+           type inet:ip-address;
+         }
+         leaf reflectorUdpPort {
+           type inet:port-number;
+         }
+         leaf parentConnectionClientIp {
+           type inet:ip-address;
+         }
+         leaf parentConnectionClientTcpPort {
+           type inet:port-number;
+         }
+         leaf parentConnectionServerIp {
+           type inet:ip-address;
+         }
+         leaf parentConnectionServerTcpPort {
+           type inet:port-number;
+         }
+         leaf dscp {
+           type inet:dscp;
+           description "The DSCP value placed in the header of TWAMP
+             UDP test packets generated by the Session-Sender.";
+         }
+         uses maintenanceStatistics;
+       }
+     }
+   }
+ }

--- a/vendor/ciena/ciena-mef-access-flow.yang
+++ b/vendor/ciena/ciena-mef-access-flow.yang
@@ -1,0 +1,466 @@
+module ciena-mef-access-flow {
+   namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-access-flow";
+   prefix "acl";
+
+   import ciena-mef-classifier {
+      prefix "classifier";
+   }
+
+   import ciena-mef-logical-port {
+      prefix "mef-logical-port";
+   }
+
+   import ciena-mef-fp {
+      prefix "mef-fp";
+   }
+
+   organization
+      "Ciena Corporation";
+
+   contact
+       "Web URL: http://www.ciena.com/
+       E-mail:  yang@ciena.com
+       Postal:  7035 Ridge Road
+       Hanover, Maryland 21076
+       U.S.A.
+       Phone:   +1 800-921-1144
+       Fax:     +1 410-694-5750";
+
+   description
+      "This YANG module defines Access Flows and Access Profiles.";
+
+   revision 2017-10-30 {
+      description
+         "Added description for lists, leafs, enums and containers.";
+      reference
+         "RFC 6020: YANG - A Data Modeling Language for
+          the Network Configuration Protocol (NETCONF).
+          No specific reference; standard not available.";
+   }
+
+   revision 2017-06-20 {
+      description
+         "Initial revision.";
+      reference
+         "RFC 6020: YANG - A Data Modeling Language for
+          the Network Configuration Protocol (NETCONF).
+          No specific reference; standard not available.";
+   }
+
+ /*
+  * typedefs
+  */
+   typedef access-flow-ref {
+      type leafref {
+         path "/acl:access-flows/acl:access-flow/acl:name";
+      }
+      description
+         "This type is used by the data models that needs to reference
+          configured Access flows.";
+   }
+
+   typedef access-profile-ref {
+      type leafref {
+         path "/acl:access-profiles/acl:access-profile/acl:name";
+      }
+      description
+         "This type is used by the data models that needs to reference
+          configured Access Profile.";
+   }
+
+   typedef acl-action-ref {
+      type leafref {
+         path "/acl:acl-actions/acl:acl-action/acl:name";
+      }
+      description
+         "This type is used by the data models that needs to reference
+          configured ACL actions.";
+   }
+
+   typedef custom-destination-ref {
+      type leafref {
+         path "/acl:acl-custom-destinations/acl:acl-custom-destination/acl:name";
+      }
+      description
+         "This type is used by the data models that needs to reference
+          custom destinations for ACLs.";
+   }
+
+   grouping  acl-destination {
+      choice destination {
+         case logical-port-list {
+            leaf-list logical-port {
+               type mef-logical-port:logical-port-ref;
+               description
+                  "Reference to logical-port.";
+            }
+            description
+                "one or more logical-ports which act as destination for the acl-action (e.g. mirror/redirect)";
+         }
+
+         case flow-point-list {
+            leaf-list flow-point {
+               type mef-fp:fp-ref;
+               description
+                  "Reference to flow-point.";
+            }
+            description
+               "one or more flow-points which act as destination for the acl-action (e.g. mirror/redirect)";
+         }
+
+         case custom-list {
+            leaf-list custom {
+               type acl:custom-destination-ref;
+               description
+                  "Reference to custom-destination object that represents the custom destinations this acl-action is being added to.";
+            }
+            description
+               "one or more custom destinations which act as destination for the acl-action (e.g. mirror/redirect)";
+         }
+         description
+            "This specifies the choice of destinations for the acl-action.";
+      }
+      description
+         "This grouping defines the destinations for ACL.";
+   }
+
+   /*
+    * Configuration.
+    */
+
+   container acl-custom-destinations {
+
+      list acl-custom-destination {
+         key "name";
+
+         leaf name {
+            type string;
+
+            description
+               "A unique string that is either system assigned or assigned
+                by the user but does not change over its life.";
+         }
+
+         leaf description {
+            type string;
+            description
+               "A more detailed description that an operator can use
+                to describe the custom destination.";
+         }
+
+         leaf destination {
+            type enumeration {
+               enum voltha-agent {
+                  description
+                     "Redirect the classified flow to a voltha-agent application.";
+               }
+            }
+            description
+               "Specifies an application name for this acl destination";
+         }
+         description
+            "This denotes list of ACL custom destinations.";
+      }
+      description
+         "Configuration data for ACL custom destinations.";
+   }
+
+   container acl-actions {
+
+      list acl-action {
+         key "name";
+
+         leaf name {
+            type string;
+
+            description
+               "A unique string that is either system assigned or assigned
+                by the user but does not change over its life.";
+         }
+
+         leaf description {
+            type string;
+            description
+               "A more detailed description that an operator can use
+                to describe the action.";
+         }
+
+         leaf action {
+            type enumeration {
+               enum redirect {
+                  description
+                     "Redirect the classified flow to one or more ports/flow-points etc.";
+               }
+               enum ingress-mirror {
+                  description
+                     "Ingress-Mirror the classified flow to one or more ports/flow-points etc.";
+               }
+            }
+            description
+               "Specifies an action for this acl action";
+         }
+
+         uses acl:acl-destination {
+            when "action = 'redirect' or action = 'ingress-mirror'";
+         }
+         description
+            "This denotes the list of ACL actions.";
+      }
+      description
+         "Configuration data for ACL actions.";
+   }
+
+   container access-flows {
+
+      list access-flow {
+         key "name";
+
+         leaf name {
+            type string;
+
+            description
+               "A unique string that is either system assigned or assigned
+                by the user but does not change over its life.";
+         }
+
+         leaf description {
+            type string;
+            description
+               "A more detailed description that an operator can use 
+                to describe the flow.";
+         }
+
+         leaf-list classifier-list {
+            type classifier:classifier-ref;
+            description
+               "A reference to a list of classifier entries.";
+         }
+
+         leaf classifier-precedence {
+            type uint32;
+            description
+               "A precedence value for the access flow. Lower values take
+                precedence over higher values";
+         }
+
+         choice parent-interface {
+
+            case none {
+               leaf none {
+                  type empty;
+                  description
+                     "A reference to an empty classifier.";
+               }
+               description
+                  "When the Access-Flow is an ACL rule in an Access-Profile, use none.
+                   In this case, the access-profile is referenced by a parent-interface instead.";
+            }
+
+            case logical-port {
+               leaf-list parent-port {
+                  type mef-logical-port:logical-port-ref;
+                  description
+                     "A reference to a list of logical-port entries.";
+               }
+               description
+                  "This is used when the Access-Flow is an ACL rule that is not part of an Access-Profile.
+                   In this case, the parent-interface defines the port that the Access-Flow applies to";
+            }
+
+            case flow-point {
+               leaf-list parent-fp {
+                  type mef-fp:fp-ref;
+                  description
+                     "A reference to a list of flow-point entries.";
+               }
+               description
+                  "This is used when the Access-Flow is an ACL rule that is not part of an Access-Profile.
+                   In this case, the parent-interface defines the flow-point that the Access-Flow applies to";
+            }
+            description
+               "This defined the interface that the Access-Flow applies to.";
+         }
+
+         leaf filter-action {
+
+            type enumeration {
+               enum deny {
+                  description 
+                     "Drop traffic for traffic that matches this specific access-flow-rule.
+                      This may be augmented with specific actions in the action list for this traffic flow";
+               }
+               enum allow {
+                  description
+                     "Do not drop traffic for traffic that matches this specific access-flow-rule.
+                      This may be augmented with specific actions in the action list for this traffic flow";
+               }
+            }
+            description
+               "Specifies the filter-action for this Access-Flow/ACL-Rule";
+         }
+
+         leaf-list augment-action {
+               type acl:acl-action-ref;
+               description
+                   "A list of Actions that may augment the filter-action of the Access-Flow/ACL-Rule.";
+         }
+
+         leaf stats-collection {
+            type enumeration {
+               enum on { 
+                  description
+                     "Stats collection on.";
+               }
+               enum off {
+                  description
+                     "Stats collection off.";
+               }
+            }
+            description
+               "Determines whether stats collection will be turned on or not for an access-flow";
+         }
+         description
+            "This denotes the list of Access-Flows/ACL-Rules.";
+      }
+      description
+         "Configuration data for Access-Flows/ACL-Rules.";
+   }
+
+   container access-profiles {
+
+      list access-profile {
+         key "name";
+ 
+         leaf name {
+            type string;
+
+            description
+               "A unique string that is either system assigned or assigned
+                by the user but does not change over its life.";
+         }
+
+         leaf description {
+            type string;
+            description
+               "A more detailed description that an operator can use
+               to describe the profile.";
+         }
+
+         leaf-list access-flow-rule {
+            type acl:access-flow-ref;
+            description
+               "A list of ACL rules, Access-Flows that are part of an access-profile.
+                Each ACL-rule/Access-Flow specifies classifiers, precedence and actions independently";
+         }
+
+         leaf default-filter-action {
+
+            type enumeration {
+               enum deny {
+                  description 
+                     "Drop traffic for all other traffic that does not match a specific access-flow-rule but
+                      classifies to this Access-Profile";
+               }
+               enum allow {
+                  description
+                     "Do not drop traffic for all other traffic that does not match a specific access-flow-rule but
+                      classifies to this Access-Profile";
+               }
+            }
+            description
+               "Specifies the default filter-action for this Access-Profile";
+         }
+
+         leaf stats-collection {
+            type enumeration {
+               enum on {
+                  description
+                     "Stats collection on.";
+               }
+               enum off {
+                  description
+                     "Stats collection off.";
+               }
+            }
+            description
+               "Determines whether stats collection will be turned on or not instance of an access-profile";
+         }
+
+         description
+            "A list of all access-profile configuration entries.";
+      }
+      description
+         "Configuration data for Access Profiles.";
+   }
+
+   /*
+    * State.
+    */
+   container access-flows-state {
+      config false;
+
+      description
+         "Access Flow operational data for all Access Flows.";
+
+      list access-flow {
+         key "name";
+         description
+            "The operational data for this Access-Flow.";
+
+         leaf name {
+            type string;
+            description
+               "A string that identifies the Access-Flow.";
+         }
+
+         leaf hitBytes {
+            type uint64;
+            description
+               "byte count of frames that hit the Access-Flow";
+         }
+
+         leaf hitFrames {
+            type uint64;
+            description
+               "frame count of frames that hit the Access-Flow";
+         }
+      }
+   }
+
+   container acl-actions-state {
+      config false;
+
+      description 
+         "ACL action operational data for all ACL Augment Actions.";
+
+      list access-action {
+         key "name";
+         description
+            "The operational data for this ACL Augment Action.";
+
+         leaf name {
+            type string; 
+            description
+               "A string that identifies the Access Augment Action.";
+         }
+
+         leaf number-of-attached-rules {
+            type uint16;
+            description
+               "Number of rules the augment action instance is associated with.";
+         }
+      }
+
+      leaf defined-acl-actions {
+         type uint16;
+         description
+            "Number of defined augment action instances on the device.";
+      }
+
+      leaf remaining-acl-actions-available {
+         type uint16;
+         description
+            "Number of available augment action instances on the device.";
+      }
+   }
+}

--- a/vendor/ciena/ciena-mef-classifier.yang
+++ b/vendor/ciena/ciena-mef-classifier.yang
@@ -1,0 +1,687 @@
+module ciena-mef-classifier {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-classifier";
+    prefix "classifier";
+    
+    import ietf-inet-types {
+        prefix "inet";
+    }
+
+    import ietf-yang-types {
+        prefix "yt";
+    }
+
+   organization
+       "Ciena Corporation";
+
+   contact
+       "Web URL: http://www.ciena.com/
+        E-mail:  yang@ciena.com
+        Postal:  7035 Ridge Road
+                 Hanover, Maryland 21076
+                 U.S.A.
+        Phone:   +1 800-921-1144
+        Fax:     +1 410-694-5750";
+
+   description
+       "This YANG module defines Ciena's management data definition for the
+        management of a classifier."; 
+
+    revision 2017-05-16 {
+        description
+            "Various updates to classifers since first revision
+             Added description for containers, leafs, lists, enums
+             and choices.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+    
+    revision 2014-12-19 {
+        description
+            "First revision of MEF based classifier";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+    
+    /*
+     * Typedefs
+     */
+    typedef classifier-ref {
+        type leafref {
+            path "/classifier:classifiers/classifier:classifier/classifier:name";
+        }
+        description
+          "This type is used by data models that need to reference
+           configured classifier list.";
+    }
+    
+    /*
+     * Feature
+     */    
+    feature filter-parameters-type {
+        description
+            "Allows for configuration of filter parameters inline.";
+    }
+    
+    identity filter-param-type {
+        description
+            "This is the base identity of the filter-param-type.";
+    }
+    
+    identity vtag-stack {
+        base filter-param-type;
+        description
+            "Classify on vtag stack.";
+    }
+
+    identity mpls-label {
+        base filter-param-type;
+        description
+            "Classify on mpls label.";
+    }
+    
+    identity dscp {
+        base filter-param-type;
+        description
+            "Classify on dscp.";
+    }
+    
+    identity source-ip {
+        base filter-param-type;
+        description
+            "Classify on source ip.";
+    }
+    
+    identity destination-ip {
+        base filter-param-type;
+        description
+            "Classify on destination ip.";
+    }
+    
+    identity l4-destination-port {
+        base filter-param-type;
+        description
+            "Classify on L4 destination port.";
+    }
+    
+    identity l4-source-port {
+        base filter-param-type;
+        description
+            "Classify on L4 source port.";
+    }
+    
+    identity ip-protocol {
+        base filter-param-type;
+        description
+            "Classify on ip protocol.";
+    }
+    
+    identity base-etype {
+        base filter-param-type;
+        description
+            "Classify on base ether type.";
+    }
+
+    identity any {
+        base filter-param-type;
+        description
+            "Classify on any traffic.";
+    }
+
+    feature vtag-stack-feature {
+        description
+            "Allows for configuration of vtag stack type inline.";
+    }
+    
+    identity vtag-stack-type {
+        description
+            "This is the base identity for vtag stack.";
+    }
+    
+    identity untagged {
+        base vtag-stack-type;
+        description
+            "Classify on untagged.";
+    }
+    
+    identity l2cp {
+        base vtag-stack-type;
+        description
+            "Classify on L2CP.";
+    }
+    
+    identity tagged {
+        base vtag-stack-type;
+        description
+            "Classify on tagged.";
+    }
+
+    identity ip-fragment {
+        base filter-param-type;
+        description
+            "Classify on ip fragment.";
+    }
+
+    identity l4-application {
+        base filter-param-type;
+        description
+            "Classify on L4 application.";
+    }
+
+    identity tcp-flags {
+        base filter-param-type;
+        description
+            "Classify on tcp flags.";
+    }
+
+    identity l4-dst-protocol {
+        base filter-param-type;
+        description
+            "Classify on l4 destination protocol.";
+    }
+
+    identity source-mac {
+        base filter-param-type;
+        description
+            "Classify on source mac.";
+    }
+
+    identity destination-mac {
+        base filter-param-type;
+        description
+            "Classify on destination mac.";
+    }
+
+    grouping classifier-group {
+        list classifier {
+            key "name";
+            ordered-by user;    // User sets the order of this list.
+            
+            leaf name {
+                type string;
+                description
+                    "A unique name for the classifier.";
+            }
+            
+            leaf filter-operation {
+                type enumeration {
+                    enum match-all {
+                    description
+                        "Classify if all configured filter entry matches.";
+                    }
+                    enum match-any {
+                    description
+                        "Classify if any configured filter entry matches.";
+                    }
+                }
+                description
+                    "Indicates the filter operation of the classifier.";
+            }
+            
+            list filter-entry {
+                key "filter-parameter";
+                
+                ordered-by user;
+                
+                leaf filter-parameter {
+                    type identityref {
+                        base filter-param-type;
+                    }
+                    description
+                        "Indicates which filter parameter is used by this filter entry";
+                }
+                
+                leaf logical-not {
+                    type boolean;
+                    default "false";
+                    description
+                        "Opposite of what is specified in the 
+                         filter-parameters. If the filter-parameter
+                         specifies a tpid as tpid-8100, then anything
+                         other than tpid-8100 is considered an acceptable
+                         packet.";
+                }
+                
+                choice filter-parameters {
+                    case vtag-stack {
+                        choice vtag-stack-type {
+                            case untagged {
+                                leaf untagged-exclude-priority-tagged {
+                                    type boolean;
+                                    description
+                                        "Classification on untagged frames excluding priority tagged frames.";
+                                }
+                            }
+                            
+                            case l2cp {
+                                leaf l2cp-exclude-priority-tagged {
+                                    type boolean;
+                                    description
+                                        "Classification on L2CP frames excluding priority tagged frames.";
+                                }
+                            }
+                            
+                            case tagged {
+                                list vtags {
+                                    key "tag";
+                                    
+                                    leaf tag {
+                                        type uint8;
+                                        description
+                                            "'1' represents outer most tag, '2' next outer most, etc.";
+                                    }
+
+                                    leaf tpid {
+                                        type enumeration {
+                                            enum tpid-8100 {
+                                                description
+                                                    "Indicates value of VLAN tag TPID to be 0x8100.";
+                                            }
+                                            enum tpid-88a8 {
+                                                description
+                                                    "Indicates value of VLAN tag TPID to be 0x88a8.";
+                                            }
+                                            enum tpid-9100 {
+                                                description
+                                                    "Indicates value of VLAN tag TPID to be 0x9100.";
+                                            }
+                                        }
+                                        description
+                                            "This leaf represents the value of VLAN tag TPID.";
+                                    }
+                                    
+                                    leaf pcp {
+                                        type uint8 {
+                                            range "0..7";
+                                        }
+                                        description
+                                            "This leaf represents the value of PCP in a single classifier.";
+                                    }
+
+                                    leaf pcp-mask {
+                                        type uint8 {
+                                            range "1..7";
+                                        }
+                                        description
+                                            "Allow PCP values to be optionally coupled with a mask in a single classifier.";
+                                    }
+
+                                    leaf dei {
+                                        type enumeration {
+                                            enum discard-eligible {
+                                            description
+                                                "Indicates DEI bit is true i.e. set to 1.";
+                                            }
+                                            enum not-discard-eligible {
+                                            description
+                                                "Indicates DEI bit is false i.e. set to 0.";
+                                            }
+                                        }
+                                        description
+                                            "Discard Eligibility Indication.";
+                                    }
+                                    
+                                    leaf vlan-id {
+                                        type uint16 {
+                                            range "1..4094";
+                                        }
+                                        description
+                                            "Represents a IEEE 802.1Q VLAN-ID.";
+                                    }
+
+                                    leaf vlan-id-max { 
+                                       type uint16 { 
+                                          range "1..4094"; 
+                                       } 
+                                       description 
+                                          "The maximum value of VLAN ID for ranged VLAN-ID values. Mutually exclusive to vlan-id-mask."; 
+                                    } 
+    
+                                    leaf vlan-id-mask { 
+                                       type uint16 { 
+                                          range "1..4095"; 
+                                       } 
+                                       description 
+                                          "Allow VLAN ID values to be optionally coupled with a mask. Mutually exclusive to vlan-id-max."; 
+                                    }  
+                                    description 
+                                        "This represents the list of vtags."; 
+                                }
+                            }
+                            description 
+                                "This represents the choice of vtag stack type in a single classifier."; 
+                        }
+                    }
+                    
+                    case mpls-label-stack {
+                        list mpls-labels {
+                            key "label"; // Need a key. It cannot be a choice param.
+                            
+                            leaf label {
+                                type uint32;
+                                description
+                                    "An administratively assigned value, which may be used
+                                     to identify the mpls label.";
+                            }
+                            choice labels {
+                                case any {
+                                    leaf label-any {
+                                        type empty;
+                                        description
+                                            "Represents any label.";
+                                    }
+                                    description
+                                        "Accept any label.";
+                                }
+                                
+                                case value {
+                                    leaf mpls-label {
+                                        type uint32;
+                                        description
+                                            "Indicates the value of mpls label.";
+                                    }
+                                }
+                                description
+                                    "This represents the choice of labels to be configured.";
+                            }
+                            
+                            choice tc {
+                                case any {
+                                    leaf tc-any {
+                                        type empty;
+                                        description
+                                            "Represents any tc value.";
+                                    }
+                                    description
+                                        "Accept any tc value.";
+                                }
+                                
+                                case value {
+                                    leaf tc-value {
+                                        type uint8;
+                                        description
+                                            "Indicates the value of tc.";
+                                    }
+                                }
+                                description
+                                    "This represents the choice of TCs to be configured.";
+                            }
+                            description 
+                                "This represents the list of mpls labels."; 
+                        }
+                    }
+                    
+                    case dscp {
+                        leaf dscp-min {
+                            type inet:dscp;
+                            description
+                                "The minimum value of DSCP.";
+                        }
+                        leaf dscp-max {
+                            type inet:dscp;
+                            description
+                                "The maximum value of DSCP for ranged DSCP values in a single classifier. Mutually exclusive to dscp-mask.";
+                        }
+                        leaf dscp-mask {
+                            type inet:dscp;
+                            description
+                                "Allow DSCP values to be optionally coupled with a mask in a single classifier. Mutually exclusive to dscp-max.";
+                        }
+                    }
+                    
+                    case source-ip {
+                        leaf source-address {
+                            type inet:ip-prefix;
+                            description
+                               "Source IP address (v4/v6) with mask.";
+                        }
+                        description
+                           "Classification on IP source-address (v4/v6) and masking.";
+                    }
+
+                    case destination-ip {
+                        leaf destination-address {
+                            type inet:ip-prefix;
+                            description
+                               "Destination IP address (v4/v6) with mask.";
+                        }
+                        description
+                           "Classification on IP destination-address (v4/v6) and masking.";
+                    }
+                    
+                    case l4-source-port {
+                        leaf source-min {
+                            type inet:port-number;
+                            description
+                               "L4 source port minimum value.";
+                        }
+                        leaf source-max {
+                            type inet:port-number;
+                            description
+                               "L4 source port maximum value.";
+                        }
+                    }
+                    
+                    case l4-destination-port {
+                        leaf destination-min {
+                            type inet:port-number;
+                            description
+                               "L4 destination port minimum value.";
+                        }
+                        leaf destination-max {
+                            type inet:port-number;
+                            description
+                               "L4 destination port maximum value.";
+                        }
+                    }
+                    
+                    case ip-protocol {
+                        leaf min-prot {
+                            type uint16;
+                            description
+                               "IP protocol minimum value.";
+                        }
+                        leaf max-prot {
+                            type uint16;
+                            description
+                               "IP protocol maximum value.";
+                        }
+                    }
+                    
+                    case base-etype {
+                        leaf base-ethertype {
+                            type uint16;
+                            description
+                               "Indicates the base ether type value.";
+                        }
+                    }
+
+                    case any {
+                        leaf any {
+                            type empty;
+                            description
+                               "Accept any classification. Wide-Open classifier";
+                        }
+                    }
+
+                    case ip-fragment {
+                        leaf ip-fragment {
+                            type boolean;
+                            description
+                               "IP-fragment bit true/false";
+                        }
+                    }
+
+                    case l4-application {
+                        leaf l4-application {
+                           type enumeration {
+                              enum twamp {
+                                  description "twamp.";
+                              }
+                           }
+                           description
+                               "This leaf represents the L4 application. Mutually exclusive with L4 destination port";
+                        }
+                    }
+
+                    case l4-dst-protocol {
+                        leaf l4-dst-protocol {
+                          type enumeration {
+                            enum bootp-client {
+                              description "bootp-client.";
+                            }
+                            enum bootp-server {
+                              description "bootp-server.";
+                            }
+                            enum bgp {
+                              description "bgp.";
+                            }
+                            enum dhcpv6-client {
+                              description "dhcpv6 client.";
+                            }
+                            enum dhcpv6-server {
+                              description "dhcpv6 server.";
+                            }
+                            enum dhcp-client {
+                              description "dhcp client.";
+                            }
+                            enum dhcp-server {
+                              description "dhcp server.";
+                            }
+                            enum dns {
+                              description "dns.";
+                            }
+                            enum ftp {
+                              description "ftp.";
+                            }
+                            enum http {
+                              description "http.";
+                            }
+                            enum ldp {
+                              description "ldp.";
+                            }
+                            enum ntp {
+                              description "ntp.";
+                            }
+                            enum olsr {
+                              description "olsr.";
+                            }
+                            enum rip {
+                              description "rip.";
+                            }
+                            enum rpc {
+                              description "rpc.";
+                            }
+                            enum snmp {
+                              description "snmp.";
+                            }
+                            enum snmptrap {
+                              description "snmp trap.";
+                            }
+                            enum ssh {
+                              description "ssh.";
+                            }
+                            enum syslog {
+                              description "syslog.";
+                            }
+                            enum tacacs {
+                              description "tacacs.";
+                            }
+                            enum telnet {
+                              description "telnet.";
+                            }
+                            enum tftp {
+                              description "tftp.";
+                            }
+                            enum twampctl {
+                              description "twampctl.";
+                            }
+                          }
+                          description
+                            "L4 protocol.";
+                        }
+                    }
+					
+                    case tcp-flags {
+                        leaf syn {
+                          type boolean;
+                          description
+                              "Sets the TCP Flag SYN true/false.";
+                        }
+                        leaf ack {
+                          type boolean;
+                          description
+                              "Sets the TCP Flag ACK true/false.";
+                        }
+                        leaf rst {
+                          type boolean;
+                          description
+                              "Sets the TCP Flag RST true/false.";
+                        }
+                        leaf urg {
+                          type boolean;
+                          description
+                              "Sets the TCP Flag URG true/false.";
+                        }
+                        leaf psh {
+                          type boolean;
+                          description
+                              "Sets the TCP Flag PSH true/false.";
+                        }
+                        leaf fin {
+                          type boolean;
+                          description
+                              "Sets the TCP Flag FIN true/false.";
+                        }
+                        description
+                          "TCP flags.";
+                    }
+
+                    case source-mac {
+                        leaf source-mac {
+                            type yt:mac-address;
+                            description
+                                "Sets the source MAC address.";
+                        }
+                        leaf source-mac-mask {
+                            type yt:mac-address;
+                            description
+                                "Sets the source MAC address MASK.";
+                        }
+                    }
+                    
+                    case destination-mac {
+                        leaf destination-mac {
+                            type yt:mac-address;
+                            description
+                                "Sets the destination MAC address.";
+                        }
+                        leaf destination-mac-mask {
+                            type yt:mac-address;
+                            description
+                                "Sets the destination MAC address mask.";
+                        }
+                    }
+                    description
+                        "Indicates the choice of filter parameters used in a single classifier.";
+                }
+                description
+                    "Indicates the list of filter entries for this classifier.";
+            }
+            description
+                "This defines the list of classifiers.";
+        }
+        description
+            "This defines the classifier group on the device.";
+    }
+
+    container classifiers {
+       uses classifier-group;
+       description
+           "Configuration data for classifiers.";
+    }
+}
+

--- a/vendor/ciena/ciena-mef-cos-to-frame-map.yang
+++ b/vendor/ciena/ciena-mef-cos-to-frame-map.yang
@@ -1,0 +1,172 @@
+module ciena-mef-cos-to-frame-map {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn:ciena-mef-cos-to-frame-map";
+    prefix "ctf";
+
+    organization
+        "Ciena Corporation";
+
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines the CoS to Frame Map. A combination of 
+         cos and color yields a pcp and dei or ip-dscp or mpls-tc.
+         Additionally, for some forwarding-plane architectures, this module also
+         defines the CoS to Queue Map. CoS yields a Queue Number and also a WRED
+         curve number for green or yellow frames.";
+
+    revision 2017-10-26 {
+        description
+            "Added description in containers, lists, leafs.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision 2015-07-16 {
+        description "Initial revision.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    /*
+     * Typedefs
+     */
+    typedef cos-to-frame-ref {
+        type leafref {
+            path "/ctf:cos-to-frame-maps/ctf:cos-to-frame-map/ctf:name";
+        }
+        description
+            "This type is used by data models that need to reference
+             configured CoS to frame maps.";
+    }
+
+    container cos-to-frame-maps {
+        description
+            "Configuration data for CoS to Frame Maps.";
+
+        list cos-to-frame-map {
+            key "name";
+
+            description
+                "A list of profiles that can contain several map entries.";
+
+            leaf name {
+                type string;
+                description
+                    "A string used to uniquely identify a profile entry within
+                     the list of maps (profiles).";
+            }
+
+            leaf description {
+                type string;
+                description
+                    "A more detailed description of the map.";
+            }
+
+            list map-entry {
+                key "cos color";
+
+                description
+                    "A list of map entries within a CoS to Frame map.";
+
+                leaf cos {
+                    type uint8 {
+                        range "0..63";
+                    }
+                    description
+                        "Class of Service bits.";
+                }
+
+                leaf color {
+                    type enumeration {
+                        enum green {
+                            description
+                                "A color of green indicates the frame is conformant with CIR.";
+                        }
+                        enum yellow {
+                            description
+                                "A color of yellow indicates the frame is not conformant with
+                                 CIR but is conformant with EIR and red means it is not
+                                 conformant with EIR or CIR and thus will be dropped.";
+                        }
+                    }
+                    description
+                        "The assigned color for the frame.";
+                }
+
+                leaf pcp {
+                    type uint8 {
+                        range "0..7";
+                    }
+                    description
+                        "The frame's VLAN tag priority bits will be set to this 
+                         value if the frame's assigned cos and color matches this 
+                         map instance.";
+                }
+
+                leaf dei {
+                    type enumeration {
+                        enum enabled {
+                            description 
+                                "The frame's VLAN tag DEI bit will be set to this if the 
+                                 frame's assigned cos and color matches this map instance.";
+                        }
+                        enum disabled {
+                            description 
+                                "The frame's VLAN tag DEI bit will be set to this if the 
+                                 frame's assigned cos and color matches this map instance.";
+                        }
+                    }
+                    description
+                        "Drop Eligibility Indication.";
+                }
+
+                leaf ip-dscp {
+                    type uint8 {
+                        range "0..63";
+                    }
+                    description
+                        "IP DiffServ Code Point value.";
+                }
+
+                leaf mpls-tc {
+                    type uint8 {
+                        range "0..7";
+                    }
+                    description
+                        "MPLS Traffic Class (TC) bits.";
+                }     
+
+                leaf queue {
+                    type uint32;
+                    description
+                        "Queue mapped to by internal CoS for E-QoS.";
+                }
+
+                leaf green-wred-curve {
+                    type uint32;
+                    description
+                        "WRED curve relative to a Queue to use for traffic whose internal
+                         color is Green.";
+                }
+
+                leaf yellow-wred-curve {
+                    type uint32;
+                    description
+                        "WRED curve relative to a Queue to use for traffic whose internal
+                         color is Yellow.";
+                }
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-mef-egress-qos-binding.yang
+++ b/vendor/ciena/ciena-mef-egress-qos-binding.yang
@@ -1,0 +1,95 @@
+module ciena-mef-egress-qos-binding {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-egress-qos-binding";
+    prefix "mef-egress-qos-binding";
+    
+    import ciena-mef-egress-qos {
+       prefix "mef-egress-qos";
+    }
+
+    import ciena-mef-logical-port {
+       prefix "mef-logical-port";
+    }
+
+    organization
+        "Ciena Corporation";
+    
+    contact
+        "Web URL: http://www.ciena.com/
+        E-mail:  yang@ciena.com
+        Postal:  7035 Ridge Road
+                 Hanover, Maryland 21076
+                     U.S.A.
+        Phone:   +1 800-921-1144
+        Fax:     +1 410-694-5750";
+    
+    description
+        "This YANG module defines Ciena's management data definition for the
+         association of certain interfaces (e.g. mef-logical-port) to a queue-group-instance.";
+    
+    revision "2017-10-23" {
+        description
+            "Added missed references and descriptions.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision "2017-02-02" {
+        description
+            "Initial Version.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+/*
+ * typedefs
+ */
+
+/*
+ * features
+ */
+
+/*
+ * Configuration model.
+ */
+    container interface-qos-binding {
+        description
+            "This container contains configuration data for interface QOS binding.";
+        
+        list interface-qos-binding {
+            key "name";
+            description
+                "It denotes list of interface QOS binding configuration data.";
+            
+            leaf name {
+                type string;
+                description
+                    "This object indicates the identifier and is a 
+                     text string that is used to identify an interface-qos-binding. 
+                     Unique string values are chosen to uniquely identify
+                     interface-qos-binding.
+                     This object should only be used for interfaces where it is not possible
+                     to import ciena-mef-egress-qos module (e.g. logical-port).";
+            }
+
+            leaf queue-group-instance {
+                type mef-egress-qos:queue-group-ref;
+                description
+                    "A reference to a Queue Group Instance specific to the Interface (e.g. logical-port).";
+            }
+
+            leaf logical-port {
+                type mef-logical-port:logical-port-ref;
+
+                description
+                    "Reference to the logical-port that the queue-group-instance is the default
+                    Queue Group Instance for the logical-port and all logical-interfaces (e.g. flow-points)
+                    which are not specifying a specific Queue Group Instance otherwise.";
+            }
+        }
+    }
+}
+

--- a/vendor/ciena/ciena-mef-egress-qos.yang
+++ b/vendor/ciena/ciena-mef-egress-qos.yang
@@ -1,0 +1,512 @@
+module ciena-mef-egress-qos {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-egress-qos";
+    prefix "mef-egress-qos";
+
+    import ciena-mef-logical-port {
+          prefix "mef-logical-port";
+    }
+
+    organization
+        "Ciena Corporation";
+
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines Ciena's configuration of
+         queues and schedulers for Egress QoS.";
+
+    revision "2017-10-23" {
+        description
+            "Added missed references and descriptions";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision "2016-02-09" {
+        description 
+            "Initial version";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    typedef cos-queue-map-ref {
+        type leafref {
+            path "/mef-egress-qos:egress-qos/mef-egress-qos:cos-queue-map/mef-egress-qos:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             configured CoS queue maps.";
+    }
+
+    typedef congestion-avoidance-profile-ref {
+        type leafref {
+            path "/mef-egress-qos:egress-qos/mef-egress-qos:congestion-avoidance-profile/mef-egress-qos:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             configured congestion avoidance profiles.";
+    }
+
+    typedef queue-group-profile-ref {
+        type leafref {
+            path "/mef-egress-qos:egress-qos/mef-egress-qos:queue-group-profile/mef-egress-qos:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             configured queue group profiles.";
+    }
+
+    typedef queue-group-indirection-ref {
+        type leafref {
+            path "/mef-egress-qos:egress-qos/mef-egress-qos:queue-group-indirection/mef-egress-qos:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             queue-groups indirectly (e.g. where the root port changes dynamically).";
+    }
+
+    typedef scheduler-profile-ref {
+        type leafref {
+            path "/mef-egress-qos:egress-qos/mef-egress-qos:scheduler-profile/mef-egress-qos:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             configured scheduler-profiles.";
+    }
+
+    typedef scheduler-ref {
+        type leafref {
+            path "/mef-egress-qos:egress-qos/mef-egress-qos:scheduler/mef-egress-qos:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             configured scheduler.";
+    }
+
+    typedef queue-group-ref {
+        type leafref {
+            path "/mef-egress-qos:egress-qos/mef-egress-qos:queue-group/mef-egress-qos:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             queue-group-instances directly (e.g. where the root port changes dynamically).";
+    }
+
+    grouping eqos-parameters-group {
+        description
+            "Egress QoS parameters used for queue group profiles and scheduler profiles.";
+
+        leaf cir {
+            type uint32;
+            description
+                "Committed information rate for aggregate shaping in kilobits per second.";
+        }
+
+        leaf cir-percent {
+             type uint32;
+             description
+                "Committed information rate for aggregate shaping on a percentage basis <0..100>.";
+        }
+
+        leaf cbs {
+            type uint32;
+            description
+                "Committed burst size in kilobytes.";
+        }
+
+        leaf eir {
+            type uint32;
+            description
+                "Maximum rate for aggregate shaping in kilobits per second.";
+        }
+
+        leaf eir-percent {
+            type uint32;
+            description
+                "Maximum rate for aggregate shaping on a percentage basis <0..100>.";
+        }
+
+        leaf ebs {
+            type uint32;
+            description
+                "Maximum burst size in kilobytes.";
+        }
+    }
+
+    container egress-qos {
+       description
+          "List of egress qos configurations.";
+
+        list cos-queue-map {
+            key "name";
+            description
+                "List of cos queue maps.";
+                
+            leaf name {
+                type string;
+                description
+                    "Name for the CoS queue map.";
+            } 
+
+            leaf cos-count {
+                type uint32;
+                description
+                     "Number of CoS values supported (e.g. 8 or 64)";
+            }
+
+            list map-entry {
+                key "cos";
+                description
+                   "List of cos map entries.";
+
+                leaf cos {
+                    type uint32 {
+                        range "0..63";
+                    }
+                    description
+                         "Internal CoS to use for mapping to a Queue, green-wred-curve and yellow-wred curve.";
+                }
+
+                leaf queue {
+                    type uint32;
+                    description
+                         "Queue mapped to by internal CoS";
+                }
+
+                leaf green-wred-curve {
+                    type uint32;
+                    description
+                         "WRED curve relative to a Queue to use for traffic whose internal color is Green.";
+                }
+
+                leaf yellow-wred-curve {
+                    type uint32;
+                    description
+                         "WRED curve relative to a Queue to use for traffic whose internal color is Yellow.";
+                }
+            }
+        }
+
+        list congestion-avoidance-profile {
+            key "name";
+            description
+               "List of congestion avoidance profiles.";
+                
+            leaf name {
+                type string;
+                description
+                    "Name for the profile.";
+            } 
+
+            leaf type {
+                type enumeration {
+                    enum wred {
+                       description
+                          "Weighted random early detection.";
+                    }
+                    enum red {
+                       description
+                          "Random early detection.";
+                    }
+                }
+                description
+                    "congestion avoidance technique.";
+            }
+        }
+
+        list queue-group-profile {
+            key "name";
+            description
+                "Defines the characteristics of an instance of a group of queues.";
+
+            leaf name {
+                type string;
+                description
+                    "Name for the profile.";
+            } 
+
+            leaf queue-count {
+                type uint32;
+                description
+                    "Number of queues in the associated queue-group instances.";
+            }
+
+            leaf cos-queue-map {
+                type cos-queue-map-ref;
+                description
+                    "cos-queue map to use for mapping CoS to a queue.";
+            }
+
+            list queue {
+                key "queue-number";
+                description
+                   "List of queues in the associated queue-group.";
+
+                leaf queue-number {
+                    type uint32;
+                    mandatory true;
+
+                    description
+                        "The queue-number for this queue. The priority and weight for this queue are determined via 
+                         the mapping of queue-number to tap-point number (typically 1:1) from the associated scheduler-profile
+                         of the parent scheduler-instance.";
+                }
+
+                leaf congestion-avoidance-profile {
+                    type congestion-avoidance-profile-ref;
+                    description
+                        "Optional congestion avoidance algorithm for this queue.";
+                }
+
+                uses eqos-parameters-group;
+
+            }
+        }
+
+        list scheduler-profile {
+            key "name";
+            description
+               "Scheduler profile associated with queue-group.";
+
+            leaf name {
+                type string;
+                description
+                    "Name for the profile.";
+            } 
+
+            leaf tap-point-count {
+                type uint32;
+                description
+                    "The number of tap-points in corresponding scheduler-instances that queues
+                     or child schedulers can uniquely use to attach to the scheduler.";
+            }
+
+            leaf scheduling-algorithm {
+                type enumeration {
+                    enum sp {
+                        description "Strict priority.";
+                    }
+                    enum rr {
+                        description "Round-robin.";
+                    }
+                    enum wrr {
+                        description "Weighted round-robin.";
+                    }
+                    enum wfq {
+                        description "Weighted fair queueing.";
+                    }
+                    enum wdrr {
+                        description "Weighted deficit round-robin.";
+                    }
+                }
+                description
+                    "The scheduling algorithm used to service the tap-points of
+                     the scheduler instances.";
+            }
+
+            uses eqos-parameters-group;
+
+            leaf cir-policy {
+                type enumeration {
+                    enum auto-adjust-disabled {
+                        description
+                        "cir-policy of auto-adjust-disabled determines that cir (not cir-percent) is used for the scheduler instance associated
+                            with this scheduler-profile and also the child queues/scheduler-instances use cir.";
+                    }
+                    enum cir-as-percent {
+                        description
+                        "cir-policy of cir-as-percent determines that cir in percentage values are used for the scheduler instance associated
+                            with this scheduler-profile and also the child queues/scheduler-instances use cir-percent.";
+                    }
+                    enum child-cir-as-percent {
+                        description
+                        "cir-policy of child-cir-as-percent determines that cir (not cir-percent) is used for the scheduler instance associated
+                            with this scheduler-profile, but cir in percentage values are used for the child queues/scheduler-instances.";
+                    }
+                    enum child-cir-sum {
+                        description
+                        "cir-policy of child-cir-sum determines that cir for the scheduler instance associated
+                            with this scheduler-profile is calculated based on the sum of cir of the child queues/scheduler-instances.";
+                    }
+                }
+                description
+                   "cir-policy is used for the scheduler instance.";
+            }
+
+            leaf eir-policy {
+                type enumeration {
+                    enum auto-adjust-disabled {
+                        description
+                        "eir-policy of auto-adjust-disabled determines that eir (not eir-percent) is used for the scheduler instance associated
+                            with this scheduler-profile and also the child queues/scheduler-instances use eir.";
+                    }
+                    enum eir-as-percent {
+                        description
+                        "eir-policy of eir-as-percent determines that eir in percentage values are used for the scheduler instance associated
+                            with this scheduler-profile and also the child queues/scheduler-instances use eir-percent.";
+                    }
+                    enum child-eir-as-percent {
+                        description
+                        "eir-policy of child-eir-as-percent determines that eir (not eir-percent) is used for the scheduler instance associated
+                            with this scheduler-profile, but eir in percentage values are used for the child queues/scheduler-instances.";
+                    }
+                }
+                description
+                   "eir-policy is used for the scheduler instance.";
+            }
+
+            list tap-point {
+                key "number";
+                description
+                    "Defines priority and weight for each tap-point of the associated scheduler instances.
+                     Either Queues or Schedulers map to the tap points and their priority and weight is obtained
+                     from this tap-point configuration.";
+
+                leaf number {
+                    type uint32;
+                    description
+                    "tap-point identifier within a scheduler-instance";
+                }
+
+                leaf priority {
+                    type uint32;
+                    description
+                    "Priority of this tap-point relative to other tap-points in a scheduler-instance. Used when scheduling algorithm is strict-priority.";
+                }
+
+                leaf weight {
+                    type uint32;
+                    description
+                    "Weight of this tap-point relative to other tap-points in a scheduler-instance. Used when scheduling algorithm is 
+                    weighted-round-robin, weighted-fair-queuing, weighted-deficit-round-robin.";
+                }
+            }
+        }
+
+        list queue-group {
+            key "name";
+            description
+                "The queue-group is an instance of a group of queues as described by the associated queue-group-profile. The queue-group
+                 instance has a parent scheduler instance which is part of a scheduling hierarchy rooted to a port.
+                 Additionally, the queue-group instance may be mapped to both directly (e.g. from flow-points) and indirectly via the
+                 queue-group-indirection (e.g. via MPLS PWs/MPLS Tunnels).";
+
+            leaf name {
+                type string;
+                description
+                    "Name for the queue group instance.";
+            }
+
+            leaf queue-group-profile {
+                type queue-group-profile-ref;
+                mandatory true;
+                description
+                    "The queue-group-profile describing the attributes of this queue-group instance.";
+            }
+
+            leaf instance-id
+            {
+                type uint32;
+                description
+                    "Identifier for the scheduler-instance.";
+            }
+
+            leaf queue-group-indirection {
+                type queue-group-indirection-ref;
+                description
+                    "The queue-group-indirection that this queue-group instance is assigned to. Multiple different queue-groups
+                     on different ports can be assigned to the same queue-group-indirection.";
+            }
+
+            leaf parent-scheduler {
+                type scheduler-ref;
+                mandatory true;
+                description
+                    "The parent-scheduler instance for this queue group.";
+            }
+        }
+
+        list scheduler {
+            key "name";
+            description
+                "The scheduler is an instance of a scheduler as described by the associated scheduler-profile. The scheduler
+                 instance itself has either a parent scheduler instance which is part of a scheduling hierarchy rooted to a port or
+                 the root port itself.";
+
+            leaf name {
+                type string;
+                description
+                    "Name for the scheduler instance.";
+            }
+
+            leaf scheduler-profile {
+                type scheduler-profile-ref;
+                mandatory true;
+                description
+                    "The scheduler-profile describing the attributes of this scheduler instance.";
+            }
+
+            leaf instance-id
+            {
+                type uint32;
+                description
+                    "Identifier for the scheduler-instance.";
+            }
+
+            leaf parent-scheduler {
+                type scheduler-ref;
+                description
+                    "Optional reference to parent-scheduler instance if this scheduler instance is not the root scheduler instance
+                     in the egress QoS hierarchy of a port.";
+            }
+
+            leaf parent-tap-point {
+                type uint32;
+                description
+                    "The tap point that this scheduler instance in a parent scheduler-instance. Determines the priority and weight
+                     for this scheduler instance relative to its parent from the scheduler-profile.";
+            }
+
+            leaf parent-port {
+                type mef-logical-port:logical-port-ref;
+                description
+                    "Optional reference to a logical-port if this scheduler instance is the root scheduler instance
+                     in the egress QoS hierarchy of a port.";
+            }
+        }
+
+        list queue-group-indirection {
+            key "name";
+            description
+                "This is an indirected identification of a queue group that would be used by entities
+                 which do not resolve directly to the root of the egress-qos hierarchy (a port).
+                 An example of this is an MPLS PW which maps to a queue-group-indirection for service-based queuing and scheduling.
+                 Dependent on the state of the underlying transport (e.g. MPLS Tunnels to next-hops to port), the actual queue-group instance
+                 being used may change dynamically, however the queue-group-indirection allows.";
+
+            leaf name {
+                type string;
+                description
+                    "Name for the queue group indirection.";
+            }
+
+            leaf indirection-id
+            {
+                type uint32;
+                description
+                    "Identifier for the queue group indirection.";
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-mef-fd.yang
+++ b/vendor/ciena/ciena-mef-fd.yang
@@ -1,0 +1,440 @@
+module ciena-mef-fd {
+   namespace "urn:ciena:params:xml:ns:yang:ciena-pn:ciena-mef-fd";
+   prefix "mef-fd";
+
+   import ciena-mef-l2cp-profile {
+      prefix "mef-l2cp";
+   }
+
+   import ciena-mef-flood-containment-profile {
+      prefix "mef-fc";
+   }
+
+   import ciena-mef-pfg-profile {
+      prefix "mef-pfg";
+   }
+
+   import ciena-mef-egress-qos {
+      prefix "mef-egress-qos";
+   }
+
+   import ciena-mef-cos-to-frame-map {
+      prefix "ctf";
+   }
+
+   import ciena-mef-frame-to-cos-map {
+      prefix "ftc";
+   }
+
+   organization
+      "Ciena Corporation";
+
+   contact
+      "Web URL: http://www.ciena.com/
+       E-mail:  yang@ciena.com
+       Postal:  7035 Ridge Road
+                Hanover, Maryland 21076
+                U.S.A.
+       Phone:   +1 800-921-1144
+       Fax:     +1 410-694-5750";
+
+   description
+      "This YANG module defines Ciena's configuration of
+       the Forwarding Domain (Bridge Domain, Virtual Switch,
+       VPLS representation for the NETCONF protocol).";
+    
+   revision "2017-08-31" {
+      description
+         "Added reference to Private Forwarding Group Profile for a FD.
+          Added description for lists, enums, containers and leafs.";
+      reference
+         "RFC 6020: YANG - A Data Modeling Language for
+          the Network Configuration Protocol (NETCONF).
+          No specific reference; standard not available.";
+    }
+    
+   revision "2016-09-25" {
+       description 
+          "Added fd-state for operational data";
+       reference
+          "RFC 6020: YANG - A Data Modeling Language for
+           the Network Configuration Protocol (NETCONF).
+           No specific reference; standard not available.";
+    }
+    
+   revision "2016-01-25" {
+       description 
+          "Initial version";
+       reference
+          "RFC 6020: YANG - A Data Modeling Language for
+           the Network Configuration Protocol (NETCONF).
+           No specific reference; standard not available.";
+   }
+
+   /*
+    * Typedefs
+    */
+
+   typedef vlan-id {
+      type uint16 {
+         range "1..4094";
+      }
+      description
+         "Represents a IEEE 802.1Q VLAN-ID.";
+   }
+
+   /*
+    * Features
+    */
+
+   /*
+    * Groupings
+    */
+
+   grouping l2-transform {
+      choice frame-type {
+         case stack {
+            list vlan-stack {
+               key "tag";
+
+               leaf tag {
+                  type uint8;
+                     description
+                        "Dependent on the transform operation, the tag numbers are
+                         push => '1' represents push outermost, '2' represents push outermost (always push to outer)";
+               }
+
+               choice action {
+                  case push {
+                     leaf push-tpid {
+                        type enumeration {
+                           enum tpid-8100 {
+                              value 33024;
+                              description
+                                 "Indicates TPID value 0x8100 to be pushed.";
+                           }
+                           enum  tpid-88a8 {
+                              value 34984;
+                              description
+                                 "Indicates TPID value 0x88A8 to be pushed.";
+                           }
+                           enum tpid-9100 {
+                              value 37120;
+                              description
+                                 "Indicates TPID value 0x9100 to be pushed.";
+                           }
+                        }
+                        default tpid-8100;
+                        description
+                           "This represents TPID value to be pushed.";
+                     }
+
+                     leaf push-pcp {
+                        type enumeration {
+                           enum pcp-0 {
+                              value 0;
+                              description
+                                 "Indicates PCP value 0 to be pushed.";
+                           }
+                           enum pcp-1 {
+                              value 1;
+                              description
+                                 "Indicates PCP value 1 to be pushed.";
+                           }
+                           enum pcp-2 {
+                              value 2;
+                              description
+                                 "Indicates PCP value 2 to be pushed.";
+                           }
+                           enum pcp-3 {
+                              value 3;
+                              description
+                                 "Indicates PCP value 3 to be pushed.";
+                           }
+                           enum pcp-4 {
+                              value 4;
+                              description
+                                 "Indicates PCP value 4 to be pushed.";
+                           }
+                           enum pcp-5 {
+                              value 5;
+                              description
+                                 "Indicates PCP value 5 to be pushed.";
+                           }
+                           enum pcp-6 {
+                              value 6;
+                              description
+                                 "Indicates PCP value 6 to be pushed.";
+                           }
+                           enum pcp-7 {
+                              value 7;
+                              description
+                                 "Indicates PCP value 7 to be pushed.";
+                           }
+                           enum map {
+                              description
+                                 "Indicates PCP value from map to be pushed.";
+                           }
+                        }
+                        description
+                           "This represents PCP value to be pushed.";
+                     }
+
+                     leaf push-dei {
+                        type enumeration {
+                           enum enabled {
+                              description
+                                 "The frame's VLAN tag DEI bit will be pushed as 1.";
+                           }
+                           enum disabled {
+                              description
+                                 "The frame's VLAN tag DEI bit will be pushed as 0.";
+                           }
+                        }
+                        description
+                           "This represents DEI value to be pushed.";
+                     }
+
+                     leaf push-vid {
+                        type vlan-id;
+                        mandatory true;
+                        description
+                           "This represents VLAN ID to be pushed.";
+                     }
+                  }
+
+                  description
+                      "This represents the L2 transform actions which will be applied on flow points
+                       of this forwarding domain.";
+               }
+
+               description
+                   "This represents list of vlan stack.";
+            }
+         }
+
+         description
+             "This choice represents frame-type options.";
+      }
+
+      description
+          "This grouping defines the L2 ingress or egress transform instances.";
+   }
+
+   /*
+    * Configuration data nodes
+    */
+   container fds {
+
+      list fd {
+         key "name";
+
+         description
+            "The list of configured forwarding domains on the device.";
+
+         leaf name {
+            type string;
+
+            description
+               "An administratively assigned string, which may be used
+                to identify the forwarding domain.";
+         }
+
+         leaf description {
+            type string;
+               description
+                  "This is string used to describe the Forwarding Domain.";
+         }
+
+         leaf mode {
+            type enumeration {
+               enum vlan {
+                  description
+                     "Forwarding domain is of type vlan.";
+               }
+               enum vpls {
+                  description
+                     "Forwarding domain is of type vpls.";
+               }
+               enum vpws {
+                  description
+                     "Forwarding domain is of type vpws.";
+               }
+            }
+
+            description
+               "The configuration mode of the forwarding domain.";
+         }
+
+         leaf vlan-id {
+            when "../mode='vlan'";
+            type uint16 {
+               range "1..4094";
+            }
+            mandatory true;
+
+            description
+               "The value of VLAN ID for the forwarding domain when mode is VLAN.";
+         }
+
+         leaf mac-learning {
+            type enumeration {
+               enum enabled {
+                  description
+                     "This indicates MAC Learning is enabled.";
+               }
+               enum disabled {
+                  description
+                     "This indicates MAC Learning is disabled.";
+               }
+            }
+
+            description
+               "MAC learning configuration for forwarding domain.";
+         }
+
+         leaf l2cp-profile {
+            type mef-l2cp:l2cp-profile-ref;
+            description
+               "Reference to a Layer 2 Control Protocol Tunneling Profile.";
+         }         
+
+         leaf flood-containment-profile {
+            type mef-fc:flood-containment-profile-ref;
+            description
+               "Reference to a Flood Containment Profile definition.";
+         }
+
+         leaf pfg-profile {
+            type mef-pfg:pfg-profile-ref;
+            description
+               "Reference to a Private Forwarding Group Profile.";
+         }
+
+         leaf cos-queue-map {
+            type mef-egress-qos:cos-queue-map-ref;
+               description
+                  "Reference to queue-map for hierarchical shaping/scheduling.";
+         }
+
+         leaf queue-group-indirection {
+            type mef-egress-qos:queue-group-indirection-ref;
+               description
+                  "Reference to queue-group-indirection for hierarchical shaping/scheduling.";
+         }
+
+         container initiate-l2-transform {
+            uses l2-transform;
+               description
+                  "For an L2-frame that is initiated/injected via this forwarding domain, this specifies the l2-transform
+                   to be applied to the frame. e.g. an L3-frame injected via this forwarding domain to L2 datapath.";
+         }
+
+         leaf initiate-cos-to-frame-map {
+            type ctf:cos-to-frame-ref;
+               description
+                  "For an L2-frame that is initiated/injected via this forwarding domain, this specifies the cos-to-frame map to
+                   use for a cos-to-frame map policy of 'mapped' from the initiate-l2-transform config.";
+         }
+
+         choice initiate-frame-to-cos {
+            case map {
+               leaf initiate-frame-to-cos-map-policy {
+                  type enumeration {
+                     enum outer-tag {
+                        description
+                           "If the policy is set to outer-tag then outer VLAN tag PCP/CFI value is 
+                            mapped to the port resolved CoS mapping table to derive the R-CoS and R-Color.";
+                     }
+                     enum inner-tag {
+                        description
+                           "If the policy is set to inner-tag then inner VLAN tag PCP/CFI value is 
+                            mapped to the port resolved CoS mapping table to derive the R-CoS and R-Color.";
+                     }
+                     enum mpls-tc {
+                        description
+                           "If the policy is set to mpls-tc then EXP bits in MPLS label is mapped to the port 
+                            resolved CoS mapping table to derive the R-CoS and R-Color.";
+                     }
+                     enum dscp {
+                        description
+                           "If the policy is set to dscp then dscp value in IP header is mapped to the port 
+                            resolved CoS mapping table to derive the R-CoS and R-Color.";
+                     }
+                  }
+                  description
+                     "For an L2-frame that is initiated/injected via this forwarding domain, this specifies the frame-to-cos-map sub-policy to
+                      use when when the policy is mapped.";
+               }
+
+               leaf initiate-frame-to-cos-map {
+                  type ftc:frame-to-cos-ref;
+                  description
+                     "For an L2-frame that is initiated/injected via this forwarding domain, this specifies the frame-to-cos map to
+                      use for an initiate frame-to-cos map policy of 'mapped'.";
+               }
+            }
+                
+            case fixed {
+               leaf cos {
+                  type uint8 {
+                     range "0..63";
+                  }
+                  description
+                     "For an L2-frame that is initiated/injected via this forwarding domain, this specifies the fixed cos value to
+                      use when when the policy is fixed.";
+               }
+                    
+               leaf color {
+                  type enumeration {
+                     enum green {
+                        description
+                           "Indicates fixed color Green.";
+                     }
+                     enum yellow {
+                        description
+                           "Indicates fixed color Yellow.";
+                     }
+                     enum red {
+                        description
+                           "Indicates fixed color Red.";
+                     }
+                  }
+                  description
+                     "For an L2-frame that is initiated/injected via this forwarding domain, this specifies the fixed color value to
+                      use when when the policy is fixed.";
+               }           
+            }
+
+            description
+               "Indicates the policy used for an L2-frame that is initiated/injected via this forwarding domain.";
+         }
+      }
+
+      description
+         "Contains list of FDs present currently in the system.";
+   }
+   
+   container fds-state {
+      config false;
+
+      description 
+         "Global FD operational data.";
+
+      list fd {
+
+         key "name";
+
+         description
+            "The operational data for this FD.";
+
+         leaf name {
+            type string;
+                
+            description
+               "A string that identifies the forwarding domain.";
+         }
+      }
+   }
+}
+

--- a/vendor/ciena/ciena-mef-flood-containment-profile.yang
+++ b/vendor/ciena/ciena-mef-flood-containment-profile.yang
@@ -1,0 +1,113 @@
+module ciena-mef-flood-containment-profile {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn:ciena-mef-flood-containment-profile";
+    prefix "mef-fc";
+
+    organization
+        "Ciena Corporation";
+
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines Ciena's configuration of
+         the Flood Containment Profile.";
+
+    revision 2017-10-26 {
+        description
+            "Added description in containers, lists, leafs.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision 2016-01-13 {
+        description "Initial revision";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    typedef flood-containment-profile-ref {
+        type leafref {
+            path "/mef-fc:flood-containment-profiles/mef-fc:flood-containment-profile/mef-fc:name";
+        }
+        description
+            "This type is used by the data models that need to reference
+             configured Flood Containment Profiles.";
+    }
+
+    container flood-containment-profiles {
+        description
+            "Configuration data for Flood Containment Profiles.";
+
+        list flood-containment-profile {
+            key "name";
+
+            description
+                "This denotes list of Flood Containment Profiles.";
+
+            leaf name {
+                type string {
+                    length "1..1024";
+                }
+                description
+                    "An administratively assigned string, which may be used
+                     to identify the profile.";
+            }
+
+            leaf description {
+                type string;
+                description
+                    "This is a user-defined string used to describe the profile.";
+            }
+
+            list containment {
+                key "frame-type";
+
+                description
+                    "This denotes list of permissible rate for frame types.";
+
+                leaf frame-type {
+                    type bits {
+                        bit unknown-unicast {
+                            description
+                                "Indicates it's a unknown unicast frame.";
+                        }
+                        bit unknown-l2-multicast {
+                            description
+                                "Indicates it's a unknown L2 multicast frame.";
+                        }
+                        bit unknown-ip-multicast {
+                            description
+                                "Indicates it's a unknown IP multicast frame.";
+                        }
+                        bit known-multicast {
+                            description
+                                "Indicates it's a known multicast frame.";
+                        }
+                        bit broadcast {
+                            description
+                                "Indicates it's a broadcast frame.";
+                        }
+                    }
+                    description
+                        "The frame types to be contained with the given rate.";
+                }
+
+                leaf rate {
+                    type uint64;
+                    description
+                        "Data rate in kbps.";
+                }
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-mef-fp.yang
+++ b/vendor/ciena/ciena-mef-fp.yang
@@ -1,0 +1,891 @@
+module ciena-mef-fp {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn:ciena-mef-fp";
+    prefix "mef-fp";
+
+    import ciena-mef-fd {
+        prefix "mef-fd";
+    }
+
+    import ciena-mef-logical-port {
+        prefix "mef-logical-port";
+    }
+
+    import ciena-mef-classifier {
+        prefix "classifier";
+    }
+
+    import ciena-mef-cos-to-frame-map {
+        prefix "ctf";
+    }
+
+    import ciena-mef-frame-to-cos-map {
+        prefix "ftc";
+    }
+
+    import ciena-mef-flood-containment-profile {
+        prefix "mef-fc";
+    }
+
+    import ciena-mef-meter-profile {
+        prefix "meter";
+    }
+
+    import ciena-mef-egress-qos {
+        prefix "mef-egress-qos";
+    }
+
+    organization
+        "Ciena Corporation";
+
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines Ciena's management data definition for the
+         management of fp.";
+
+    revision 2017-10-25 {
+        description
+            "Added missing reference and description for container, grouping,
+             enums, leafs and list.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision "2016-01-28" {
+        description
+            "Initial Version.";
+        reference
+            "UNI and EVC Definition of Managed Objects (MEF 40), January 2013.";
+    }
+
+    /*
+     * typedefs
+     */
+
+    typedef fp-ref {
+        type leafref {
+            path "/mef-fp:fps/mef-fp:fp/mef-fp:name";
+        }
+        description
+            "This type is used by the data models that need to reference
+             configured flow points.";
+    }
+
+    typedef vlan-id {
+        type uint16 {
+            range "1..4094";
+        }
+        description
+            "Represents a IEEE 802.1Q VLAN-ID.";
+    }
+
+    /*
+     * features
+     */
+
+    /*
+     * groupings
+     */
+    grouping transform {
+        description
+            "This grouping defines L2 ingress or egress transform instances.";
+
+        choice frame-type {
+            description
+                "This choice represents frame-type options.";
+            case stack {
+                list vlan-stack {
+                    key "tag";
+
+                    description
+                        "This represents list of VLAN stack.";
+                    leaf tag {
+                        type uint8;
+                        description
+                            "Dependent on the xform operation, the tag numbers are
+                             stamp => '1' represents outermost tag, '2' next outermost (next inner)
+                             pop => '1' represents pop outermost, '2' represents pop outermost, (always pop from outer)
+                             push => '1' represents push outermost, '2' represents push outermost (always push to outer).";
+                    }
+
+                    choice action {
+                        description 
+                            "This choice represents actions to be performed on
+                             xform operations.";
+                        case push {
+                            leaf push-tpid {
+                                type enumeration {
+                                    enum tpid-8100 {
+                                        value 33024;
+                                        description
+                                            "TPID value 8100 to be pushed.";
+                                    }
+                                    enum  tpid-88a8 {
+                                        value 34984;
+                                        description
+                                            "TPID value 88A8 to be pushed.";
+                                    }
+                                    enum tpid-9100 {
+                                        value 37120;
+                                        description
+                                            "TPID value 9100 to be pushed.";
+                                    }
+                                }
+                                mandatory true;
+                                description
+                                    "This represents TPID value to be pushed.";
+                            }
+
+                            leaf push-pcp {
+                                type enumeration {
+                                    enum pcp-0 {
+                                        value 0;
+                                        description
+                                            "PCP value 0 to be pushed.";
+                                    }
+                                    enum pcp-1 {
+                                        value 1;
+                                        description
+                                            "PCP value 1 to be pushed.";
+                                    }
+                                    enum pcp-2 {
+                                        value 2;
+                                        description
+                                            "PCP value 2 to be pushed.";
+                                    }
+                                    enum pcp-3 {
+                                        value 3;
+                                        description
+                                            "PCP value 3 to be pushed.";
+                                    }
+                                    enum pcp-4 {
+                                        value 4;
+                                        description
+                                            "PCP value 4 to be pushed.";
+                                    }
+                                    enum pcp-5 {
+                                        value 5;
+                                        description
+                                            "PCP value 5 to be pushed.";
+                                    }
+                                    enum pcp-6 {
+                                        value 6;
+                                        description
+                                            "PCP value 6 to be pushed.";
+                                    }
+                                    enum pcp-7 {
+                                        value 7;
+                                        description
+                                            "PCP value 7 to be pushed.";
+                                    }
+                                    enum map {
+                                        description
+                                            "PCP value map to be pushed.";
+                                    }
+                                }
+                                description
+                                    "This represents PCP value to be pushed.";
+                            }
+
+                            leaf push-dei {
+                                type enumeration {
+                                    enum enabled {
+                                        description
+                                            "DEI enabled.";
+                                    }
+                                    enum disabled {
+                                        description
+                                            "DEI disabled.";
+                                    }
+                                }
+                                description
+                                    "This represents DEI value to be pushed";
+                            }
+
+                            leaf push-vid {
+                                type vlan-id;
+                                mandatory true;
+                                description
+                                    "This represents VLAN ID to be pushed.";
+                            }
+                        }
+
+                        case pop {
+                            leaf pop-type {
+                                type empty;
+                                description
+                                    "This represents pop action type.";
+                            }
+                        }
+
+                        case stamp {
+                            leaf stamp-tpid {
+                                type enumeration {
+                                    enum no-op {
+                                        description
+                                            "No operation.";
+                                    }
+                                    enum tpid-8100 {
+                                        value 33024;
+                                        description
+                                            "TPID value 8100 will be stamped.";
+                                    }
+                                    enum  tpid-88a8 {
+                                        value 34984;
+                                        description
+                                            "TPID value 88A8 will be stamped.";
+                                    }
+                                    enum tpid-9100 {
+                                        value 37120;
+                                        description
+                                            "TPID value 9100 will be stamped.";
+                                    }
+                                }
+                                description
+                                    "This represents stamping TPID value.";
+                            }
+
+                            leaf stamp-pcp {
+                                type enumeration {
+                                    enum pcp-0 {
+                                        value 0;
+                                        description
+                                            "PCP value 0 will be stamped.";
+                                    }
+                                    enum pcp-1 {
+                                        value 1;
+                                        description
+                                            "PCP value 1 will be stamped.";
+                                    }
+                                    enum pcp-2 {
+                                        value 2;
+                                        description
+                                            "PCP value 2 will be stamped.";
+                                    }
+                                    enum pcp-3 {
+                                        value 3;
+                                        description
+                                            "PCP value 3 will be stamped.";
+                                    }
+                                    enum pcp-4 {
+                                        value 4;
+                                        description
+                                            "PCP value 4 will be stamped.";
+                                    }
+                                    enum pcp-5 {
+                                        value 5;
+                                        description
+                                            "PCP value 5 will be stamped.";
+                                    }
+                                    enum pcp-6 {
+                                        value 6;
+                                        description
+                                            "PCP value 6 will be stamped.";
+                                    }
+                                    enum pcp-7 {
+                                        value 7;
+                                        description
+                                            "PCP value 7 will be stamped.";
+                                    }
+                                    enum no-op {
+                                        description
+                                            "No operation.";
+                                    }
+                                    enum map {
+                                        description
+                                            "Mapped PCP value will be stamped.";
+                                    }
+                                }
+                                description
+                                    "This represents stamping PCP value.";
+                            }
+
+                            leaf stamp-dei {
+                                type enumeration {
+                                    enum no-op {
+                                        description
+                                            "No operation.";
+                                    }
+                                    enum enabled {
+                                        description
+                                            "DEI value enabled.";
+                                    }
+                                    enum disabled {
+                                        description
+                                            "DEI value disabled.";
+                                    }
+                                }    
+                                description
+                                    "This represents stamping DEI value.";
+                            }
+
+                            choice stamp-vid {
+                                description
+                                    "This choice represents stamp-vid options.";
+                                case no-op {
+                                    leaf no-op {
+                                        type empty;
+                                        description
+                                            "No operation.";
+                                    }
+                                }
+                                case vid-value {
+                                    leaf stamp-vid-value {
+                                        type vlan-id;
+                                        description
+                                            "This represents VLAN ID value to be stamped."; 
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            case untagged {
+
+                leaf untagged-tpid {
+                    type enumeration {
+                        enum tpid-8100 {
+                            value 33024;
+                            description
+                                "TPID value 8100.";
+                        }
+                        enum  tpid-88a8 {
+                            value 34984;
+                            description
+                                "TPID value 88A8.";
+                        }
+                        enum tpid-9100 {
+                            value 37120;
+                            description
+                                "TPID value 9100.";
+                        }
+                    }
+                    description
+                        "This represents untagged TPID value.";
+                }
+
+                leaf untagged-pcp {
+                    type enumeration {
+                        enum pcp-0 {
+                            value 0;
+                            description
+                                "PCP value 0.";
+                        }
+                        enum pcp-1 {
+                            value 1;
+                            description
+                                "PCP value 1.";
+                        }
+                        enum pcp-2 {
+                            value 2;
+                            description
+                                "PCP value 2.";
+                        }
+                        enum pcp-3 {
+                            value 3;
+                            description
+                                "PCP value 3.";
+                        }
+                        enum pcp-4 {
+                            value 4;
+                            description
+                                "PCP value 4.";
+                        }
+                        enum pcp-5 {
+                            value 5;
+                            description
+                                "PCP value 5.";
+                        }
+                        enum pcp-6 {
+                            value 6;
+                            description
+                                "PCP value 6.";
+                        }
+                        enum pcp-7 {
+                            value 7;
+                            description
+                                "PCP value 7.";
+                        }
+                        enum map {
+                            description
+                                "PCP value map.";
+                        }
+                    }
+                    description
+                        "This represents untagged PCP value.";
+                }
+
+                leaf untagged-dei {
+                    type enumeration {
+                        enum enabled {
+                            description
+                                "DEI admin state enabled.";
+                        }
+                        enum disabled {
+                            description
+                                "DEI admin state disabled.";
+                        }
+                    }
+                    description
+                        "Administrative state of DEI.";
+                }
+
+                leaf untagged-vid {
+                    type vlan-id;
+                    description
+                        "This represents untagged VLAN ID.";
+                }
+            }
+        }
+    }
+
+
+    /*
+     * Configuration.
+     */
+    container fps {
+        description
+            "Contains list of FPs present currently in the system.";
+
+        list fp {
+            key "name";
+            description
+                "A list of all mef-fp configuration entries.";
+
+            leaf name {
+                type string;
+                description
+                    "This object indicates the flow point identifier. 
+                     The identifier is a text string that is used to identify 
+                     a flow point. 
+                     Unique string values are chosen to uniquely identify the 
+                     flow point.
+                     Octet values of 0x00 through 0x1f are illegal.
+                     MEF 26.1 restricts the maximum size identifiers to 45 
+                     octets.";
+                reference
+                    "[MEF 6.1] 6.1; [MEF 7.2] 6.2.1.3.";
+            }
+
+            leaf description {
+                type string;
+                description
+                    "A editable string used to describe this entry.";
+            }
+
+            leaf fd-name {
+                type leafref {
+                    path "/mef-fd:fds/mef-fd:fd/mef-fd:name";
+                }
+                description
+                    "Reference to FD object that represents the VLAN/VS of which
+                     this FP is a member of.";
+            }
+
+            leaf logical-port {
+                type mef-logical-port:logical-port-ref;
+                description
+                    "Reference to logical-port object that represents the port
+                     this VLAN/VS member is being added to.";
+            }
+
+            choice type {
+                description
+                    "This choice represents type of FP (i.e- Q-in-Q or MPLS-PW
+                     or UNI or other).";
+                case q-in-q {
+                    leaf svlan {
+                        type uint32;
+                        description
+                            "FP of type Q-in-Q.";
+                    }
+                }
+                case mpls-pw {
+                    leaf mpls-pw {
+                        type empty;
+                        description
+                            "FP of type MPLS-PW.";
+                    }
+                }
+                case uni {
+                    leaf uni {
+                        type empty;
+                        description
+                            "FP of type UNI.";
+                    }
+                }
+                case other {
+                    leaf other {
+                        type empty;
+                        description
+                            "FP of type other.";
+                    }
+                }
+            }
+
+            leaf mtu-size {
+                type uint32;
+                units "octets";
+                default "2000";
+                description
+                    "This object indicates the configured EVC maximum service 
+                     frame format size. It must be less than or equal to the 
+                     max-mtu-size. Vendors may choose to go beyond this limit.";
+                reference
+                    "[MEF 6.1] 6.1; [MEF 7.2] 6.2.1.3";
+            }
+
+            leaf admin-state {
+                type enumeration {
+                    enum enabled {
+                        description
+                            "Admin state enabled.";
+                    }
+                    enum disabled {
+                        description
+                            "Admin state disabled.";
+                    }
+                }
+                description
+                    "This represents administrative state of FP.";
+            }
+
+            list ingress-l2-transform {
+                key "ingress-name";
+
+                description
+                    "Represents list of ingress L2 transforms associated with 
+                     VS/VLAN membership.";
+                leaf ingress-name {
+                    type string;
+                    description
+                        "Need a key for this list. It cannot be
+                         a choice of several objects but objects
+                         that will always be specified.";
+                }
+
+                uses transform;  
+            }
+
+            list egress-l2-transform {
+                key "egress-name";
+
+                description
+                    "Represents list of egress L2 transforms associated with 
+                     VS/VLAN membership.";
+                leaf egress-name {
+                    type string;
+                    description
+                        "Need a key for this list. It cannot be
+                         a choice of several objects but objects
+                         that will always be specified.";
+                }
+
+                uses transform;
+            }
+
+            choice ingress-l3-transform {
+                description
+                    "Ingress L3 transform can be either ingress-l3-mapped or 
+                     remark-dscp.";
+                case map {
+                    leaf ingress-l3-mapped {
+                        type empty;
+                        description
+                            "This represents ingress L3 map.";
+                    }
+                }
+                case remark-dscp {
+                    leaf ingress-remark-dscp-value {
+                        type uint8 {
+                            range "0..63";
+                        }
+                        description
+                            "This represents ingress DSCP remarking value.";
+                    }
+                }
+            }
+
+            choice egress-l3-transform {
+                description
+                    "Egress L3 transform can be either egress-l3-mapped or 
+                     remark-dscp.";
+                case map {
+                    leaf egress-l3-mapped {
+                        type empty;
+                        description
+                            "This represents egress L3 map.";
+                    }
+                }
+                case remark-dscp {
+                    leaf egress-remark-dscp-value {
+                        type uint8 {
+                            range "0..63";
+                        }
+                        description
+                            "This represents egress DSCP remarking value.";
+                    }
+                }
+            }
+
+            choice frame-to-cos {
+                description
+                    "This choice represents frame to CoS value can be either 
+                     mapped or fixed.";
+                case map {
+                    leaf map-policy {
+                        type enumeration {
+                            enum outer-tag {
+                                description
+                                    "Map policy value outer-tag.";
+                            }
+                            enum inner-tag {
+                                description
+                                    "Map policy value inner-tag.";
+                            }
+                            enum mpls-tc {
+                                description
+                                    "Map policy value mpls-tc.";
+                            }
+                            enum dscp {
+                                description
+                                    "Map policy value DSCP.";
+                            }
+                        }
+                        description
+                            "This represents map policy.";
+                    }
+
+                    leaf frame-to-cos-map {
+                        type ftc:frame-to-cos-ref;
+                        description
+                            "Reference to a frame to CoS mapping.";
+                    }    
+                }
+
+                case fixed {
+                    leaf cos {
+                        type uint8 {
+                            range "0..63";
+                        }
+                        description
+                            "This represents fixed CoS value.";
+                    }
+
+                    leaf color {
+                        type enumeration {
+                            enum green {
+                                description
+                                    "Fixed color green.";
+                            }
+                            enum yellow {
+                                description
+                                    "Fixed color yellow.";
+                            }
+                            enum red {
+                                description
+                                    "Fixed color red.";
+                            }
+                        }
+                        description
+                            "This represents fixed color value.";
+                    }           
+                }
+            }
+
+            leaf cos-to-frame-map {
+                type ctf:cos-to-frame-ref;
+                description
+                    "Reference to a CoS to frame mapping.";
+            }
+
+            leaf flood-containment-profile {
+                type mef-fc:flood-containment-profile-ref;
+                description
+                    "Reference to a Flood Containment Profile definition.";
+            }
+
+            leaf-list classifier-list {
+                type classifier:classifier-ref;
+                description
+                    "This represents a list of references to Netconf classifier objects.";
+            }
+
+            leaf classifier-list-precedence {
+                type uint32;
+                description
+                    "This represents a list of classifier precedence.";
+            }
+
+            leaf mac-learning {
+                type enumeration {
+                    enum enabled {
+                        description
+                            "Enables MAC learning.";
+                    }
+                    enum disabled {
+                        description
+                            "Disables MAC learning.";
+                    }
+                }
+                description
+                    "This represents MAC learning status.";
+            }
+
+            leaf meter-profile {
+                type meter:meter-ref;
+                description
+                    "A reference to a Meter Profile.";
+            }
+
+            leaf pfg-group {
+                type enumeration {
+                    enum leaf {
+                        description
+                            "Represents PFG group leaf.";
+                    }
+                    enum root {
+                        description
+                            "Represents PFG group root.";
+                    }
+
+                    enum mesh {
+                        description
+                            "Represents PFG group mesh.";
+                    }
+                    enum spoke {
+                        description
+                            "Represents PFG group spoke.";
+                    }
+
+                    enum group-A {
+                        description
+                            "Represents PFG group group-A.";
+                    }
+                    enum group-B {
+                        description
+                            "Represents PFG group group-B.";
+                    }
+                    enum group-C {
+                        description
+                            "Represents PFG group group-C.";
+                    }
+                    enum group-D {
+                        description
+                            "Represents PFG group group-D.";
+                    }
+                }
+                description
+                    "The Private-Forwarding-Group that the flow-point belongs to for the scope of a
+                     Private-Forwarding-Group-Profile.
+                     Can be leaf/root for a PFG-profile with PFG-type of leaf-and-root or 
+                     spokemesh-and-leafroot.
+                     Can be mesh/spoke for a PFG-profile with PFG-type of spoke-and-mesh or 
+                     spokemesh-and-leafroot.
+                     Can be groupA/B/C/D for a PFG-profile with PFG-type of pfg-groups.";
+            }
+
+            leaf queue-group-instance {
+                type mef-egress-qos:queue-group-ref;
+                description
+                    "A reference to a Queue Group Instance.";
+            }
+
+            leaf stats-collection {
+                type enumeration {
+                    enum on {
+                        description
+                            "Stats collection on.";
+                    }
+                    enum off {
+                        description
+                            "Stats collection off.";
+                    }
+                }
+                description
+                    "Determines whether stats collection will be turned on or not for a flow-point.";
+            }
+        }
+    }
+
+    /*
+     * State.
+     */
+    container fps-state {
+        config false;
+
+        description 
+            "Flow Point operational data for all Flow-Points.";
+
+        list fp {
+            key "name";
+            description
+                "The operational data for this Flow Point.";
+
+            leaf name {
+                type string;
+                description
+                    "A string that identifies the flow point.";
+            }
+
+            leaf rxAcceptedBytes {
+                type uint64;
+                description
+                    "Ingress accepted byte count.";
+            }
+
+            leaf rxAcceptedFrames {
+                type uint64;
+                description
+                    "Ingress accepted frame count.";
+            }
+
+            leaf txForwardedBytes {
+                type uint64;
+                description
+                    "Egress forwarded byte count.";
+            }
+
+            leaf txForwardedFrames {
+                type uint64;
+                description
+                    "Egress forwarded frame count.";
+            }
+
+            leaf rxYellowBytes {
+                type uint64;
+                description
+                    "Ingress yellow byte count.";
+            }
+
+            leaf rxYellowFrames {
+                type uint64;
+                description
+                    "Ingress yellow frame count.";
+            }
+
+            leaf rxDroppedBytes {
+                type uint64;
+                description
+                    "Ingress dropped byte count.";
+            }
+
+            leaf rxDroppedFrames {
+                type uint64;
+                description
+                    "Ingress dropped frame count.";
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-mef-frame-to-cos-map.yang
+++ b/vendor/ciena/ciena-mef-frame-to-cos-map.yang
@@ -1,0 +1,177 @@
+module ciena-mef-frame-to-cos-map {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn:ciena-mef-frame-to-cos-map";
+    prefix "ftc";
+
+    organization
+        "Ciena Corporation";
+ 
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines the Frame to Cos Map.";
+    
+    revision 2017-10-23 {
+        description
+            "Added missing reference and description for container and list.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision 2015-07-16 {
+        description 
+            "Initial revision.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+    
+    /*
+     * Typedefs
+     */
+    typedef frame-to-cos-ref {
+        type leafref {
+            path "/ftc:frame-to-cos-maps/ftc:frame-to-cos-map/ftc:name";
+        }
+        description
+            "This type is used by data models that need to reference
+             configured frame to CoS maps.";
+    }
+    
+    container frame-to-cos-maps {
+        description
+            "Configuration Data for Frame to CoS profiles.";    
+
+        list frame-to-cos-map {
+            key "name";
+            
+            description
+                "A list of profiles that can contain several map entries.";
+
+            leaf name {
+                type string;             
+                description
+                    "A string used to uniquely identify a list of profiles.";
+            }
+            
+            leaf description {
+                type string;
+                description
+                    "A more detailed description of the map.";
+            }
+            
+            list map-entry {
+                key "name";
+                description
+                    "A list of map entries within a frame-to-cos map profile.";
+                
+                leaf name {
+                    type string;
+                    description
+                        "A string used to uniquely identify a particular map 
+                         entry within the profile.";
+                }
+                
+                choice frame-type {
+                    description
+                        "The frame type can be either vlan-tag or IP or MPLS type.";
+
+                    case vlan-tag {
+                        leaf pcp {
+                            type uint8 {
+                                range "0..7";
+                            }
+                            description
+                                "This represents VLAN tag priority bits of frame.";
+                        }
+
+                        leaf dei {
+                            type enumeration {
+                                enum enabled {
+                                    description
+                                        "Enables VLAN tag DEI bit.";
+                                }
+                                enum disabled {
+                                    description
+                                        "Disables VLAN tag DEI bit.";
+                                }
+                            }
+                            description
+                                "This represents VLAN tag DEI bits of frame.";
+                        }
+                        description
+                            "For layer 2 frames, the VLAN tag's priority bits and 
+                             DEI value are used as key fields to derive an assigned 
+                             COS and color for the frame.";
+                    }
+                    
+                    case ip {
+                        leaf ip-dscp {
+                            type uint8 {
+                                range "0..63";
+                            }
+                            description
+                                "This represents IP header DSCP value.";
+                        }
+                        description
+                            "For IP frames, DSCP bits are used to derive an assigned 
+                             CoS and color for the frame.";
+                    }
+                    
+                    case mpls {
+                        leaf mpls-tc {
+                            type uint8 {
+                                range "0..7";
+                            }
+                            description
+                                "This represents MPLS label EXP bits.";
+                        }
+                        description
+                            "For frames with MPLS label, EXP bits are used to derive an 
+                             assigned CoS and color for the frame.";
+                    }
+                }
+                
+                leaf cos {
+                    type uint8 {
+                        range "0..63";
+                    }
+                    description
+                        "Class of Service bits.";
+                }
+                
+                leaf color {
+                    type enumeration {
+                        enum green {
+                            description
+                                "This represents frame color green.";
+                        }
+                        enum yellow {
+                            description
+                                "This represents frame color yellow.";
+                        }
+                        enum red {
+                            description
+                                "This represents frame color red.";
+                        }
+                    }
+                    description
+                        "The assigned color for the frame. A color of green
+                         indicates the frame is conformant with CIR,
+                         a yellow indicates it is not conformant with CIR but
+                         is conformant with EIR and red means it is not 
+                         conformant with EIR or CIR and thus will be dropped.";
+                }     
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-mef-l2cp-profile.yang
+++ b/vendor/ciena/ciena-mef-l2cp-profile.yang
@@ -1,0 +1,197 @@
+module ciena-mef-l2cp-profile {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-l2cp-profile";
+    prefix "mef-l2cp";
+
+    organization
+        "Ciena Corporation";
+
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines Ciena's configuration of
+         the L2 Control Protocol Profile.";
+
+    revision 2017-10-26 {
+        description
+            "Added description in containers, lists, leafs.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision 2015-05-13 {
+        description "Initial revision";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    typedef l2cp-profile-ref {
+        type leafref {
+            path "/mef-l2cp:l2cp-profiles/mef-l2cp:l2cp-profile/mef-l2cp:name";
+        }
+        description
+            "This type is used by the data models that need to reference
+             configured L2 Control Protocol Profiles.";
+    }
+
+    typedef DispositionType {
+        type enumeration {
+            enum discard {
+                description
+                    "This indicates L2 Control Protocol PDUs are to be dropped.";
+            }
+            enum peer {
+                description
+                    "This indicates L2 Control Protocol PDUs are to be peered.";
+            }
+            enum forward {
+                description
+                    "This indicates L2 Control Protocol PDUs are to be forwarded.";
+            }
+        }
+        description
+            "This type is used to determine disposition of L2 Control Protocol PDUs.";
+    }
+
+    container l2cp-profiles {
+        description
+            "Configuration Data for L2 Control Protocol Profiles.";
+
+        list l2cp-profile {
+            key "name";
+
+            description
+                "This denotes the list of L2 Control Protocol Profiles.";
+
+            leaf name {
+                type string;
+                description
+                    "An administratively assigned string, which may be used
+                     to identify the profile.";
+            }
+
+            leaf description {
+                type string;
+                description
+                    "This is a user-defined string used to describe the profile.";
+            }
+
+            leaf untagged-cos-policy {
+                type enumeration {
+                    enum fixed {
+                        description 
+                            "This policy assigns fixed resolved and frame CoS to
+                             forwarded untagged L2 control frames.";
+                    }
+                    enum ignore {
+                        description
+                            "This policy doesn't assign explicit CoS to forwarded
+                             untagged L2 control frames. Instead it allows the control 
+                             frames to pick resolved and frame CoS in datapath just 
+                             like untagged data frames.";
+                    }
+                }
+                description
+                    "This denotes CoS policy for forwarded untagged L2 control frames.";
+            }
+
+            leaf fixed-cos {
+                type uint8 {
+                    range "0..63";
+                }
+                description
+                    "This denotes fixed resolved CoS and frame CoS for forwarded 
+                     untagged L2 control frames.";
+            }
+
+            list protocol-disposition {
+                key "protocol";
+
+                description
+                    "This denotes the list of disposition of L2 Control Protocols.";
+
+                leaf protocol {
+                    type enumeration {
+                        enum xstp {
+                            description "STP/RSTP/MSTP protocols.
+                                         MAC DA 01-80-C2-00-00-00.";
+                        }
+                        enum lacp {
+                            description "LACP protocol. Ethertype 0x8809/01.
+                                         MAC DA 01-80-C2-00-00-02.";
+                        }
+                        enum lamp {
+                            description "LAMP protocol. Ethertype 0x8809/02.
+                                         MAC DA 01-80-C2-00-00-02.";
+                        }
+                        enum link-oam {
+                            description "LINK OAM protocol. Ethertype 0x8809/03.
+                                         MAC DA 01-80-C2-00-00-02.";
+                        }
+                        enum port-auth {
+                            description "Port Authentication protocol. Ethertype 0x888E.
+                                         MAC DA 01-80-C2-00-00-03.";
+                        }
+                        enum e-lmi {
+                            description "E-LMI protocol. Ethertype 0x88EE.
+                                         MAC DA 01-80-C2-00-00-07.";
+                        }
+                        enum lldp {
+                            description "LLDP protocol. Ethertype 0x88CC.
+                                         MAC DA 01-80-C2-00-00-0E.";
+                        }
+                        enum ptp-peer-delay {
+                            description "PTP Peer-Delay protocol. Ethertype 0x88F7.
+                                         MAC DA 01-80-C2-00-00-0E.";
+                        }
+                        enum esmc {
+                            description "ESMC protocol. Ethertype 0x8809/0A.
+                                         MAC DA 01-80-C2-00-00-02.";
+                        }
+                        enum garp-block {
+                            description "GARP/MRP block range.
+                                         MAC DA 01-80-C2-00-00-20 to 01-80-C2-00-00-2F.";
+                        }
+                        enum bridge-rsvd-0b0f {
+                            description "Bridge reserved range.
+                                         MAC DA 01-80-C2-00-00-0B/0F.";
+                        }
+                        enum bridge-rsvd-0c0d {
+                            description "Bridge reserved range.
+                                         MAC DA 01-80-C2-00-00-0C/0D.";
+                        }
+                        enum bridge-block {
+                            description "Bridge block range.
+                                         MAC DA 01-80-C2-00-00-00 to 01-80-C2-00-00-0A and
+                                         01-80-C2-00-00-0E.";
+                        }
+                    }
+                    description
+                        "This denotes the L2 Control Protocol.";
+                }
+
+                leaf untagged-disposition {
+                    type DispositionType;
+                    description
+                        "Disposition assigned to untagged form of L2 control protocol PDUs.";
+                }
+
+                leaf tagged-disposition {
+                    type DispositionType;
+                    description
+                        "Disposition assigned to tagged form of L2 control protocol PDUs.";
+                }
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-mef-logical-port.yang
+++ b/vendor/ciena/ciena-mef-logical-port.yang
@@ -1,0 +1,348 @@
+module ciena-mef-logical-port {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-logical-port";
+    prefix "mef-logical-port";
+
+    import ietf-interfaces {
+        prefix "if";
+    }
+
+    import ietf-yang-types {
+        prefix "yt";
+    }
+
+    import ciena-mef-frame-to-cos-map {
+        prefix "ftc";
+    }
+
+    import ciena-mef-cos-to-frame-map {
+        prefix "ctf";
+    }
+
+    import ciena-mef-meter-profile {
+        prefix "meter";
+    }
+
+    import ciena-mef-flood-containment-profile {
+        prefix "mef-fc";
+    }
+
+    organization
+        "Ciena Corporation";
+
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines Ciena's management data definition for the
+         management of a Logical Port.";
+
+    revision "2017-09-18" {
+        description
+            "Added operational data for logical ports.
+             Added description in containers, lists, leafs.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision "2014-10-02" {
+        description
+            "Initial Version.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    /*
+     * typedefs
+     */
+    typedef logical-port-ref {
+        type leafref {
+            path "/mef-logical-port:logical-ports/mef-logical-port:logical-port/mef-logical-port:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             configured logical ports.";
+    }
+
+    typedef lp-admin-state 
+    {
+        type enumeration 
+        {
+            enum disable {
+                description
+                    "The logical port is enabled.";
+            }
+            enum enable {
+                description
+                    "The logical port is disabled.";
+            }
+        }
+        description
+            "The admin state of logical port.";
+    }
+
+    typedef lp-oper-state 
+    {
+        type enumeration 
+        {
+            enum up {
+                description
+                    "The logical port is up.";
+            }
+            enum down {
+                description
+                    "The logical port is down.";
+            }
+        }
+        description
+            "The oper state of logical port.";
+    }
+
+    /*
+     * Configuration model.
+     */
+    container logical-ports {
+        description
+            "Configuration data for Logical Ports.";
+
+        list logical-port {
+            key "name";
+
+            description
+                "This denotes list of Logical Ports.";
+
+            leaf name {
+                type string;
+                description
+                    "This object indicates the identifier and is a 
+                     text string that is used to identify a logical port. 
+                     Unique string values are chosen to uniquely identify
+                     the port.
+                     Octet values of 0x00 through 0x1f are illegal.
+                     MEF 26.1 restricts the maximum size identifiers to 
+                     45 octets.";
+                reference
+                    "[MEF 7.2] 6.2.1.4";
+            }
+
+            leaf admin-state {
+                type lp-admin-state;
+                default enable;
+                description
+                    "Enable or disable this logical-port.";
+            }
+
+            leaf binding {
+                type if:interface-ref;
+                description
+                    "A Reference to an Interface.";
+            }
+
+            leaf mtu {
+                type uint32 {
+                    range "64..9216";
+                }
+                default 1526;
+                description
+                    "The size in bytes of the maximum transmission unit.";
+            }
+
+            leaf meter-profile {
+                type meter:meter-ref;
+                description
+                    "A reference to a Meter Profile.";
+            }
+
+            choice frame-to-cos-policy {
+                description
+                    "Indicates Frame to CoS Policy.";
+
+                case map {
+                    leaf policy {
+                        type enumeration {
+                            enum outer-tag {
+                                description
+                                    "If the policy is set to outer-tag then outer VLAN tag PCP/CFI
+                                     value is mapped to the port resolved CoS mapping table to
+                                     derive the R-CoS and R-Color.";
+                            }
+                            enum inner-tag {
+                                description
+                                    "If the policy is set to inner-tag then inner VLAN tag PCP/CFI
+                                     value is mapped to the port resolved CoS mapping table to
+                                     derive the R-CoS and R-Color.";
+                            }
+                            enum dscp {
+                                description
+                                    "If the policy is set to dscp then dscp value in IP header
+                                     is mapped to the port resolved CoS mapping table to
+                                     derive the R-CoS and R-Color.";
+                            }
+                            enum outer-mpls-tc {
+                                description
+                                    "If the policy is set to outer-mpls-tc then top MPLS label
+                                     EXP value is mapped to the port resolved CoS mapping table to
+                                     derive the R-CoS and R-Color.";
+                            }
+                        }
+                        description
+                            "Indicates the policy used to assign CoS values to incomming packets.";
+                    }
+
+                    leaf frame-to-cos-map {
+                        type ftc:frame-to-cos-ref;
+                        description
+                            "Reference to a Frame to CoS Map.";
+                    }
+                }
+
+                case fixed {
+                    leaf cos {
+                        type uint8 {
+                            range "0..63";
+                        }
+                        description
+                            "Fixed cos value assigned when the CoS policy is fixed.";
+                    }
+
+                    leaf color {
+                        type enumeration {
+                            enum green {
+                                description
+                                    "Sets color to Green.";
+                            }
+                            enum yellow {
+                                description
+                                    "Sets color to Yellow.";
+                            }
+                            enum red {
+                                description
+                                    "Sets color to Red.";
+                            }
+                        }
+                        description
+                            "Fixed color value assigned when the CoS policy is set to fixed.";
+                    }
+                }
+            }
+
+            leaf cos-to-frame-map {
+                type ctf:cos-to-frame-ref;
+                description
+                    "Reference to a CoS to Frame Map.";
+            }
+
+            leaf flood-containment-profile {
+                type mef-fc:flood-containment-profile-ref;
+                description
+                    "Reference to a Flood Containment Profile.";
+            }
+
+            leaf description {
+                type string;
+                description
+                    "A more detailed description of a logical port.";
+            }      
+
+            leaf-list outer-tpid {
+                type enumeration {
+                    enum tpid-8100 {
+                        description
+                            "Indicates value of Outer VLAN Tag TPID to be 0x8100.";
+                    }
+                    enum tpid-88a8 {
+                        description
+                            "Indicates value of Outer VLAN Tag TPID to be 0x88a8.";
+                    }
+                    enum tpid-9100 {
+                        description
+                            "Indicates value of Outer VLAN Tag TPID to be 0x9100.";
+                    }
+                }
+                description
+                    "A list of valid outer-vlan-tag TPIDs for the logical port.";
+            }
+
+            leaf-list inner-tpid {
+                type enumeration {
+                    enum tpid-8100 {
+                        description
+                            "Indicates value of Inner VLAN Tag TPID to be 0x8100.";
+                    }
+                    enum tpid-88a8 {
+                        description
+                            "Indicates value of Inner VLAN Tag TPID to be 0x88a8.";
+                    }
+                    enum tpid-9100 {
+                        description
+                            "Indicates value of Inner VLAN Tag TPID to be 0x9100.";
+                    }
+                }
+                description
+                    "A list of valid inner-vlan-tag TPIDs for the logical port.";
+            }
+
+            leaf egress-qos {
+                type enumeration {
+                    enum off {
+                        description
+                            "Indicates Egress QoS is off for the logical port.";
+                    }
+                    enum on {
+                        description
+                            "Indicates Egress QoS is on for the logical port.";
+                    }
+                }
+                description
+                    "The Egress QoS state for the logical port.";
+            }
+        }
+    }
+
+    container logical-port-oper-status {
+        config false;
+        description
+            "Operational Data for logical ports.";
+
+        list logical-port-status
+        {
+            key "name";
+
+            description
+                "List of all logical ports operational data.";
+
+            leaf name {
+                type string;
+                description
+                    "A string that identifies the logical port.";
+            }
+
+            leaf index {
+                type uint32;
+                description
+                    "Index of this logical port.";
+            }
+
+            leaf mac-address {
+                type yt:mac-address;
+                description
+                    "MAC Address of this logical port.";
+            }
+
+            leaf oper-state {
+                type lp-oper-state;
+                description
+                    "Operational state of this logical port.";
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-mef-mac-management.yang
+++ b/vendor/ciena/ciena-mef-mac-management.yang
@@ -1,0 +1,504 @@
+module ciena-mef-mac-management {
+   namespace "urn:ciena:params:xml:ns:yang:ciena-pn:ciena-mef-mac-management";
+   prefix "mef-mac-management";
+
+   import ciena-mef-logical-port {
+      prefix "mef-logical-port";
+   }
+
+   import ciena-mef-fp {
+      prefix "mef-fp";
+   }
+
+   import ciena-mef-fd {
+      prefix "mef-fd";
+   }
+
+   import ietf-yang-types {
+      prefix "yt";
+   }
+
+   import ciena-types {
+      prefix ciena;
+   }
+
+   organization
+      "Ciena Corporation";
+
+   contact
+      "Web URL: http://www.ciena.com/
+       E-mail:  yang@ciena.com
+       Postal:  7035 Ridge Road
+                Hanover, Maryland 21076
+                U.S.A.
+       Phone:   +1 800-921-1144
+       Fax:     +1 410-694-5750";
+
+   description
+      "This YANG module defines Ciena's configuration of
+       the L2 Forwarding Databases (FDB), MAC-Tables, MAC Address Management";
+
+   revision "2017-10-23" {
+      description
+         "Added missed references and descriptions";
+      reference
+         "RFC 6020: YANG - A Data Modeling Language for
+          the Network Configuration Protocol (NETCONF).
+          No specific reference; standard not available.";
+   }
+
+   revision "2017-07-28" {
+      description 
+         "Initial version";
+      reference
+         "RFC 6020: YANG - A Data Modeling Language for
+          the Network Configuration Protocol (NETCONF).
+          No specific reference; standard not available.";
+   }
+
+   /*
+    * typedefs
+    */
+   typedef fd-ref {
+      type leafref {
+         path "/mef-fd:fds/mef-fd:fd/mef-fd:name";
+      }
+     description
+        "This type is used by the data models that need to reference
+         configured fd";
+   }
+
+   typedef fdb-ref {
+      type leafref {
+         path "/mef-mac-management:fdbs/mef-mac-management:fdb/mef-mac-management:name";
+      }
+     description
+        "This type is used by the data models that need to reference
+         configured fdb";
+   }
+
+   /*
+    * Type definition
+    */
+   identity mac-refresh-algorithm {
+      description
+         "Algorithm to refresh dynamic-mac entries.";
+   }
+
+   identity  sa-hit-refresh {
+       base mac-refresh-algorithm;
+       description
+          "With this algorithm, dynamic-mac entries are refreshed based on a MAC-SA match.";
+   }
+
+   identity sa-da-hit-refresh {
+      base mac-refresh-algorithm;
+      description
+         "With this algorithm, dynamic-mac entries are refreshed based on a MAC-DA or MAC-SA match.";
+   }
+
+   /*
+    * Features
+    */
+
+   /*
+    * Configuration data nodes
+    */
+   container mac-management {
+      description
+         "MAC aging configuration.";
+
+      leaf mac-aging {
+         type ciena:admin-state;
+         default enabled;
+         description
+            "Configuration Control of MAC-Aging.";
+      }
+
+      leaf mac-aging-timeout {
+         type uint32;
+         units seconds;
+         default 300;
+         description
+            "The number of seconds of inactivity to determine when a given dynamic mac-entry in an
+             FDB ages out and is removed from the FDB.";
+      }
+
+      leaf dynamic-mac-refresh-algorithm
+      {
+         type identityref {
+            base mac-refresh-algorithm;
+         }
+         description
+            "Algorithm selection to refresh dynamic-mac entries.";
+      }
+
+      choice  mac-maximum-table-size {
+         description
+            "Maximum size of the MAC table.";
+
+         case size {
+            leaf size {
+               type uint32;
+               description
+                  "The maximum number of mac-entries allowed.";
+            }
+         }
+
+         case maximum {
+            leaf maximum {
+               type empty;
+               description
+                  "The maximum number of mac-entries is determined by underlying forwarding-plane.";
+            }
+         }
+      }
+   }
+
+   container fdbs {
+      description
+         "Forwarding databases configuration parameters.";
+
+      list fdb {
+         key "name";
+
+         description
+            "The list of configured l2 forwarding databases.";
+
+         leaf name {
+            type string;
+            description
+               "An administratively assigned string, which may be used to identify the l2 forwarding database.
+                Typically this may be the name of the forwarding-domain when there is an FDB per forwarding-domain (IVL case).";
+         }
+            
+         leaf description {
+            type string;
+            description
+               "This is string used to describe the l2 Forwarding Database.";
+         }
+            
+         leaf mac-learning {
+            type ciena:admin-state;
+            description
+               "Configuration Control of MAC-Learning-Enable per-FDB. Separately there may be configuration
+                control of MAC-Learning-Enable at a more granular level (e.g. per FD, per-Flow-Point etc).";
+         }
+      }
+   }
+
+   container static-macs {
+      description
+         "Static MACs configuration parameters.";
+
+      list mac-entry {
+         key "mac-address fdb";
+
+         description
+            "The list of configured static mac entries. The destination-interface indirectly determines the
+             fdb that the static mac-entry belongs to.";
+
+         leaf mac-address {
+            type yt:mac-address;
+            description
+               "The mac-address for this static-mac entry.";
+         }
+
+         leaf mac-address-mask {
+            type yt:mac-address;
+            description
+               "An optional mac-address mask for this static-mac entry.";
+         }
+
+         leaf fdb {
+            type mef-mac-management:fdb-ref;
+            description
+               "Reference to fdb name, based on the static-mac to be added.";
+         }
+
+         choice destination-interface {
+            description
+               "Selection of destination interface as flow point or logical port.";
+
+            case flow-point {
+               leaf flow-point {
+                  type mef-fp:fp-ref;
+                  description
+                     "Reference to a flow point.";
+               }
+            }
+
+            case logical-port {
+               leaf logical-port {
+                  type mef-logical-port:logical-port-ref;
+                  description
+                     "Reference to a logical port.";
+               }
+            }
+         }
+
+         leaf filter-action {
+            type enumeration {
+               enum allow {
+                  description
+                     "Allow frames that matches to this instance.";
+               }
+               enum drop {
+                  description
+                     "Drop frames that matches to this instance.";
+               }
+            }
+            description
+               "Take action on frames which matches to this instance.";
+         }
+      }
+   }
+
+   container mac-access-controls {
+      description
+         "This is a container which holds configuration data for mac access control.";
+
+      list mac-access-control {
+         key "logical-port";
+         description
+            "The list of mac-access-controls configured.";
+
+         leaf logical-port {
+            type mef-logical-port:logical-port-ref;
+            description
+               "The list of mac-access-controls configured.";
+         }
+
+         choice mac-learn-limit {
+            description
+               "MAC learn limit on / off selection.";
+
+            case on {
+               leaf maximum-dynamic-macs {
+                  type uint64;
+                  description
+                     "The count of dynamic mac entries beyond which mac-learning will not be allowed to occur for this scope";
+               }
+
+               leaf forward-unlearned {
+                  type boolean;
+                  description
+                     "Setting true, forward frames containing unlearned SMAC addresses when 
+                      MAC learn limit has been reached on a logical port.
+                      Setting false, drop frames containing unlearned SMAC addresses when 
+                      MAC learn limit has been reached on a logical port.";
+               }
+            }
+
+            case off {
+               leaf mac-learn-limit-off {
+                  type empty;
+                  description
+                     "MAC learn limit set to off.";
+               }
+            }
+         }
+      }
+   }
+
+   /*
+    * Oper State data nodes
+    */
+   container fdbs-state {
+      config false;
+
+      description 
+         "FDB operational data for all L2 Forwarding-Databases (MAC-Tables).";
+
+      list fdb {
+         key "name";
+         description
+            "The operational data for this L2 Forwarding Database.";
+
+         leaf name {
+            type string;
+            description
+               "A string that identifies the L2 Forwarding Database.";
+         }
+
+         leaf mac-learn-count {
+            type uint64;
+            description
+               "Current count of mac entries in the fdb";
+         }
+         
+         leaf mac-max-learn-count {
+            type uint64;
+            description
+               "Maximum count of mac entries allowed in the fdb";
+         }
+
+         list mac-entry {
+            key "mac-address";
+            description
+               "The list of mac entries in the fdb.";
+
+            leaf mac-address {
+               type yt:mac-address;
+               description
+                  "The mac-address for this mac entry.";
+            }
+
+            leaf mac-address-mask {
+               type yt:mac-address;
+               description
+                  "An optional mac-address mask for this mac entry.";
+            }
+
+            choice destination-interface {
+               description
+                  "Destination interface selection.";
+
+               case flow-point {
+                  leaf flow-point {
+                     type mef-fp:fp-ref;
+                     description
+                        "Reference to a flow point..";
+                  }
+               }
+
+               case logical-port {
+                  leaf logical-port {
+                     type mef-logical-port:logical-port-ref;
+                     description
+                        "Reference to a logical port.";
+                  }
+               }
+            }
+
+            leaf mac-learn-type {
+               type enumeration {
+                  enum dynamic {
+                     description
+                        "Dynamic learned MAC.";
+                  }
+                  enum static {
+                     description
+                        "Static learned MAC.";
+                  }
+               }
+               description
+                  "Dynamic learned MAC or static MAC.";
+            }
+         }
+      }
+   }
+
+   container mac-access-controls-state {
+      config false;
+
+      description
+         "This is a container which holds mac access control operational state data.";
+
+      list mac-access-control {
+         key "logical-port";
+         description
+            "The list of mac-access-controls configured.";
+
+         leaf logical-port {
+            type mef-logical-port:logical-port-ref;
+            description
+               "Reference to a logical port.";
+         }
+
+         leaf mac-dynamic-access-count {
+            type uint64;
+            description
+               "The current count of dynamic mac entries for this scope";
+         }
+
+         leaf high-water-mark {
+            type uint64;
+            description
+               "High water mark of dynamically learned MAC entries";
+         }
+
+         leaf is-threshold-reached {
+            type boolean;
+            description
+               "Mac learn limit threshold reached or not, true means yes and false means no";
+         }
+      }
+   }
+
+   /*
+    * RPC.
+    */
+   rpc dynamic-mac-flush {
+      description
+         "Flush dynamic MAC-entries from FDB(s) at a given scope.";
+
+      input {
+         choice flush-scope {
+            description
+               "Flush mac address learned on FD or FP or logical port or all.";
+
+            case forwarding-domain {
+               leaf forwarding-domain {
+                  type fd-ref;
+                  description
+                     "Flush all dynamic mac-entries learned against the specified forwarding-domain.";
+               }
+            }
+
+            case flow-point {
+               leaf flow-point {
+                  type mef-fp:fp-ref;
+                  description
+                     "Flush all dynamic mac-entries learned against the specified flow-point.";
+               }
+            }
+
+            case logical-port {
+               leaf logical-port {
+                  type mef-logical-port:logical-port-ref;
+                  description
+                     "Flush all dynamic mac-entries learned against the specified logical-port.";
+               }
+            }
+
+            case all {
+               leaf all {
+                  type empty;
+                  description
+                     "Flush all dynamic mac-entries learned on the device as a whole.";
+               }
+            }
+         }
+      }
+      output {
+         leaf status {
+            type string;
+            description
+               "Status of MAC flush operation.";
+         }
+      }  
+   }
+
+   rpc service-access-control-state-clear {
+      description
+         "Clear the service access control state data.";
+
+      input {
+         leaf logical-port {
+            type mef-logical-port:logical-port-ref;
+            description
+               "The logical port name to clear the state data.";
+         }
+      }
+      output {
+         leaf status {
+            type string;
+            description
+               "Status of the clear state operation.";
+         }
+      }
+   }
+}
+
+

--- a/vendor/ciena/ciena-mef-meter-profile.yang
+++ b/vendor/ciena/ciena-mef-meter-profile.yang
@@ -1,0 +1,138 @@
+module ciena-mef-meter-profile {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-meter-profile";
+    prefix "meter";
+    
+    organization
+        "Ciena Corporation";
+ 
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines the Meter Profile configuration 
+         requirements.";
+
+    revision 2017-10-23 {
+        description
+            "Added missing reference and description for container and list.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision 2015-07-16 {
+        description 
+            "Initial revision.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+    
+    /*
+     * Typedefs
+     */
+    typedef meter-ref {
+        type leafref {
+            path "/meter:meter-profiles/meter:meter-profile/meter:name";
+        }
+        description
+            "This type is used by data models that need to reference
+             configured meter profiles.";
+    }
+
+    container meter-profiles {
+        description
+            "Configuration Data for Meter Profiles.";
+
+        list meter-profile {
+            key "name";
+            
+            description
+                "This denotes list of Meter Profiles.";
+        
+            leaf name {
+                type string;
+                description
+                    "A unique identifier for the profile that is either
+                     set as part of configuration or set by the system.";
+            }
+            
+            leaf description {
+                type string;
+                description
+                    "A more detailed description of the profile.";
+            }
+            
+            leaf cir {
+                type uint32;
+                description
+                    "Committed Information Rate (CIR). CIR is a Bandwidth 
+                     Profile parameter. It defines the average rate in 
+                     Kbits/s of Service Frames up to which the network 
+                     delivers Service Frames and meets the performance 
+                     objectives defined by the CoS Service Attribute.";
+            }
+ 
+            leaf eir {
+                type uint32;
+                description
+                    "Excess Information Rate (EIR). EIR is a Bandwidth Profile 
+                     parameter. It defines the average rate in Kbits/s of 
+                     Service Frames up to which the network may deliver 
+                     Service Frames but without any performance objectives.";
+            }
+
+            leaf cbs {
+                type uint32;
+                description
+                    "Commited Burst Size (CBS). CBS is a Bandwidth Profile 
+                     parameter. It limits the maximum number of bytes 
+                     available for a burst of Service Frames sent at the UNI 
+                     speed to remain CIR-conformant.";
+            }
+
+            leaf ebs {
+                type uint32;
+                description
+                    "Excess Burst Size (EBS). EBS is a Bandwidth Profile 
+                     parameter. It limits the maximum number of bytes 
+                     available for a burst of Service Frames sent at the UNI 
+                     speed to remain EIR-conformant.";
+            }
+
+            leaf color-aware {
+                type boolean;
+                description
+                    "The Bandwidth Profile algorithm is said to be in color 
+                     aware mode when each Service Frame already has a level 
+                     of compliance (i.e., a color) associated with it and 
+                     that color is taken into account in determining the 
+                     level of compliance  by the Bandwidth Profile  
+                     algorithm. The Bandwidth Profile algorithm is said to be 
+                     in color blind mode when the color (if any) already 
+                     associated with each Service Frame is ignored by the 
+                     Bandwidth Profile Algorithm.";
+            }
+
+            leaf coupling-flag {
+                type boolean;
+                description
+                    "CF is a Bandwidth Profile parameter. The Coupling Flag 
+                     allows the choice between two modes of operation of the 
+                     rate enforcement algorithm. It takes a value of 0 or 1 
+                     only.";
+                reference
+                    "MEF 10.2, Section 7.11.1, Standard Bandwidth Profile
+                     and Parameters.";
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-mef-pfg-profile.yang
+++ b/vendor/ciena/ciena-mef-pfg-profile.yang
@@ -1,0 +1,188 @@
+module ciena-mef-pfg-profile {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-pfg-profile";
+    prefix "mef-pfg";
+    
+    organization
+        "Ciena Corporation";
+
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines Ciena's configuration of
+         the Private Forwarding Group Profile.";
+
+    revision 2017-10-23 {
+        description
+            "Added missing reference and description for container and list.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision 2016-05-19 {
+        description  
+            "Initial revision.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    typedef pfg-profile-ref {
+        type leafref {
+            path "/mef-pfg:pfg-profiles/mef-pfg:pfg-profile/mef-pfg:name";
+        }
+        description
+            "This type is used by the data models that need to reference
+             configured Private Forwarding Group Profiles.";
+    }
+
+    typedef PfgType {
+        type enumeration {
+            enum pfg-groups {
+                description
+                    "This pfg-type allows for up to 4 PFG groups with configurable forwarding 
+                     policies. Interfaces (e.g. flow points) in the domain (e.g forwarding-domain) 
+                     will specify which PFG-group A,B,C or D that they belong to. This is the only 
+                     PfgType which allows configuration of forwarding group policies.";
+            }
+            enum spoke-and-mesh {
+                description
+                    "This pfg-type supports spoke and mesh with strict forwarding policy rules
+                       spoke => can forward to mesh and can forward to spoke.
+                       mesh => can forward to spoke but cannot forward to mesh.
+                     Interfaces (e.g. flow points) in the domain (e.g forwarding-domain) will 
+                     specify which PFG-group Spoke or Mesh that they belong to.";
+            }
+            enum leaf-and-root {
+                description
+                    "This pfg-type supports leaf and root with strict forwarding policy rules
+                       leaf => can forward to root but cannot forward to leaf.
+                       root => can forward to leaf and can forward to root.
+                     Interfaces (e.g. flow points) in the domain (e.g forwarding-domain) will 
+                     specify which PFG-group Leaf or Root that they belong to.";
+            }
+            enum spokemesh-and-leafroot {
+                description
+                    "This pfg-type supports leaf, root, spoke and mesh with strict forwarding 
+                     policy rules
+                       leaf  => can forward to root, can forward to mesh, can forward to spoke, 
+                                but cannot forward to leaf.
+                       root  => can forward to root, can forward to mesh, can forward to spoke, 
+                                can forward to leaf.
+                       spoke => can forward to root, can forward to mesh, can forward to mesh, 
+                                can forward to leaf.
+                       mesh  => can forward to root, can forward to spoke, can forward to leaf, 
+                                but cannot forward to mesh.
+                     Interfaces (e.g. flow points) in the domain (e.g forwarding-domain) will 
+                     specify which PFG-group Spoke, Mesh, Leaf or Root that they belong to.";
+            }
+        }
+
+        description
+            "This represents different types of PFG Profiles.";
+    }
+
+    typedef group-policy {
+        type bits {
+            bit forward-to-a {
+                description
+                    "can forward to PFG-group A.";
+            }
+            bit forward-to-b {
+                description
+                    "can forward to PFG-group B.";
+            }
+            bit forward-to-c {
+                description
+                    "can forward to PFG-group C.";
+            }
+            bit forward-to-d {
+                description
+                    "can forward to PFG-group D.";
+            }
+        }
+        description
+            "When PfgType is pfg-groups the forwarding policies between the groups can be 
+             configured. Each PFG Group A,B,C or D can define the set of PFG-groups that 
+             it can forward to (including itself). If a forward-to-x bit is not set for a
+             PFG-group, the PFG-group cannot forward to any interface e.g. flow-point) in 
+             that PFG-group. Each interface defines which PFG-group it belongs to.";
+    }
+
+    container pfg-profiles {
+
+        description
+            "Contains the list of PFG profiles currently present in the system.";
+        list pfg-profile {
+            key "name";
+
+            description
+                "Represents configurational data for corresponding PFG profile.";
+
+            leaf name {
+                type string {
+                }
+                description
+                    "An administratively assigned string, which may be used
+                     to identify the profile.";
+            }
+            
+            leaf description {
+                type string;
+                description
+                    "This is a user-defined string used to describe the profile.";
+            }
+
+            leaf pfg-type {
+                type PfgType;
+                description
+                    "The type of PFG-profile which has configurable policies or strict forwarding 
+                     policies.";
+            }
+
+            leaf pfg-group-count {
+                type uint32;
+                description
+                    "When the pfg-type is pfg-groups, this defines the number of PFG groups that 
+                     are valid in this profile.
+                     2 => PFG-Groups A and B
+                     3 => PFG-Groups A, B and C
+                     4 => PFG-Groups A,B,C and D.";
+            }
+	    
+            leaf group-A-policy {
+                type group-policy;
+                description
+                    "The set of forwarding rules for Group A.";
+            }
+
+            leaf group-B-policy {
+                type group-policy;
+                description
+                    "The set of forwarding rules for Group B.";
+            }
+
+            leaf group-C-policy {
+                type group-policy;
+                description
+                    "The set of forwarding rules for Group C.";
+            }
+
+            leaf group-D-policy {
+                type group-policy;
+                description
+                    "The set of forwarding rules for Group D.";
+            }
+        }
+    }
+}
+

--- a/vendor/ciena/ciena-mef-qos-flow.yang
+++ b/vendor/ciena/ciena-mef-qos-flow.yang
@@ -1,0 +1,333 @@
+module ciena-mef-qos-flow {
+    namespace "urn:ciena:params:xml:ns:yang:ciena-pn::ciena-mef-qos-flow";
+    prefix "flow";
+    
+    import ciena-mef-classifier {
+        prefix "classifier";
+    }
+    
+    import ciena-mef-meter-profile {
+        prefix "meter";
+    }
+    
+    import ciena-mef-frame-to-cos-map {
+        prefix "ftc";
+    }
+    
+    import ciena-mef-cos-to-frame-map {
+        prefix "ctf";
+    }
+    
+    import ciena-mef-logical-port {
+        prefix "mef-logical-port";
+    }
+    
+    import ciena-mef-fp {
+        prefix "mef-fp";
+    }
+    
+    organization
+        "Ciena Corporation";
+ 
+    contact
+        "Web URL: http://www.ciena.com/
+         E-mail:  yang@ciena.com
+         Postal:  7035 Ridge Road
+                  Hanover, Maryland 21076
+                  U.S.A.
+         Phone:   +1 800-921-1144
+         Fax:     +1 410-694-5750";
+
+    description
+        "This YANG module defines the QoS Flow.";
+    
+    revision 2017-10-23 {
+        description 
+            "Added missing reference and description.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+
+    revision 2016-02-03 {
+        description 
+            "Initial revision.";
+        reference
+            "RFC 6020: YANG - A Data Modeling Language for
+             the Network Configuration Protocol (NETCONF).
+             No specific reference; standard not available.";
+    }
+    
+/*
+ * typedefs
+ */
+    typedef qos-flow-ref {
+        type leafref {
+            path "/flow:qos-flows/flow:qos-flow/flow:name";
+        }
+        description
+            "This type is used by the data models that needs to reference
+             configured QoS flows.";
+    }
+    
+    container qos-flows {
+        description
+            "Contains the list of QoS flows present currently in the system."; 
+
+        list qos-flow {
+            key "name";
+
+            description
+                "This represents configurational data of corresponding QoS flow."; 
+
+            leaf name {
+                type string;
+                
+                description
+                    "A unique string that is either system assigned or assigned
+                     by the user but does not change over its life.";
+            }
+            
+            leaf description {
+                type string;
+                description
+                    "A more detailed description that an operator can use
+                     to describe the flow.";
+            }
+            
+            leaf-list classifier-list {
+                type classifier:classifier-ref;
+                description
+                    "A reference to a list of classifier entries.";
+            }
+            
+            leaf classifier-precedence {
+                type uint32;
+                description
+                    "A precedence value for the qos flow. Lower values take
+                     precedence over higher values.";
+            }
+            
+            leaf meter-profile {
+                type meter:meter-ref;
+                description
+                    "A reference to a Meter Profile.";
+            }
+            
+            choice parent-interface {
+                description
+                    "Parent interfaces can be either logical port(s) or FP(s).";
+                case port {     
+                    leaf-list parent-port {
+                        type mef-logical-port:logical-port-ref;
+                        description
+                            "A reference to list of logical ports, that this 
+                             traffic-profile is acting on.";
+                    }
+                }
+                
+                case fp {
+                    leaf-list parent-fp {
+                        type mef-fp:fp-ref;
+                        description
+                            "A reference to FP, represents a list of FPs that
+                             acting on this QoS flow.";
+                    }
+                }
+            }
+            
+            leaf cos-to-frame-map {
+                type ctf:cos-to-frame-ref;
+                description
+                    "A reference to a CoS to Frame map.";
+            }
+            
+            choice frame-to-cos-map {
+                description
+                    "Frame to CoS mapping can be either mapped or fixed.";
+
+                case map {
+                    leaf map-policy {
+                        type enumeration {
+                            enum outer-vlan-tag {
+                                description
+                                    "Use outer VLAN to map to CoS 
+                                     and color.";
+                            }
+                            enum inner-vlan-tag {
+                                description
+                                    "Use inner VLAN to map to CoS
+                                     and color.";
+                            }
+                            enum dscp {
+                                description
+                                    "Use DSCP to map to CoS and 
+                                     color.";
+                            }
+                            enum  outer-mpls-tc {
+                                description
+                                    "Use MPLS EXP bits to map to CoS
+                                     and color.";
+                            }
+                        }
+                        description
+                            "This represents mapping policy value for CoS and color.";
+                    }
+                    
+                    leaf map-entry {
+                        type ftc:frame-to-cos-ref;
+                        description
+                            "A reference to a Frame to CoS map.";
+                    }
+                }
+                
+                case fixed {
+                    leaf fixed-cos {
+                        type uint16 {
+                            range "0..63";
+                        }
+                        description
+                            "This represents fixed cos value assigned when the
+                             CoS policy is fixed.";
+                    }
+
+                    leaf fixed-color {
+                        type enumeration {
+                            enum green {
+                                description
+                                    "Fixed color value Green.";
+                            }
+                            enum yellow {
+                                description
+                                    "Fixed color value Yellow.";
+                            }
+                            enum red {
+                                description
+                                    "Fixed color value Red.";
+                            }
+                        }
+                        description
+                            "Fixed color value assigned when the CoS policy is set to fixed.";
+                    }
+                }
+            }
+            
+            choice ingress-l2-transform {
+                description
+                    "This represents ingress L2 transform.";
+                case stamp {     
+                    choice dei-policy {
+                        description
+                            "DEI policy can be either mapped or fixed.";
+                        case map {
+                            leaf dei-map {
+                                type empty;
+                                description
+                                    "Map from the incoming frame.";
+                            }
+                        }
+                        case fixed {
+                            leaf dei-value {
+                                type boolean;
+                                description
+                                    "Fixed DEI value.";
+                            }
+                        }
+                    }
+
+                    choice pcp-policy {
+                        description
+                            "PCP policy can be either mapped or fixed.";
+                        case map {
+                            leaf pcp-map {
+                                type empty;
+                                description
+                                    "Map from the incoming frame.";
+                            }
+                        }
+                        case fixed {
+                            leaf pcp-value {
+                                type uint8 {
+                                    range "0..7";
+                                }
+                                description
+                                    "Fixed PCP value.";
+                            }
+                        }
+                    }
+                }
+            }
+            
+            choice ingress-l3-transform {
+                description
+                    "This represents ingress L3 transform.";
+                case stamp {
+                    choice dscp-policy {
+                        description
+                            "This choice describes DSCP policy can either mapped to frame-to-cos
+                             value or can be a fixed value in range 0 to 63.";
+                        case map {
+                            leaf dscp-map {
+                                type ftc:frame-to-cos-ref;
+                                description
+                                    "Reference to a Frame to CoS Map.";
+                            }
+                        }
+                        
+                        case fixed {
+                            leaf dscp-value {
+                                type uint8 {
+                                    range "0..63";
+                                }
+                                description
+                                    "Fixed DSCP value.";
+                            }
+                        }
+                    }
+                }
+            }
+
+            leaf stats-collection {
+               type enumeration {
+                  enum on {
+                      description
+                          "Stats collection on.";
+                  }
+                  enum off {
+                      description
+                          "Stats collection off.";
+                  }
+               }
+               description
+                  "Determines whether stats collection will be turned on or not for a qos-flow.";
+            }
+        }
+    }
+    
+    /*
+     * Oper Data
+     */
+    container qos-flow-state {
+
+        config false;
+
+        description
+            "Global Qos Flow operational data.";
+
+        list qos-flow {
+
+            key "name";
+
+            description
+                "The operational data for this Qos Flow.";
+
+            leaf name {
+                type string;
+
+                description
+                    "A string that identifies the Qos Flow.";
+            }
+        }
+    }
+}

--- a/vendor/ciena/ciena-sat.yang
+++ b/vendor/ciena/ciena-sat.yang
@@ -1,0 +1,3354 @@
+
+module ciena-sat {
+  namespace "http://www.ciena.com/ns/yang/ciena-sat";
+  prefix "ciena-sat";
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  import ieee802-dot1q-types
+  {
+    prefix ieee;
+  }
+
+  import ciena-types {
+    prefix ciena;
+  }
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  import ciena-mef-logical-port {
+     prefix "mef-logical-port";
+  }
+
+  import ciena-mef-fp {
+     prefix "mef-fp";
+  }
+
+  organization      
+   "Ciena Corporation";
+
+  contact
+    "Web URL: http://www.ciena.com/
+    E-mail:  yang@ciena.com
+    Postal:  7035 Ridge Road
+    Hanover, Maryland 21076
+    U.S.A.
+    Phone:   +1 800-921-1144
+    Fax:     +1 410-694-5750";
+
+  description
+    "This YANG module defines Ciena's data definition for the
+    management of benchmark Service Activation Testing.
+
+    Copyright (c) 2016 Ciena Corporation.  All rights
+    reserved.
+
+    All information contained herein is, and remains
+    the property of Ciena Corporation. Dissemination of this
+    information or reproduction of this material is strictly
+    forbidden unless prior written permission is obtained from
+    Ciena Corporation.";
+
+  revision "2017-12-07" {
+    description
+      "Added support for outage test.";
+    reference
+      "Carrier Ethernet Service Activation Testing (MEF 48), Oct 2014";
+  }
+
+  revision "2017-10-26" {
+    description
+      "Changed entity's role to a leaf instead of a choice.
+       Changed entity's port to be a logical-port reference
+       Replaced test instance's sub-port ID for flow point ID - refence to
+        an MEF flow point
+       Added active dst MAC, active s-vid and active c-vid leaf to the
+        test instance operational data";
+    reference
+      "Carrier Ethernet Service Activation Testing (MEF 48), Oct 2014";
+  }
+
+  revision "2016-11-01" {
+    description
+      "Initial Version.";
+    reference
+      "Carrier Ethernet Service Activation Testing (MEF 48), Oct 2014";
+  }
+
+  /*
+   * typedefs 
+   */
+
+  typedef name-string {
+    type string {
+      length "1..45";
+    }
+    description
+      "A text string of up to 45 characters.";
+  }
+
+  typedef latency-pdv-test-state-type {
+    type enumeration {
+      enum idle { 
+        description
+          "Test is not configured or hasn't started yet.";
+      }
+      enum sending-traffic { 
+        description
+          "Sending test packets.";
+      }
+      enum waiting-for-timestamp-data {
+        description
+          "Collecting latency data.";
+      }
+      enum waiting-for-residual-packets {
+        description
+          "Waiting for all test packets to return back to collector.";
+      }
+      enum processing-results {
+        description
+          "Processing latency data collected.";
+      }
+      enum stopped-by-interval-timer {
+        description
+          "Test stopped by the interval timer.";
+      }
+      enum stopped-by-duration-timer {
+        description
+          "Test stopped by the duration timer.";
+      }
+      enum stopped-by-user {
+        description
+          "Test stopped by the user.";
+      }
+      enum done {
+        description
+          "Testing complete.";
+      }
+    }
+    description     
+     "Possible states for the latency and packet delay variation tests.";
+  }
+
+  typedef throughput-test-state-type {
+    type enumeration {
+      enum idle {
+        description
+          "Test is not configured or hasn't started yet.";
+      }
+      enum running {
+        description
+          "Test traffic is being sent.";
+      }
+      enum waiting-for-residual-packets {
+        description
+          "Waiting for all test packets to return back to collector.";
+      }
+      enum processing-results {
+        description
+          "Processing throughput results.";
+      }
+      enum stopped-by-interval-timer {
+        description
+          "Test stopped by the interval timer.";
+      }
+      enum stopped-by-duration-timer {
+        description
+          "Test stopped by the duration timer.";
+      }
+      enum stopped-by-user {
+        description
+          "Test stopped by the user.";
+      }
+      enum done {
+        description
+          "Test complete.";
+      }
+      enum tx-max-throughput-for-yellow-test {
+        description
+          "Transitting green test frames at maximum throughput found, while
+           yellow test frames are sent in search of yellow maximum throughput.";
+      }
+    }
+    description     
+     "Throughput test states";
+  }
+
+  typedef frameloss-test-state-type {
+    type enumeration {
+      enum idle {
+        description
+          "Test is not configured or hasn't started yet.";
+      }
+      enum running-first-test {
+        description
+          "Sending test packets for the first frame loss pass.";
+      }
+      enum WaitingForResidualFirstPackets {
+        description
+          "Waiting for all test packets from the first frame loss pass to 
+           return back to collector.";
+      }
+      enum processing-first-results {
+        description
+          "Processing results for the first frame loss pass.";
+      }
+      enum running-second-test {
+        description
+          "Sending test packets for the first frame loss pass.";
+      }
+      enum waiting-for-residual-second-packets {
+        description
+          "Waiting for all test packets from the second frame loss pass 
+           to return back to collector.";
+      }
+      enum processing-second-results {
+        description
+          "Processing results for the second frame loss pass.";
+      }
+      enum stopped-by-interval-timer {
+        description
+          "Test stopped by the interval timer.";
+      }
+      enum stopped-by-duration-timer {
+        description
+          "Test stopped by the duration timer.";
+      }
+      enum stopped-by-user {
+        description
+          "Test stopped by the user.";
+      }
+      enum done {
+        description
+          "Test complete.";
+      }
+    }
+    description     
+     "Frame loss test states";
+  }
+
+  typedef rfc2544-test-state-type {
+    type enumeration {
+      enum idle {
+        description
+          "Test is not configured or hasn't started yet.";
+      }
+      enum running {
+        description
+          "The RFC 1544 test suite is currently running. 
+           Refer to the throughput, frame loss and latency test state 
+           to find out which test from the suite is currently executing.";
+      }
+      enum stopped-by-interval-timer {
+        description
+          "Test stopped by the interval timer.";
+      }
+      enum stopped-by-duration-timer {
+        description
+          "Test stopped by the duration timer.";
+      }
+      enum stopped-by-user {
+        description
+          "Test stopped by the user.";
+      }
+      enum done {
+        description
+          "Test complete.";
+      }
+    }
+    description     
+     "RFC 2544 test suite state.";
+  }
+
+  typedef y1564-test-state-type {
+    type enumeration {
+      enum idle {
+        description
+          "Test is not configured or hasn't started yet.";
+      }
+      enum running {
+        description
+          "The Y.1564 test suite is currently running. 
+           Refer to the throughput, frame loss, latency and PDV test state 
+           to find out which test from the suite is currently executing.";
+      }
+      enum stopped-by-interval-timer {
+        description
+          "Test stopped by the interval timer.";
+      }
+      enum stopped-by-duration-timer {
+        description
+          "Test stopped by the duration timer.";
+      }
+      enum stopped-by-user {
+        description
+          "Test stopped by the user.";
+      }
+      enum done {
+        description
+          "Test complete.";
+      }
+    }
+    description     
+     "Y1564 test suite state.";
+  }
+
+  typedef outage-test-state-type {
+    type enumeration {
+      enum idle {
+        description
+          "Test is not configured or hasn't started yet.";
+      }
+      enum running {
+        description
+          "The outage test is currently running.";
+      }
+      enum stopped-by-duration-timer {
+        description
+          "Test stopped by the duration timer.";
+      }
+      enum stopped-by-user {
+        description
+          "Test stopped by the user.";
+      }
+      enum processing-outage-records {
+        description
+          "Processing outage test records.";
+      }
+      enum done {
+        description
+          "Test complete.";
+      }
+    }
+    description     
+     "outage test state.";
+  }
+
+  typedef priority {
+    type uint8 {
+      range "0..7";
+    }
+    description
+      "Range of priorities from 0-7 inclusive.";
+  }
+
+  typedef basic-color
+  {
+    type enumeration {
+      enum green {
+        description
+          "Green traffic.";
+      }
+      enum yellow {
+        description 
+          "Yellow traffic.";
+      }
+    }
+    description     
+     "Traffic color which is associated with the dot1q DEI 
+      (drop eligible indictor) bit value.";
+  }
+
+  typedef color {
+    type enumeration {
+      enum green {
+        description
+          "The test is configured to run with green traffic only.";
+      }
+      enum yellow {
+        description
+          "The test is configured to run with yellow traffic only.";
+      }
+      enum green-yellow {
+        description
+          "The test is configured to run with green traffic starting at 
+           the configured bandwidth and yellow traffic starting at 
+           the configured excess bandwidth.";
+      }
+      enum green-yellow-red {
+        description
+          "The test is configured to run with green traffic starting at 
+           the configured bandwidth and yellow traffic starting at 1.25 
+           times the configured excess bandwidth.";
+      }
+    }
+    description     
+     "Defines which traffic color needs to be tested. Green 
+      test traffic is generated with DEI bit set to 0 and
+      uses the profile bandwidth parameter as the starting
+      bandwidth; yellow test traffic is generated with DEI bit
+      set to 1 and uses the profile excess-bandwidth parameter
+      as the starting bandwidth. When testing for red, the test
+      stream has its DEI bit set to 1 and the starting bandwidth
+      is (excess-bandwidth * 1.25)";
+  }
+
+  typedef kpi-result-type {
+    type enumeration {
+      enum not-available {
+        description
+          "No KPI (Key Performance Indicator) configured for the test.";
+      }
+      enum pass {
+        description
+          "The test results are within the configured KPI. 
+           The test is therefore considered a pass";
+      }
+      enum fail {
+        description
+          "The test results are outside the configured KPI boundary. 
+           The test is therefore considered a fail.";
+      }
+    }
+    description     
+     "Provides a pass or fail for the test results compared to
+      the selected KPI profile's pass crieteria for the test.";
+  }
+
+  typedef throughput-kpi-percent {
+    type uint32;
+    description     
+     "Percent of bandwidth that the maximum throughput result
+      shouldn't go below for the test to be considered a pass.
+      The value is given as an integer but represent a 4 decimal
+      point percent. Ex: 0.2000 is reported as 2000.";
+  }
+
+  typedef frameloss-kpi-percent {
+    type uint32;
+    description     
+     "Percent of the frameloss test staring bandwidth, the frame
+      loss shouldn't exceed for the test to be considered a pass.
+      The value is given as an integer but represent a 4 decimal
+      point percent. Ex: 0.2000 is reported as 2000.";
+  }
+
+  typedef throughput-result {
+    type uint32;
+    description     
+     "Throughput results in Mbps are sent as unsigned integer
+      multiplied by 100 to provide a 2 decimal point accuracy.
+      If result is 123.45 Mbps, it is sent as 12345 and should
+      be divided by 100 by the application retrieving the
+      data.";
+  }
+
+  typedef frameloss-result {
+    type uint32;
+    description     
+     "Frame loss results in Percent of frame loss start bandwidth
+      are sent as unsigned integer multitplied by 100 to provide a
+      2 decimal point accuracy.
+      If result is 12.34 %, it is sent as 1234 and should
+      be divided by 100 by the application retrieving the
+      data.";
+  }
+
+  typedef pcp-bitmap {
+    type bits {
+      bit pcp0 { 
+        position 0; 
+        description "pcp 0.";
+      }
+      bit pcp1 { 
+        position 1; 
+        description "pcp 1.";
+      }
+      bit pcp2 { 
+        position 2; 
+        description
+          "pcp 2.";
+      }
+      bit pcp3 { 
+        position 3; 
+        description 
+          "pcp 3.";
+      }
+      bit pcp4 { 
+        position 4; 
+        description
+          "pcp 4.";
+        }
+      bit pcp5 { 
+        position 5; 
+        description
+          "pcp 5.";
+        }
+      bit pcp6 { 
+        position 6; 
+        description 
+          "pcp 6.";
+      }
+      bit pcp7 { 
+        position 7; 
+        description
+          "pcp 7.";}
+    }
+    description     
+     "Bitmap of the VLAN PCP (Priority Code) value to test
+      with. When The RFC2544 test is selected in the profile,
+      only 1 PCP bit can be set. For other tests, a test 
+      session will be run simultaneously for each PCP set
+      in the bitmap. In the latter case, the bandwidth will
+      be distributed among the set of PCPs according to the
+      selected PCP Bandwidth allocation profile. If no
+      such profile is configured, the bandwidth will be
+      evenly distributed among all set PCPs.";
+  }
+
+  /*
+   * Groupings
+   */
+
+  grouping kpi-values {
+    description
+      "Common fields for pcp KPIs and untagged KPIs";
+
+    // may be extended to have entry per color
+    // in future versions, but for 6.16.1 we do not support this
+      
+    leaf throughput {
+      type ciena-sat:throughput-kpi-percent;
+      description 
+        "Throughput KPI for the given KPI profile, PCP and color
+         expressed in percent of bandwidth * 10000 to provide a 4
+         decimal point value.";
+    }
+
+    leaf frameloss {
+      type ciena-sat:frameloss-kpi-percent;
+      description 
+        "Frameloss KPI for the given KPI profile, PCP and color
+         expressed in percent of bandwidth * 10000 to provide a 4
+         decimal point value.";
+    }
+
+    leaf latency {
+      type uint32;
+      units "microseconds";
+      description 
+        "Maximum latency in micro-seconds that the latency result
+         should not exceed in order for the test to be considered
+         a pass.";
+      }
+
+    leaf pdv {
+      type uint32;
+      units "microseconds";
+      description 
+        "Maximum PDV in micro-seconds that the PDV test result
+         should not exceed in order for the test to be 
+         considered a pass.";
+    }
+
+    leaf single-outage-max {
+      type uint32 {
+        range "0..10000";
+      }
+      units "milliseconds";
+      description 
+        "Maximum time in milli-seconds that any single 
+         outage should not exceed in order for the test 
+         to be considered a pass.";
+    }
+
+    leaf sum-outages-max {
+      type uint32 {
+        range "0..30000";
+      }
+      units "milliseconds";
+      description 
+        "Maximum time in milli-seconds that the sum of recorded
+         outages should not exceed in order for the test 
+         to be considered a pass.";
+    }
+
+    leaf max-num-outages {
+      type uint32 {
+        range "0..128";
+      }
+      description
+        "Maximum number of outages that can occur during
+         the outage test in order for the test to be 
+         considered a pass.";
+    }
+  }
+
+  grouping notification-base-fields {
+    description
+      "Common fields for all SAT notifications.";
+
+    leaf severity {
+      type ciena:event-severity;
+      description
+        "Severity.";
+    }
+    leaf mac-address {
+      type yang:mac-address;
+      description
+        "Mac address.";
+    }
+    leaf test-instance-name {
+      type name-string;
+      mandatory true;
+      description
+        "Name of the test instance.";
+    }
+  }
+
+  grouping notification-test-kpi-fields {
+    description
+      "Common fields for all SAT test KPI failure notifications";
+
+    uses notification-base-fields;
+
+    leaf kpi-profile {
+      type name-string;
+      description
+        "KPI profile name.";
+    }
+    leaf kpi-pcp {
+      type priority;
+      description 
+        "PCP - when not untagged.";
+    }
+    leaf kpi-untagged {
+      type boolean;
+      description 
+        "Untagged.";
+    }
+    leaf kpi-color {
+      type basic-color;
+      description
+        "Color.";
+    }
+    leaf current-pkt-size {
+      type uint32;
+      description
+        "current packet size.";
+    }
+    leaf emix-sequence {
+      type name-string;
+      description
+        "emix sequence name.";
+    }
+  }
+
+  /*
+   * Config data
+   */
+
+  container sat {
+    description
+      "SAT configuration data.";
+
+    container sat-global {
+      description
+        "SAT global configuration data.";
+
+      leaf admin-state {
+        type ciena:admin-state;
+        default disabled;
+        description   
+         "Overall administrative state of the benchmark feature.";
+      }
+
+      leaf default-emix-sequence {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description   
+         "Default EMIX sequence to be used on a test instance
+          when no EMIX is specified in the test instance 
+          targeted test profile. This applies to generator
+          test instances only.";
+      }
+
+      leaf generator-default-kpi-profile {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:kpi-profile/ciena-sat:name";
+        }
+        description   
+         "Default KPI profile to be used to analyze the results
+          of a test instance when no KPI profile is specifed in
+          the targeted test profile. This applies to generator
+          test instances only.";
+      }
+
+      leaf generator-default-bw-alloc-profile {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:bw-alloc-profile/ciena-sat:name";
+        }
+        description   
+         "Default bandwidth allocation profile to be used with
+          a test instance when no bandwidth allocation profile is
+          specified in the targeted test profile. This applies to
+          generator test instances only.";
+      }
+    }
+
+    /* Entity table */
+
+    list entity {
+      key "name";
+      description   
+       "Service activation testing entity configuration.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the service activation test entity.";
+      }
+
+      leaf port {
+        type mef-logical-port:logical-port-ref;
+        description 
+         "SAT entity's port under test";
+      }
+
+      leaf role {
+        type enumeration {
+          enum reflector {
+            description
+              "SAT entity's mode of operation is reflector.";
+          }
+          enum generator {
+            description
+              "SAT entity's mode of operation is generator.";
+          }
+        }
+        description 
+         "SAT entity's mode of operation";
+      }
+
+      leaf generator-h-frame-size {
+         when "../role='generator'";
+        type uint32;
+        description 
+         "Maximum frame size that should be generated by the generator
+         device. This H frame size should be set to leave enough room for
+         extra encapsulation bytes that will be pushed onto the 
+         packet by the switch when pushing this test packet out on
+         the network side port.
+         A value of 0 indicates that the maximum frame size for the
+         entity port should be used. 
+         The generator device will ensure that any frame size list
+         or EMIX used during the test is adjusted accordingly.
+         This field is only valid for a generator SAT entity.";
+      }
+
+      leaf assoc-gen-vendor-type {
+         when "../role='reflector'";
+        type enumeration {
+           enum other {
+             description
+               "The remote generator is NOT a Ciena device.";
+           }
+           enum ciena {
+             description
+               "The remote generator is a Ciena device.";
+           }
+         }
+         default ciena;
+         description 
+          "This is an indicator as to what is the vendor of the associated 
+           generator entity connected to this reflector SAT entity.
+           This field is only valid for a reflector SAT entity.";
+      }
+
+      leaf reflection-level {
+         when "../role='reflector'";
+        type enumeration {
+           enum none {
+             description
+               "Not configured.";
+           }
+           enum l2-only {
+             description
+               "Only the L2 layer fields need to be swapped on reflected packets.";
+           }
+           enum l2-to-l3-ipv4-only {
+             description
+               "The L2 MAC addresses as well as the IPv4 addresses need to 
+                be swapped on reflected packets.";
+           }
+           enum l2-to-l3-ipv6-only {
+             description
+               "The L2 MAC addresses as well as the IPv6 addresses need to 
+                be swapped on reflected packets.";
+           }
+           enum l2-to-l4-ipv4-only {
+             description
+               "L2 MAC addresses, IPv4 addresses and UDP ports need to  
+                be swapped on the reflected packets.";
+           }
+           enum l2-to-l4-ipv6-only {
+             description
+               "L2 MAC addresses, IPv6 addresses and UDP ports need to 
+                be swapped on the reflected packets.";
+           }
+           enum l2-to-l4 {
+             description
+               "L2 MAC addresses, IPv4 or IPv6 addresses and UDP ports need 
+                to be swapped on the reflected packets.";
+           }
+         }
+         description 
+          "For reflector entities, this indicates the minimum reflection
+           level required. If test traffic is going over an ethernet L2
+           cloud, l2-only is fine. But if the test traffic is going over
+           an IP network, the reflector needs to be able to swap L2 and
+           L3 fields. Depending on the type of IP network, the user
+           needs to configure IPv4 or IPv6. L2 to L4 will swap MAC 
+           addresses, IP addresses and src and destination L4 port.
+           Depending on the reflection level required, a different device
+           is used to implement the reflector.
+           This field is only valid for an 8.x reflector SAT entity.
+           The default value is l2-to-l4.";
+      }
+
+      leaf reflector-mac-validation {
+         when "../role='reflector'";
+        type boolean;
+        default true;
+        description 
+          "Used to indicate whether the reflector should classify
+           classify on the mac or not.";
+      }
+
+      leaf mode {
+        type enumeration {
+          enum in-service {
+            description
+              "In service mode; customer traffic is not blocked on the port
+               under test while service activation testing is in progress.";
+          }
+          enum out-of-service {
+            description
+              "Out of service mode; all customer traffic is dropped at the port
+               under test while service activation testing is in progress.";
+          }
+          enum vid-out-of-service {
+            description
+              "Vlan ID Out Of Servcie mode; only customer traffic for the 
+               Vlan IDs currently being tested is being dropped at the port 
+               under test; all other customer traffic goes through.";
+          }
+          enum evc-out-of-service { // not supported by 6.x
+            description
+              "Virtual Circuit Out Of Service; all customer traffic 
+               associated with the virtual circuit(s) currently under test 
+               is being dropped at the port under test; 
+               all other customer traffic goes through.";
+          }
+        }
+        default in-service;
+        description 
+         "SAT entity's mode of operation";
+      }
+
+      leaf admin-state {
+        type ciena:admin-state;
+        default disabled;
+        description 
+         "SAT entity's administrative state.";
+      }
+    }
+
+    /* Emix sequence table */
+
+    list emix-sequence {
+      key "name";
+      description   
+       "EMIX sequence entry.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of this EMIX sequence";
+      }
+
+      leaf sequence {
+        type string {
+          length "1..16";
+        }
+        description 
+         "EMIX sequence which is a sequence of up to
+          16 letters from the following set, that can
+          be repeated, where each letter is associated with
+          the frame size below it:
+               a    b    c    d    e    f    g    h    u     v   w   x 
+              64   128  256  512  1024 1280 1518 MTU custom 84  68  88 
+          The u frame size is user configurable via the
+          emix-sequence-UFrameSize attribute
+          while the h frame size is the maximum frame size
+          configured at the entity level. If the h frame size is
+          not configured at the entity level, h takes the value of
+          the maximum frame size of the port under test.
+          Letter v is the minimum frame size for IPv6 untagged or dot1q
+          test frames, w is the minimum for IPv4 qinq test frames, and
+          x is the minimum for IPv6 qinq test frames.
+          The EMIX character set is available via the
+          emix-sequence-character-set list.";
+      }
+
+      leaf u-frame-size {
+        type uint32 {
+          range "64..9216";
+        }
+        default 594;
+        description 
+         "The frame size associated with the u letter
+          in the given sequence. The default value is
+          594.";
+      }
+    }
+
+    /* kpi-profile table */
+
+    list kpi-profile {
+      key "name";
+      description   
+       "Key performance indicator pass/fail criteria.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the KPI profile";
+      }
+
+      list pcp {
+        key "pcp-value";
+
+        description 
+          "Each PCP within the KPI profile has its own configuration.";
+
+        leaf pcp-value {
+          type priority;
+          description 
+           "PCP value associated with this entry";
+        }
+
+        uses kpi-values;
+      }
+
+      container untagged {
+        description
+          "Untagged traffic does not have a PCP, so it is handled separately.";
+
+        uses kpi-values;
+      }
+    }
+
+    /* bandwidth allocation profile table */
+
+    list bw-alloc-profile {
+      key "name";
+
+      description   
+       "BW allocation profile entry";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the bandwidth allocation profile";
+      }
+
+      list pcp {
+        key "pcp-value";
+
+        description
+          "Each PCP within the bw-alloc-profile has its own configuration.";
+
+        leaf pcp-value {
+          type priority; 
+          description 
+           "PCP value associated with this entry.";
+        }
+
+        leaf ratio {
+          type uint32 {
+            range "0..1000000";
+          }
+          description 
+           "Ratio of test bandwidth to allocate to the
+            test session with this PCP value.";
+        }
+      }
+    }
+
+    /* test profile table */
+
+    list test-profile {
+      key "name";
+      description   
+       "Service activation test profile configuation information.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the profile.";
+      }
+
+      leaf bandwidth {
+        type uint32 {
+          range "1..10000";
+        }
+        description 
+         "Maximum bandwidth to use when generating green test
+          traffic for the profile.";
+      }
+
+      leaf excess-bandwidth {
+        type uint32 {
+          range "0..10000";
+        }
+        default 0;
+        description 
+         "Maximum bandwidth to use when generating yellow test
+          traffic for the profile. When testing for red color,
+          this bandwidth is multiplied by 1.25";
+      }
+
+      leaf interval {
+        type enumeration {
+          enum t15min {
+            description
+              "15 minutes.";
+          }
+          enum t1hr {
+            description
+              "1 hour.";
+          }
+          enum t6hr {
+            description
+              "6 hours.";
+          }
+          enum tCompletion {
+            description
+              "Interval between the start of one test group and the start
+               of the nexxt test group configured on the profile (latency,
+               pdv, throughput, frameloss, rfc2544 and/or y1564).";
+          }
+          enum t2hr {
+            description
+              "2 hours.";
+          }
+        }
+        default tCompletion;
+        description 
+         "Interval between the start of one test group to the start
+          of the next test group.";
+      }
+
+      leaf duration {
+        type enumeration {
+          enum t15min {
+            description
+              "15 minutes.";
+          }
+          enum t1hr {
+            description
+              "1 hour.";
+          }
+          enum t6hr {
+            description
+              "6 hours.";
+          }
+          enum t24hr {
+            description
+              "24 hours.";
+          }
+          enum tIndefinite {
+            description
+              "Indefinite.";
+          }
+          enum tOnce {
+            description
+              "Once.";
+          }
+        }
+        default tOnce;
+        description 
+         "Duration of the testing. The test group is repeated until
+          the duration ends. When indefinite is set, test group is
+          repeated until the user manually stops the test.";
+      }
+
+      leaf-list frame-size {
+        type uint32 {
+          range 64..9216;
+        }
+        max-elements 10;
+        description 
+         "Used to replace the existing frame size table with the specified list.
+          List of frame sizes the test will run with. The selected tests are 
+          performed for one frames size, then the same test is repeated with
+          the next frame size in the list.  Results are provided for each 
+          separate frame size from the list.  When rfc2544 is selected, the
+          default frame size is made up of the following 7 frame sizes:
+          64,128,256,512,1024,1280,1518; The first frame size may differ
+          from 64 depending on the VLAN encapsulation type configured and/or
+          the IP version used for the test:
+          Untagged, non IP or IPv4          64
+          Untagged IPv6                     84
+          dot1q non IP or IPv4              64
+          dot1q IPv6                        84
+          QinQ non IP or IPv4               68
+          QinQ IPv6                         88.";
+      }
+
+      leaf max-searches {
+        type uint8 {
+          range "1..16";
+        }
+        default 7;
+        description 
+         "The throughput test uses a binary search to find the maximum
+          rate at which test traffic can be sent without any packet drops.
+          This attributes dictates the maximum number of searches to perform
+          in the binary search algorithm, before stopping the test.";
+      }
+
+      leaf max-samples {
+        type uint8 {
+          range "2..20";
+        }
+        default 10;
+        description 
+         "For the latency and PDV tests, this is the number of
+          samples to take in order to determine the min, avg
+          and max latency and avg PDV.";
+      }
+
+      leaf sampling-interval {
+        type uint16 {
+          range "1..600";
+        }
+        default 1;
+        description 
+         "This is the number of 100ms steps to use when running any of the
+          configured tests. A value of 1 represents 100ms, a value of 600
+          makes a sampling interval of 1 minutes (600 * 100ms). For the
+          throughput and frame loss tests, this is the number of milliseconds
+          to generate test traffic for before stopping and checking for 
+          frame drops. For latency and PDV, it represents the number of 
+          milliseconds between samples.";
+      }
+
+      leaf frameloss-start-bw {
+        type enumeration {
+          enum profile-bandwidth {
+            description
+              "Bandwidth specified in profile.";
+          }
+          enum maximum-throughput {
+            description
+              "Maximum throughput.";
+          }
+        }
+        default maximum-throughput;
+        description 
+         "For the frame loss test, this indicates which bandwidth
+          value to use as the starting bandwidth; the maximum
+          bandwidth determined via the throughput test or the
+          bandwidth parameter configured in the profile. Note
+          that when rfc2544 is enabled, this value is ignored and 
+          the maximum bandwidth of the link is used (minimum of the 
+          port under test speed and entity/FPGA link speed).";
+      }
+
+      leaf vid-validation {
+        type boolean;
+        default true;
+        description 
+         "Indicates whether the VID of the reflected test frame should
+          be checked for a match when it arrives back at the generator.
+          If VID validation is set to false, PCP and Color validation
+          are ignored and automatically become false.";
+      }
+
+      leaf pcp-validation {
+        type boolean;
+        default true;
+        description 
+         "Used to indicate whether the PCP value of the
+          test packet should be used to classifier the reflected
+          packets or not. When color remarking is used, this should
+          be set to false. Default is true.";
+      }
+
+      leaf color-validation {
+        type boolean;
+        default true;
+        description 
+         "Used to indicate whether the color bit of the
+          test packet should be used to classifier the reflected
+          packets or not. In color unaware testing, this should
+          be set to false. Default is true.";
+      }
+
+      leaf kpi-profile-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:kpi-profile/ciena-sat:name";
+        }
+        description 
+         "Name of a valid KPI profile, from the 
+          kpi-profile list, to use when
+          analysing the test results for this profile.";
+      }
+
+      leaf bw-alloc-profile {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:bw-alloc-profile/ciena-sat:name";
+        }
+        description 
+         "Name of a valid Bandwidth Allocation profile,
+          from the bw-alloc-profile list,
+          used for distributing the profile bandwidth amongst
+          the configured PCP values for this profile when running
+          tests.";
+      }
+
+      leaf emix-sequence {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description 
+         "Name of a valid EMIX sequence configured in the
+          emix-sequence list, to use when y1564
+          is selected. The EMIX sequence is used instead of the
+          frame size list if and only if y1564 is selected.";
+      }
+
+      leaf encap-type {
+        type enumeration {
+          enum untagged {
+            description
+              "Untagged.";
+          }
+          enum dot1Q {
+            description
+              "Dot1q.";
+          }
+          enum qinq {
+            description
+              "QinQ.";
+          }
+        }
+        default untagged;
+        description 
+         "Encapsulation type to use for generated packets.";
+      }
+
+      leaf pdu-type {
+        type enumeration {
+          enum ethernet {
+            description
+              "Ethernet.";
+          }
+          enum ip {
+            description
+              "IP.";
+          }
+          enum udp-echo {
+            description
+              "UDP echo.";
+          }
+        }
+        default ethernet;
+        description 
+         "Test PDU type.";
+      }
+
+      leaf dst-mac {
+        type yang:mac-address;
+        description 
+         "MAC address to use as the destination MAC address on
+          the generated packets.";
+      }
+
+      leaf s-vid { // Not supported in 6.x
+        type ieee:vlanid;
+        description 
+         "S-VLAN ID to used for generated packets when encapType is set to QinQ";
+      }
+
+      leaf s-pcp { // Not supported in 6.x
+        type ciena-sat:pcp-bitmap;
+        description 
+         "Bitmap of the S-VLAN PCP (Priority Code Point) value to 
+          test with. When RFC2544 test is enabled, only one 
+          PCP can be set in the mask. Otherwise, a test session
+          will be run for each PCP bit set. Used when the encapType
+          set to QinQ";
+      }
+
+      leaf s-color {  // Not supported in 6.x
+        type ciena-sat:color;
+        description 
+         "Color of the S-VLAN tag for the test traffic. This is 
+          directly related to the value of the DEI bit 
+          configured in the VLAN tag of the test traffic. Green
+          traffic will have its DEI bit set to 0 while Yellow
+          traffic will have its DEI bit set to 1.
+          Green test traffic is generated based on the bandwidth
+          configured in the test profile. Yellow traffic is
+          generated based on the excess-bandwidth parameter.
+          Finally, if the user selects green-yellow-red, the
+          yellow traffic is generated at 1.25 * excess-bandwidth.
+          This is used only when encapType is set to QinQ";
+      }
+
+      leaf c-vid {
+        type ieee:vlanid;
+        description 
+         "C-VLAN ID to used for generated packets when encapType is set to
+          QinQ or dot1q.";
+      }
+
+      leaf c-pcp {
+        type ciena-sat:pcp-bitmap;
+        default pcp0;
+        description 
+         "Bitmap of the C-VLAN PCP (Priority Code Point) value to 
+          test with. When RFC2544 test is enabled, only one 
+          PCP can be set in the mask. Otherwise, a test session
+          will be run for each PCP bit set. Only used when the
+          encapType is set to dot1q. In the QinQ type, the c-pcp 
+          of the test packet takes the same value as the s-pcp to
+          simplify software.";
+      }
+
+      leaf c-color {
+        type ciena-sat:color;
+        default green;
+        description 
+         "Color of the C-VLAN tag for the test traffic. This is 
+          directly related to the value of the DEI bit 
+          configured in the VLAN tag of the test traffic. Green
+          traffic will have its DEI bit set to 0 while Yellow
+          traffic will have its DEI bit set to 1.
+          Green test traffic is generated based on the bandwidth
+          configured in the test profile. Yellow traffic is
+          generated based on the excess-bandwidth parameter.
+          Finally, if the user selects green-yellow-red, the
+          yellow traffic is generated at 1.25 * excess-bandwidth.
+          This is used only when encapType is set to dot1q.
+          In a QinQ configuration, the c-dei bit is set to the
+          same value as the s-dei bit in order to simplify
+          software.";
+      }
+
+      leaf tpid {
+        type enumeration {
+          enum 0x8100 {
+            description
+              "VLAN tagged frame.";
+          }
+          enum 0x88a8 {
+            description
+              "Provider bridging.";
+          }
+          enum 0x9100 {
+            description
+              "Proprietary.";
+          }
+        }
+        default 0x8100;
+        description 
+         "Vlan tag protocol identifier to use for the generated packets.";
+      }
+
+      leaf dscp {
+        type inet:dscp;
+        description 
+         "IP DSCP value to use for the generated packets.";
+      }
+
+      leaf src-addr {
+        type inet:ip-address;
+        description 
+         "Specifies the unicast source IP address to use in IP test packet.";
+      }
+
+      leaf dst-addr {
+        type inet:ip-address;
+        description 
+         "Specifies the unicast destination IP addr to use in IP test packet.";
+      }
+
+      leaf custom-payload {
+        type binary {
+          length "0..256";
+        }
+        description 
+         "Custom payload to be used in the generated packets.";
+      }
+
+      leaf throughput-test {
+        type boolean;
+        default false;
+        description 
+         "Run throughput test";
+      }
+
+      leaf frameloss-test {
+        type boolean;
+        default false;
+        description 
+         "Run frame loss test";
+      }
+
+      leaf latency-test {
+        type boolean;
+        default false;
+        description 
+         "Run latency test";
+      }
+
+      leaf pdv-test {
+        type boolean;
+        default false;
+        description 
+         "Run packet delay variation test";
+      }
+
+      leaf burst-test { // Not supported yet
+        type boolean;
+        description 
+         "Run packet burst test";
+      }
+
+      leaf rfc2544-suite {
+        type boolean;
+        default false;
+        description 
+         "Run RFC2544 test suite which includes throughput, frame
+          loss and latency tests";
+      }
+
+      leaf y1564-suite {
+        type boolean;
+        default false;
+        description 
+         "The Y1564 test includes the throughput, frameloss,
+          latency and PDV tests and requires an EMIX sequence to be
+          configured. If the profile's EMIX sequencei s not configured,
+          the default generator EMIX sequence is used.
+          Y1564 and RFC2544 are mutually exclusive.";
+      }
+
+      leaf outage-test {
+        type boolean;
+        default false;
+        description
+          "Run outage test";
+      }
+    }
+
+    /* test instance table */
+
+    list test-instance {
+      key "name";
+      description   
+       "Service activation test instance configuration data.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Unique name given to the test instance.";
+      }
+
+      leaf flow-point-id { // Not supported in 6.x
+        type mef-fp:fp-ref;
+        description 
+         "flow-point or sub-port to base this test instance on. The flow-point has
+          to be a child of the logical port under test associated with an existing 
+          entity.";
+      }
+
+      leaf profile {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-profile/ciena-sat:name";
+        }
+        description 
+         "Name of an existing test profile to be used with the test instance as
+          the template for testing. A test profile ID has to be specified if
+          this test instance is associated with a generator entity. If it's a
+          reflector test instance, a profile ID CANNOT be specified, it has
+          to remain unset.";
+      }
+
+      leaf s-vid { // Not supported in 6.x
+        type uint16;
+        description 
+         "S VLAN ID to use for testing.
+          For generator test instances, this over-writes the value defined in 
+          the referenced test profile if applicable (encap-type set to qinq).
+          For reflector test instances, this has to be set to a valid s-vid
+          accepted by the associated sub-port. A value of 0xFFFF indicates 
+          ANY s-vid.";
+      }
+
+      leaf c-vid {
+        type uint16;
+        description 
+         "C VLAN ID to use for testing.
+          For generator test instances, this over-writes the value defined 
+          in the referenced test profile if applicable (encap-type set to 
+          dot1q or qinq).
+          For reflector test instances, this has to be set to a valid c-vid
+          accepted by the associated port/sub-port. 
+          A value of 0xFFFF indicates ANY c-vid.";
+      }
+
+      leaf untagged {
+        type boolean;
+        default false;
+        description 
+         "When set to true, this indicates that the test instance
+          is to be associated with untagged data traffic. When this
+          is set, the cvid and svid parameters must be 0.";
+      }
+
+      leaf dst-mac {
+        type yang:mac-address;
+        description 
+         "Destination MAC address to use for generator test instances. When set,
+          this over writes the value specified in the referenced test profile.
+          This field is not applicable for reflector test instances.";
+      }
+
+      leaf admin-state {
+        type ciena:admin-state;
+        default disabled;
+        description 
+         "Indicates the administrative state of the test instance. 
+          Upon enabling a test instance, resources are allocated in hardware. 
+          For reflector test instances, this triggers the start of reflection 
+          of any test traffic received that matches the specified vid 
+          combination on the specified port/sub-port.";
+      }
+    }
+  }
+
+
+  /*
+   * Operational state data nodes
+   */
+
+  container sat-state {
+    config false;
+ 
+    description
+      "Operational data for SAT.";
+
+    container sat-global {
+      description 
+        "SAT global operational data.";
+
+      leaf platform-max-config-entities {
+        type uint16;
+        description   
+         "Maximum number of entities that can be created on
+          this platform.";
+      }
+
+      leaf platform-max-config-test-intancess {
+        type uint16;
+        description   
+         "Maximum number of test instances that can be created on
+          this platform.";
+      }
+
+      leaf platform-max-config-test-profiles {
+        type uint16;
+        description   
+         "Maximum number of test profiles that can be created on
+          this platform.";
+      }
+
+      leaf platform-max-config-kpi-profiles {
+        type uint16;
+        description   
+         "Maximum number of KPI profiles that can be created on
+          this platform.";
+      }
+
+      leaf platform-max-config-bw-alloc-profiles {
+        type uint16;
+        description   
+         "Maximum number of bandwidth distribution profiles
+          that can be created on this platform.";
+      }
+
+      leaf platform-max-config-emix-sequences {
+        type uint16;
+        description   
+         "Maximum number of EMIX sequences that can be created on
+          this platform, including the system created ones.";
+      }
+
+      leaf platform-max-simultaneous-running-tests {
+        type uint16;
+        description   
+         "Maximum number of test instances that can be running
+          simultaneously on this platform.";
+      }
+
+      leaf configured-entities {
+        type uint16;
+        description   
+         "Number of entities currently configured.";
+      }
+
+      leaf configured-test-intances {
+        type uint16;
+        description   
+         "Number of test instances currently configured.";
+      }
+
+      leaf configured-profiles {
+        type uint16;
+        description   
+         "Number of test profiles currently configured.";
+      }
+
+      leaf configured-emix-sequences {
+        type uint16;
+        description   
+         "Number of EMIX sequences currently configured, including
+          the system created ones.";
+      }
+
+      leaf configured-kpi-profiles {
+        type uint16;
+        description   
+         "Number of KPI profiles currently configured.";
+      }
+
+      leaf configured-bw-alloc-profiles {
+        type uint16;
+        description   
+         "Number of bandwidth distribution profiles currently
+          configured.";
+      }
+
+      leaf enabled-test-intancess {
+        type uint16;
+        description   
+         "Number of test instances currently enabled across
+          the platform.";
+      }
+
+      leaf generator-running-test-intancess {
+        type uint16;
+        description   
+         "Number of generator test instances currently running
+          across the platform.";
+      }
+    }
+
+    list entity {
+      key "name";
+
+      description
+        "Operational data for entity.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the service activation test entity.";
+      }
+
+      leaf id {
+        type uint32;
+        description 
+         "Entity unique ID assigned on creation by the system.";
+      }
+
+      leaf oper-state {
+        type ciena:oper-state;
+        description 
+         "Entity operational enable/disable. An entity
+          is operationally enabled when the feature is
+          enabled, the entity is enabled and at least one
+          test instance associated with that entity is 
+          enabled (reflector) or running (generator)";
+      }
+
+      leaf slot-id { 
+        type uint32;
+        description 
+         "The slot Id of the line module associated with this entity.
+          For non-distributed platforms or single card nodes, this is
+          always 1.";
+      }
+
+      leaf local-mac {
+        type yang:mac-address;
+        description 
+         "Mac address assigned to the SAT entity.";
+      }
+
+      leaf max-config-test-instances {
+        type uint16;
+        description 
+         "Maximum number of test instances that can
+          be configured on this entity.";
+      }
+
+      leaf max-simultaneous-test-instances {
+        type uint16;
+        description 
+         "Maximum number of test instances that can
+          be enabled (reflector) or running (generator)
+          on this entity, given the availability of 
+          hw sessions.";
+      }
+
+      leaf num-test-instances-configured {
+        type uint16;
+        description 
+         "Number of test instances currently configured
+          on this SAT entity.";
+      }
+
+      leaf num-test-instances-enabled {
+        type uint16;
+        description 
+         "Number of test instances currently enabled on this SAT entity.";
+      }
+
+      leaf gen-num-test-instances-running {
+        type uint16;
+        description 
+         "Number of test instances currently running on this generator entity. 
+          This information is only valid for generator entities.";
+      }
+
+      leaf bw-available {
+        type uint32;
+        description 
+         "Bandwidth in Mbps, available for test traffic if a reflector. 
+          Bandwidth remaining for other test instances to be started 
+          if this is a generator SAT entity.";
+      }
+
+      leaf gen-bw-used-by-running-tests {
+        type uint32;
+        description 
+         "Bandwidth used by test instances
+          currently running on this generator entity, in Mbps.";
+      }
+
+      leaf available-hw-sessions {
+        type uint32;
+        description 
+         "Maximum number of simultaneous hardware sessions available 
+          on this SAT entity.";
+      }
+
+      leaf allocated-hw-sessions {
+        type uint32;
+        description
+         "Number of hw sessions currently allocated to enabled test instances.";
+      }
+
+      container statistics {
+        description
+          "A collection of entity-related statistics objects.";
+
+        leaf tx-bytes {
+          type yang:counter64;
+          description 
+           "Number of bytes transmitted by the benchmark port";
+        }
+
+        leaf tx-pkts {
+          type yang:counter64;
+          description 
+           "Number of packets transmitted by the benchmark port";
+        }
+
+        leaf rx-bytes {
+          type yang:counter64;
+          description 
+           "Number of bytes received on the benchmark port.";
+        }
+
+        leaf rx-pkts {
+          type yang:counter64;
+          description 
+           "Number of packets received on the benchmark port.";
+        }
+
+        leaf miss-class-pkts {
+          type yang:counter64;
+          description 
+           "Test packets received that didn't match any enabled
+            test session.";
+        }
+
+        leaf crc-err-pkts {
+          type yang:counter64;
+          description 
+           "Test packets received with CRC errors";
+        }
+
+        leaf udp-chksum-err-pkts {
+          type yang:counter64;
+          description 
+           "Test packets received with UDP checksum errors";
+        }
+      }
+    }
+
+    list emix-sequence {
+      key "name";
+
+      description
+        "Emix sequence.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of this EMIX sequence";
+      }
+
+      leaf id {
+        type uint8 {
+          range "1..32";
+        }
+        description 
+         "Unique Id of the EMIX sequence entry";
+      }
+
+      leaf num-of-ref {
+        type uint16;
+        description 
+         "Number of generator test profiles currently
+          using this EMIX sequence for testing.
+          If this is the default EMIX sequence
+          set in the generator, that also counts
+          as one reference.";
+      }
+
+      leaf user-created {
+        type boolean;
+        description 
+         "Flag indicating whether this sequence was 
+          created by the user or by the system at
+          initialization. Only user created sequences
+          are editable.";
+      }
+    }
+
+    list gen-test-session-allocation {
+
+      key "entity-name 
+           test-instance-name 
+           untagged
+           pcp 
+           color";
+      description   
+       "Test session (aka hardware session) allocation entry.
+        If untagged is True, pcp and color are irrelevant.";
+
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Name of entity.";
+      }
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        description 
+         "Name of test instance.";
+      }
+    
+      leaf untagged {
+        type boolean;
+        description 
+          "Untagged.";
+      }
+
+      leaf pcp {
+        type priority;
+        description 
+         "PCP value.";
+      }
+
+      leaf color {
+        type basic-color;
+        description 
+         "Color - green or yellow only.";
+      }
+
+      leaf session-id {
+        type uint32 {
+          range "0..127";
+        }
+        description 
+         "Id of the hardware session allocated to the given
+          test instance, pcp and color for this entity.";
+      }
+
+      leaf emix-sequence-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description 
+         "EMIX sequence used with this session. If not set, 
+          this indicates that the the frame size list is being used
+          for the test and current-frame-size
+          indicates which packet size is currently being tested.";
+      }
+
+      leaf current-frame-size {
+        type uint32;
+        description 
+         "Packet size in bytes currently used by the running test.";
+      }
+
+      leaf throughput-test-state {
+        type ciena-sat:throughput-test-state-type;
+        description 
+         "State of the throughput test for this hardware session
+          defined by the test instance, pcp and color";
+      }
+
+      leaf frameloss-test-state {
+        type ciena-sat:frameloss-test-state-type;
+        description 
+         "State of the frameloss test for this hardware session
+          defined by the test instance, pcp and color";
+      }
+
+      leaf latency-test-state {
+        type ciena-sat:latency-pdv-test-state-type;
+        description 
+         "State of the latency test for this hardware session
+          defined by the test instance, pcp and color";
+      }
+
+      leaf pdv-test-state {
+        type ciena-sat:latency-pdv-test-state-type;
+        description 
+         "State of the PDV test for this hardware session
+          defined by the test instance, pcp and color";
+      }
+
+      leaf rfc2544-test-state {
+        type ciena-sat:rfc2544-test-state-type;
+        description 
+         "State of the RFC2544 test for this hardware session
+          defined by the test instance, pcp and color";
+      }
+
+      leaf y1564-test-state {
+        type ciena-sat:y1564-test-state-type;
+        description 
+         "State of the Y1564 test for this hardware session
+          defined by the test instance, pcp and color";
+      }
+
+      leaf outage-test-state {
+        type ciena-sat:outage-test-state-type;
+        description 
+         "State of the outage test for this hardware session
+          defined by the test instance, pcp and color";
+      }
+
+      leaf num-outages-so-far {
+        type uint32;
+        description 
+         "Outages detected so far";
+      }
+
+      leaf outage-progress {
+        type uint8;
+        description
+          "Percentage of outage test completed";
+      }
+
+      leaf current-rate {
+        type uint32;
+        description 
+         "Traffic rate currently used to generate packets as percent
+          of the line rate";
+      }
+
+      leaf samples-completed {
+        type uint32;
+        description 
+         "When latency and/or pdv is running, this indicates how 
+          many samples have been gathered so far.";
+      }
+    }
+
+    list test-instance-statistics {
+      key "entity-name 
+           test-instance-name";
+
+      description   
+       "Benchmark test instance packet statistics";
+
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Entity name.";
+      }
+
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        description 
+         "Test instance name.";
+      }
+
+      leaf rx-pkts {
+        type yang:counter64;
+        description 
+         "Total number of received packets for 
+          this test instance.";
+      }
+
+      leaf rx-ipv4-pkts {
+        type yang:counter64;
+        description 
+         "Total number of IPv4 packets received for
+          this test instance.";
+      }
+
+      leaf rx-ipv4-udp-pkts {
+        type yang:counter64;
+        description 
+         "Total number of IPv4 UDP packets received for
+          this test instance.";
+      }
+
+      leaf rx-ipv6-pkts {
+        type yang:counter64;
+        description 
+         "Total number of IPv6 packets received for
+          this test instance.";
+      }
+
+      leaf rx-ipv6-udp-pkts {
+        type yang:counter64;
+        description 
+         "Total number of IPv6 UDP packets received for
+          this test instance.";
+      }
+
+      leaf rx-non-ip-pkts {
+        type yang:counter64;
+        description 
+         "Total number of non-IP packets received for
+          this test instance.";
+      }
+
+      leaf rx-unrecognized-pkts {
+        type yang:counter64;
+        description 
+         "Total number of unrecognized packets received for
+          this test instance.";
+      }
+
+      leaf rx-duplicate-pkts {
+        type yang:counter64;
+        description 
+         "Total number of packets received with a duplicate
+          this test instance.";
+      }
+
+      leaf rx-duplicate-pkts-overflow {
+        type boolean;
+        description 
+         "When set to true, this indicates that the duplicate
+          pkt counter has rolled over in hardware and therefore,
+          rxDuplicate-pkts might not be accurate.";
+      }
+
+      leaf rx-ooo-pkts {
+        type yang:counter64;
+        description 
+         "Total number of packets received with an out of 
+          order sequence number. The sequence number was less
+          than the expected sequence number for this test instance.";
+      }
+
+      leaf rx-ooo-pkts-overflow {
+        type boolean;
+        description 
+         "When set to true, this indicates that the out of order
+          pkt counter has rolled over in hardware and therefore,
+          rxOOO-pkts might not be accurate.";
+      }
+
+      leaf rx-disc-seq-num-pkts {
+        type yang:counter64;
+        description 
+         "Total number of packets received with a sequence number
+          greater then the expected sequence number for this test instance.";
+      }
+
+      leaf rx-disc-seq-num-pkts-overflow {
+        type boolean;
+        description 
+         "When set to true, this indicates that the discontinuity
+          in sequence number pkt counter has rolled over in hardware
+          and therefore, rxDiscSeqNum-pkts might not be accurate.";
+      }
+
+      leaf tx-pkts {
+        type yang:counter64;
+        description 
+         "Total number of packets transmitted for this test instance.";
+      }
+    }
+
+    list gen-test-session-throughput-results {
+      key "entity-name
+           test-instance-name 
+           untagged
+           pcp 
+           color 
+           profile-frame-size-index";
+
+      description   
+       "generator test session throughput results.
+        If untagged is True, pcp and color are irrelevant.";
+
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Entity name.";
+      }
+
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        description 
+         "Test instance name.";
+      }
+
+      leaf untagged {
+        type boolean;
+        description 
+          "Untagged.";
+      }
+
+      leaf pcp {
+        type priority;
+        description 
+         "PCP value";
+      }
+
+      leaf color {
+        type basic-color;
+        description 
+         "Color - green or yellow only.";
+      }
+
+      leaf profile-frame-size-index {
+        type uint8 {
+          range "0..9";
+        }
+        description 
+         "Frame size index for which those throughput results are
+          for. When EMIX is used, in which case emix-sequence is 
+          not NULL, there is only one frame size index for
+          the given test instance, pcp and color. In such a case, the 
+          frame size index will be 0 and frame size will also be 0.";
+      }
+
+      leaf frame-size {
+        type uint32;
+        description 
+         "Packet size in bytes. If 0, then the emix-sequence indicates 
+          the name of the EMIX sequence used for the test";
+      }
+
+      leaf emix-sequence {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description 
+         "ID of the EMIX sequence that was used for running the
+          test which produced these results. When 0,
+          frame size indicates the size of the test frame
+          associated with these results.";
+      }
+
+      leaf min {
+        type ciena-sat:throughput-result;
+        description 
+         "Minimum throughput recorded for the given packet size 
+          in Mbps * 100. The value is multiplied by 100 to be able
+          to send the results as an integer but should be divided
+          by 100 when displayed to provide a 2 decimal point accuracy.
+          A result of 123.45 is sent as 12345.";
+      }
+
+      leaf max {
+        type ciena-sat:throughput-result;
+        description 
+         "Maximum throughput recorded for the given packet size
+          in Mbps * 100. The value is multiplied by 100 to be able
+          to send the results as an integer but should be divided
+          by 100 when displayed to provide a 2 decimal point accuracy.
+          A result of 123.45 is sent as 12345.";
+      }
+
+      leaf avg {
+        type ciena-sat:throughput-result;
+        description 
+         "Average throughput recorded for the given packet size
+          in Mbps * 100. The value is multiplied by 100 to be able
+          to send the results as an integer but should be divided
+          by 100 when displayed to provide a 2 decimal point accuracy.
+          A result of 123.45 is sent as 12345.";
+      }
+
+      leaf iterations {
+        type uint32;
+        description 
+         "Number of times the test has been run for this packet size.";
+      }
+
+      leaf kpi-result {
+        type ciena-sat:kpi-result-type;
+        description 
+         "Pass or fail results for the test which is determined
+          by comparing the max throughput against the selected 
+          KPI test instance's throughput pass criteria. If no KPI test instance
+          is selected for the given test instance Id, the result will
+          be 'notApplicable'.";
+      }
+    }
+
+    list gen-test-session-frameloss-results {
+      key "entity-name 
+           test-instance-name 
+           untagged
+           pcp 
+           color 
+           profile-frame-size-index 
+           rate-index";
+
+      description   
+       "generator test session frameloss results.
+        If untagged is True, pcp and color are irrelevant.";
+
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Entity name.";
+      }
+
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        description 
+         "Test instance name.";
+      }
+
+      leaf untagged {
+        type boolean;
+        description 
+          "Untagged.";
+      }
+
+      leaf pcp {
+        type priority;
+        description 
+         "PCP value.";
+      }
+
+      leaf color {
+        type basic-color;
+        description 
+         "Color - green or yellow only.";
+      }
+
+      leaf profile-frame-size-index {
+        type uint8 {
+          range "0..9";
+        }
+        description 
+         "Frame size index.";
+      }
+
+      leaf rate-index {
+        type uint8 {
+          range "0..9";
+        }
+        description 
+         "Rate index.";
+      }
+
+      leaf frame-size {
+        type uint32;
+        description 
+         "Packet size in bytes. If 0, then the emix-sequence
+          indicates the name of the EMIX sequence used for the test";
+      }
+
+      leaf emix-sequence {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description 
+         "EMIX sequence that was used for running the
+          test which produced these results. When not set,
+          frame size indicates the size of the test frame
+          associated with these results.";
+      }
+
+      leaf rate {
+        type uint32;
+        description 
+         "Rate in percent of line rate.";
+      }
+
+      leaf first {
+        type ciena-sat:frameloss-result;
+        description 
+         "Percentage of frames lost on first test sequence.";
+      }
+
+      leaf second {
+        type ciena-sat:frameloss-result;
+        description 
+         "Percentage of frames lost on second test sequence.";
+      }
+
+      leaf kpi-result {
+        type ciena-sat:kpi-result-type;
+        description 
+         "Pass or fail results for the test which is determined
+          by comparing the frameloss result against the selected 
+          KPI test instance's frameloss pass criteria. If no KPI test instance
+          is selected for the given test instance Id, the result will
+          be 'notApplicable'.";
+      }
+
+      leaf result {
+        type ciena-sat:frameloss-result;
+        description 
+         "Percentage of frames lost on the largest test sequence results.";
+      }
+    }
+
+    list gen-test-session-latency-results {
+      key "entity-name 
+           test-instance-name 
+           untagged
+           pcp 
+           color 
+           profile-frame-size-index";
+
+      description   
+       "generator test session latency results.
+        If untagged is True, pcp and color are irrelevant.";
+
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Entity name.";
+      }
+
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        description 
+         "Automagically generated leafref leaf.";
+      }
+
+      leaf untagged {
+        type boolean;
+        description 
+          "Untagged.";
+      }
+
+      leaf pcp {
+        type priority;
+        description 
+         "PCP value.";
+      }
+
+      leaf color {
+        type basic-color;
+        description 
+         "Color - green or yellow only.";
+      }
+
+      leaf profile-frame-size-index {
+        type uint8 {
+          range "0..9";
+        }
+        description 
+         "Frame size index.";
+      }
+
+      leaf frame-size {
+        type uint32;
+        description 
+         "Packet size in bytes.";
+      }
+
+      leaf emix-sequence {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description 
+         "Name of the EMIX sequence that was used for running the
+          test which produced these results. When not set,
+          frame size indicates the size of the test frame
+          associated with these results.";
+      }
+
+      leaf min {
+        type uint32;
+        description 
+         "Minimum latency recorded for the given packet size.";
+      }
+
+      leaf max {
+        type uint32;
+        description 
+         "Maximum latency recorded for the given packet size.";
+      }
+
+      leaf avg {
+        type uint32;
+        description 
+         "Average latency recorded for the given packet size.";
+      }
+
+      leaf samples {
+        type uint32;
+        description 
+         "Number of samples taken during the test.";
+      }
+
+      leaf kpi-result {
+        type ciena-sat:kpi-result-type;
+        description 
+         "Pass or fail results for the test which is determined
+          by comparing the frameloss result against the selected 
+          KPI test instance's latency pass criteria. If no KPI test instance
+          is selected for the given test instance Id, the result will
+          be 'notApplicable'.";
+      }
+    }
+
+    list gen-test-session-pdv-results {
+      key "entity-name 
+           test-instance-name 
+           untagged
+           pcp 
+           color 
+           frame-size-index";
+
+      description   
+       "generator test session packet delay variation results.
+        If untagged is True, pcp and color are irrelevant.";
+
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Entity name.";
+      }
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        description 
+         "Test instance name.";
+      }
+
+      leaf untagged {
+        type boolean;
+        description 
+          "Untagged.";
+      }
+
+      leaf pcp {
+        type priority;
+        description 
+         "PCP value.";
+      }
+
+      leaf color {
+        type basic-color;
+        description 
+         "Color - green or yellow only.";
+      }
+
+      leaf frame-size-index {
+        type uint8 {
+          range "0..9";
+        }
+        description 
+         "Frame size index associated with these PDV stats.";
+      }
+
+      leaf frame-size {
+        type uint32;
+        description 
+         "Packet size in bytes.";
+      }
+
+      leaf emix-sequence {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description 
+         "Name of the EMIX sequence that was used for running the
+          test which produced these results. When not set,
+          frame size indicates the size of the test frame
+          associated with these results.";
+      }
+
+      leaf avg {
+        type uint32;
+        description 
+         "Average PDV recorded for the given packet size.";
+      }
+
+      leaf samples {
+        type uint32;
+        description 
+         "Number of samples used for the test.";
+      }
+
+      leaf kpi-result {
+        type ciena-sat:kpi-result-type;
+        description 
+         "Pass or fail results for the test which is determined
+          by comparing the frameloss result against the selected 
+          KPI test instance's throughput PDV criteria. If no KPI test instance
+          is selected for the given test instance Id, the result will
+          be 'notApplicable'.";
+      }
+    }
+
+    list gen-test-session-outage-results {
+      key "entity-name 
+           test-instance-name 
+           untagged
+           pcp
+           color
+           frame-size-index";
+
+      description   
+       "generator test session frameloss results.
+        If untagged is True, pcp and color are irrelevant.";
+
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Entity name.";
+      }
+
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        description 
+         "Test instance name.";
+      }
+
+      leaf untagged {
+        type boolean;
+        description 
+          "Untagged.";
+      }
+
+      leaf pcp {
+        type priority;
+        description 
+         "PCP value.";
+      }
+
+      leaf color {
+        type basic-color;
+        description 
+         "Color - green or yellow only.";
+      }
+
+      leaf frame-size-index {
+        type uint8 {
+          range "0..9";
+        }
+        description 
+         "Frame size index associated with these PDV stats.";
+      }
+
+      leaf frame-size {
+        type uint32;
+        description 
+         "Packet size in bytes.";
+      }
+
+      leaf emix-sequence {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description 
+         "Name of the EMIX sequence that was used for running the
+          test which produced these results. When not set,
+          frame size indicates the size of the test frame
+          associated with these results.";
+      }
+
+      leaf outage-test-start-time {
+        type yang:date-and-time;
+        description 
+         "Date and time this outage test was started.";
+      }
+
+      leaf outage-test-end-time {
+        type yang:date-and-time;
+        description 
+         "Date and time this outage test ended.";
+      }
+
+      leaf total-outages {
+        type uint32;
+        description 
+         "Total number of outages, both recorded and unrecorded.";
+      }
+
+      leaf recorded-outages {
+        type uint32;
+        description 
+         "Number of recorded outages with detailed statistics.";
+      }
+
+      leaf sum-total-outages {
+        type uint64;
+        units "microseconds";
+        description 
+         "Sum of total outages, both recorded and unrecorded.";
+      }
+
+      leaf sum-recorded-outages {
+        type uint64;
+        units "microseconds";
+        description 
+         "Sum of recorded outages.";
+      }
+
+      leaf average-throughput {
+        type ciena-sat:throughput-result;
+        description 
+         "Average throughput recorded in Mbps * 100. 
+          The value is multiplied by 100 to be able
+          to send the results as an integer but should be divided
+          by 100 when displayed to provide a 2 decimal point accuracy.
+          A result of 123.45 is sent as 12345.";
+      }
+
+      leaf overall-kpi-result {
+        type ciena-sat:kpi-result-type;
+        description 
+         "Overall Pass or fail result for the test. 
+          FAIL if either sum-outages-kpi-result or 
+          max-outages-kpi-result or ANY of the single outage
+          kpi-result leaves are FAIL.
+          If no KPI instance is selected for the given 
+          test instance Id, the result will be 'notApplicable'.";
+      }
+
+      leaf sum-outages-kpi-result {
+        type ciena-sat:kpi-result-type;
+        description 
+         "Fail if the sum of recorded outages exceeds
+          the maximum KPI specified.
+          If no KPI test instance is selected for the given 
+          test instance Id, the result will be 'notApplicable'.";
+      }
+
+      leaf max-outages-kpi-result {
+        type ciena-sat:kpi-result-type;
+        description 
+         "Fail if the total number of outages exceeds
+          the maximum KPI specified.
+          If no KPI test instance is selected for the given 
+          test instance Id, the result will be 'notApplicable'.";
+      }
+
+      list per-outage {
+        key "outage-index";
+
+        description 
+          "Each of the first 128 outages has its own details.";
+
+        leaf outage-index {
+          type uint8 {
+            range "1..128";
+          }
+          description 
+           "Index of this individual outage entry";
+        }
+
+        leaf start-time {
+          type yang:date-and-time;
+          description 
+           "Date and time this individual outage began.";
+        }
+
+        leaf end-time {
+          type yang:date-and-time;
+          description 
+           "Date and time this individual outage ended.";
+        }
+ 
+        leaf length {
+          type uint64;
+          units "microseconds";
+          description
+           "Length of this individual outage in usecs.";
+        }
+
+        leaf frames-dropped {
+          type uint64;
+          description 
+           "Number of frames dropped during this outage.";
+        }
+
+        leaf kpi-result {
+          type ciena-sat:kpi-result-type;
+          description 
+           "Pass or fail results for the test which is determined
+            by comparing the duration against the selected KPI
+            test instance's single outage duration pass criteria. 
+            If no KPI test instance is selected for the given test 
+            instance Id, the result will be 'notApplicable'.";
+        }
+      }
+    }
+
+    list emix-character-set {
+      key "index";
+      description   
+       "EMIX character and its associated frame size.";
+
+      leaf index {
+        type uint8 {
+          range "1..26";
+        }
+        description 
+         "Character index.";
+      }
+
+      leaf character {
+        type string {
+          length "1";
+        }
+        description 
+         "EMIX character that can be used for creating an EMIX sequence.
+          The character set currently includes: a b c d e f g h u v w x  ";
+      }
+
+      leaf frame-size {
+        type string {
+          length "1..6";
+        }
+        description 
+         "Frame size associated with the character. For h, the frame size
+          is the port under test's MTU and the u character is a custom
+          frame size configurable for each EMIX. The u frame size can take 
+          a value of 64 to 10000 and defaults to 594. If u is bigger than
+          the MTU of the port under test, it will be reduced to the same
+          size as h.";
+      }
+    }
+
+    list emix-frame-size-for-sat-entity {
+      key "entity-name 
+           emix-sequence";
+
+      description   
+       "Frame size associated with given EMIX 
+        sequence and frame size index on a given Entity";
+
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Entity name.";
+      }
+      leaf emix-sequence {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:emix-sequence/ciena-sat:name";
+        }
+        description 
+         "Emix sequence name.";
+      }
+
+      leaf-list emix-frame-size {
+        type uint32 {
+          range "64..9216";
+        }
+        description 
+         "List of Frame sizes associated with the letters 
+          in the EMIX sequence.";
+      }
+
+      leaf avg-frame-size {
+        type uint32 {
+          range "64..9216";
+        }
+        description 
+         "Average frame size for the EMIX sequence on this entity.";
+      }
+    }
+
+    list kpi-profile {
+      key "name";
+      description   
+       "Key performance indicator pass/fail criteria.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the KPI profile";
+      }
+
+      leaf id {
+        type uint32 {
+          range "1..32";
+        }
+        description 
+         "Unique Id of the KPI profile entry";
+      }
+
+      leaf num-of-ref {
+        type uint32;
+        description 
+         "Number of generator test profiles currently
+          using this KPI profile for results analysis.
+          If this is the default KPI profile set in
+          the generator, that also counts as one reference.";
+      }
+    }
+
+    list bw-alloc-profile {
+      key "name";
+
+      description   
+       "BW allocation profile operational data.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the bandwidth allocation profile";
+      }
+
+      leaf id {
+        type uint32 {
+          range "1..32";
+        }
+        description 
+         "Unique Id of the bandwidth allocation
+          profile entry";
+      }
+
+      leaf num-of-ref {
+        type uint32;
+        description 
+         "Number of generator test profiles currently
+          using this bandwidth allocation profile
+          for testing.
+          If this is the default BW allocation
+          profile set in the generator, that also counts
+          as one reference.";
+      }
+    }
+
+    list test-profile {
+      key "name";
+
+      description
+        "Operational data for each test profile.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the test profile";
+      }
+
+      leaf id {
+        type uint32 {
+          range "1..256";
+        }
+        description 
+         "index for test profile records.";
+      }
+
+      leaf hw-sessions-required {
+        type uint32;
+        description 
+         "This represents the number of hardware sessions 
+          required to enable/run a test instance using 
+          this profile according to the profile's current
+          configuration.
+          One hardware session is required for each outer tag
+          PCP and color configured.
+          Ex 1) Encap type set to dot1q, c-pcp is 0,3 and 
+                c-color is set to green, 2 PCPs * 1 color =
+                2 hw sessions.
+          Ex 2) Encap type set to qinq, s-pcp is 0,4,5 and
+                s-color is set to green-yellow, then you
+                need 3 PCPs * 2 colors = 6 hw sessions.
+          Ex 3) Encap type set to untagged, only 1 hw session
+                is required.";
+      }
+
+      leaf num-of-ref {
+        type uint32;
+        description 
+         "Number of generator test instances currently
+          using this test profile for testing.";
+      }
+    }
+
+    list test-instance {
+      key "name";
+
+      description
+        "Operational data for a test instance.";
+
+      leaf name {
+        type name-string;
+        description 
+         "Name of the test instance";
+      }
+
+      leaf id {
+        type uint32 {
+          range "1..1280";
+        }
+        config false;
+        description 
+         "Unique identifier for the test instance.";
+      }
+
+      leaf current-interval {
+        type uint32;
+        description 
+         "Applicable to generator test instances, this indicates the 
+          number of intervals of the selected tests have been run, 
+          including the current one, in relation to the total number of
+          intervals to complete. This is based on the profile's
+          interval and duration configured.";
+      }
+
+      leaf total-intervals {
+        type uint32;
+        description 
+         "Applicable to generator test instances, this indicates the 
+          total number of intervals of the selected tests to be run
+          by a single start command on the test instance. This is 
+          based on the profile's interval and duration configured.
+          A value of 0 should be interpreted as unknown and -1 as
+          indefinite.";
+      }
+
+      leaf last-iteration-start-timestamp {
+        type yang:date-and-time;
+        description 
+         "Date and time of the last iteration that started since the 
+          last time the system was rebooted or the statistics were
+          cleared on the test instance.";
+      }
+
+      leaf assoc-entity {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        description 
+         "Name of the entity this test instance is associated with.";
+      }
+
+      leaf oper-state {
+        type ciena:oper-state;
+        description 
+         "Test instance operational enable/disable.";
+      }
+
+      leaf active-s-vid {
+        type uint32;
+        description 
+         "Active s-vid that is used by the Test-Instance. 
+         For Generator: it is user supplied vtag-stack when the 
+         test instance is created OR if not supplied, the value
+         configured in the test profile.
+         For Reflector: The active s-vid is provided on create 
+         Test-Instance, if not * or untagged 0 means not configured,
+         and FFFF means any s-vid.";
+      }
+
+      leaf active-c-vid {
+        type uint32;
+        description 
+         "Active c-vid that is used by the Test-Instance. 
+         For Generator: it is user supplied vtag-stack when the 
+         test instance is created OR if not supplied, the value
+         configured in the test profile.
+         For Reflector: The active c-vid is provided on create 
+         Test-Instance, if not * or untagged 0 means not configured,
+         and FFFF means any c-vid.";
+      }
+
+      leaf active-untagged-data {
+        type boolean;
+        description 
+         "When set to true, this indicates that the test instance
+          is associated with untagged data traffic. When this is 
+          set, the active-s-vid and active-c-vid parameters are 0.";
+      }
+
+      leaf active-dst-mac {
+      type yang:mac-address;
+      description
+        " Destination MAC address used for generator test 
+          instances. When set, this over writes the value 
+          specified in the referenced test profile.This 
+          field is not applicable for reflector TI.";
+      }
+
+      leaf active-start-bw {
+        type uint32;
+        description 
+         "Port Under Test's max bandwidth, if RFC-2544 is 
+          set in bandwidth profile, else bandwidth specified 
+          in bandwidth profile. This field is not applicable
+          for reflector TI.";
+      }
+    }
+  }
+
+
+  /*
+   * RPC Operations
+   */
+
+  rpc entity-clear-statistics {
+    description
+      "Clear the statistics/counters of the targeted SAT entity.";
+
+    input {
+      leaf entity-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:entity/ciena-sat:name";
+        }
+        mandatory "true";
+        description
+          "Name of a SAT entity to clear counters for. A reflector SAT entity
+           has to be disabled in order to be able to clear its counters. A
+           generator SAT entity cannot have any running test instances for 
+           a request to clear its counters to be successful.";
+      }
+    }
+    output {
+      leaf status {
+        type string;
+        description
+          "Status of the clear statistics operation.";
+      }
+    }
+  }
+
+  rpc test-instance-start {
+    description
+      "Start testing for the targeted generator test instance.";
+
+    input {
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        mandatory "true";
+        description
+          "Name of the generator test instance for which to initiate testing.";
+      }
+    }
+    output {
+      leaf status {
+        type string;
+        description
+          "Status of the start test operation.";
+      }
+    }
+  }
+
+  rpc test-instance-stop {
+    description
+      "Stop testing for the targeted generator test instance.";
+
+    input {
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        mandatory "true";
+        description
+          "Name of the generator test instance for which to abort testing.";
+      }
+    }
+    output {
+      leaf status {
+        type string;
+        description
+          "Status of the stop test operation.";
+      }
+    }
+  }
+
+  rpc test-instance-connectivity-test {
+    description
+      "Perform a connectivity test for the targeted generator test instance.";
+    input {
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        mandatory "true";
+        description
+          "Name of the generator test instance targeted by this action.";
+      }
+    }
+    output {
+      leaf status {
+        type string;
+        description
+          "Status of the trigger test operation.";
+      }
+    }
+  }
+
+  rpc test-instance-clear-statistics {
+    description
+      "Clear the results and counters for the targeted test instance.";
+
+    input {
+      leaf test-instance-name {
+        type leafref {
+          path "/ciena-sat:sat/ciena-sat:test-instance/ciena-sat:name";
+        }
+        mandatory "true";
+        description
+          "Name of the test instance targeted by this action. Reflector test
+           instances have to be disabled prior to clearing their counters,
+           and geneartor test instances cannot be running tests.";
+      }
+    }
+    output {
+      leaf status {
+        type string;
+        description
+          "Status of the clear statistics operation.";
+      }
+    }
+  }
+
+
+  /*
+   * Notifications  - Not supported in 6.16.1
+   */
+
+  notification test-started {
+    description
+      "Testing for this generator test instance has been initiated.";
+
+    uses notification-base-fields;
+
+    leaf port {
+      type mef-logical-port:logical-port-ref;
+      description
+        "port under test.";
+    }
+    leaf svid {
+      type ieee:vlanid;
+      description
+        "S-VID.";
+    }
+    leaf cvid {
+      type ieee:vlanid;
+      description
+        "C-VID.";
+    }
+    leaf dst-mac {
+      type yang:mac-address;
+      description
+        "Mac address.";
+    }
+  }
+
+  notification test-stopped {
+    description
+      "Testing for this generator test instance has been stopped.";
+
+    uses notification-base-fields;
+  }
+
+  notification test-completed {
+    description
+      "Testing for this generator test instance has completed.";
+
+    uses notification-base-fields;
+  }
+
+  notification test-iteration-completed {
+    description
+      "Testing for this generator test instance has completed.";
+
+    uses notification-base-fields;
+
+    leaf iteration {
+      type uint32;
+      description
+        "iteration.";
+    }
+  }
+
+  notification test-throughput-kpi-failure {
+    description
+      "This generator test instance's iteration throughput results are 
+       below the set KPI value.";
+
+    uses notification-test-kpi-fields;
+
+    leaf throughput-result {
+      type uint32;
+      description
+        "Maximum throughput recorded for the given packet size
+         in Mbps * 100. The value is multiplied by 100 to be able
+         to send the results as an integer but should be divided
+         by 100 when displayed to provide a 2 decimal point accuracy.
+         A result of 123.45 is sent as 12345.";
+    }
+  }
+
+  notification test-frameloss-kpi-failure {
+    description
+      "This generator test instance's iteration frameloss results are 
+       above the set KPI value.";
+
+    uses notification-test-kpi-fields;
+
+    leaf frameloss-result {
+      type uint32;
+      description
+        "Frame loss results in Percent of frame loss start bandwidth
+         are sent as unsigned integer multitplied by 100 to provide a
+         2 decimal point accuracy.
+         If result is 12.34 %, it is sent as 1234 and should
+         be divided by 100 by the application retrieving the
+         data.";
+    }
+  }
+
+  notification test-latency-kpi-failure {
+    description
+      "This generator test instance's iteration latency results are 
+       above the set KPI value.";
+
+    uses notification-test-kpi-fields;
+
+    leaf latency-result {
+      type uint32;
+      description
+        "Maximum latency recorded for the given packet size.";
+    }
+  }
+
+  notification test-pdv-kpi-failure {
+    description
+      "This generator test instance's iteration packet delay variation 
+       results are above the set KPI value.";
+
+    uses notification-test-kpi-fields;
+
+    leaf pdv-result {
+      type uint32;
+      description
+        "Average PDV recorded for the given packet size.";
+    }
+  }
+
+  notification test-outage-max-number-kpi-failure {
+    description
+      "This generator test instance's outage results do not
+       meet the set KPI values for max number of outages.";
+
+    uses notification-test-kpi-fields;
+
+    leaf num-outages {
+      type uint32;
+      description
+        "Number of outages that occurred during the outage test.";
+    }
+  }
+
+  notification test-outage-single-outage-kpi-failure {
+    description
+      "This generator test instance's iteration outage
+       results do not meet the set KPI values.";
+
+    uses notification-test-kpi-fields;
+
+    leaf single-outage-max-duration {
+      type uint64;
+      units "microseconds";
+      description
+        "Length of maximum individual outage in usecs.";
+    }
+  }
+
+  notification test-outage-sum-outages-kpi-failure {
+    description
+      "This generator test instance's outage results do not
+       meet the set KPI values for max time of total recorded outages.";
+
+    uses notification-test-kpi-fields;
+
+    leaf sum-recorded-outages {
+      type uint64;
+      units "microseconds";
+      description 
+        "Time in micro-seconds of the sum of recorded outages.";
+    }
+  }
+}

--- a/vendor/ciena/ciena-types.yang
+++ b/vendor/ciena/ciena-types.yang
@@ -1,0 +1,588 @@
+module ciena-types {
+  namespace "http://www.ciena.com/ns/yang/ciena-types";
+  prefix "ciena-types";
+  
+  import ietf-inet-types {
+    prefix inet;
+  }
+  
+  organization
+    "Ciena Corporation";
+  
+  contact
+    "Web URL: http://www.ciena.com/
+     E-mail:  yang@ciena.com
+     Postal:  7035 Ridge Road
+              Hanover, Maryland 21076
+              U.S.A.
+     Phone:   +1 800-921-1144
+     Fax:     +1 410-694-5750";
+
+  description
+    "This YANG module defines Ciena standard types and groupings.
+
+     Copyright (c) 2016 Ciena Corporation.  All rights 
+     reserved.
+
+     All information contained herein is, and remains
+     the property of Ciena Corporation. Dissemination of this 
+     information or reproduction of this material is strictly 
+     forbidden unless prior written permission is obtained from 
+     Ciena Corporation.";
+  
+  revision 2016-05-11 {
+    description 
+      "Initial version";
+    reference
+      "RFC 6020: YANG - A Data Modeling Language for
+       the Network Configuration Protocol (NETCONF).
+       No specific reference; standard not available.";
+  }
+  
+  /*
+   * Typedefs
+   */
+  typedef state {
+    type enumeration {
+      enum disabled {
+        description
+        "The node is disabled.";
+      }
+      enum enabled {
+        description
+        "The node is enabled.";
+      }
+    }
+    description
+      "The state of the node.";
+  }
+  
+  typedef admin-state {
+    type state;
+    description
+      "The admin state of the node.";
+  }
+  
+  typedef oper-state {
+    type state;
+    description
+      "The oper state of the node.";
+  }
+
+  typedef on-off-state {
+    type enumeration {
+      enum off {
+        description 
+          "The off state.";
+      }
+      enum on {
+        description 
+          "The on state.";
+      }
+    }
+    description 
+      "The on / off state.";
+  } 
+
+  typedef event-severity {
+    type enumeration {
+      enum critical {
+        description
+          "The critical severity.";
+      }
+      enum major {
+        description
+          "The major severity.";
+      }
+      enum minor {
+        description
+          "The minor severity.";
+      }
+      enum warning {
+        description
+          "The warning severity.";
+      }
+      enum config {
+        description
+          "The config severity.";
+      }
+      enum info {
+        description
+          "The info severity.";
+      }
+      enum debug {
+        description
+          "The debug severity.";
+      }
+    }
+    description
+      "The system event severity.";
+  }
+  
+
+  typedef slot-index {
+    type enumeration {
+      enum non-existent {
+        value -1;
+        description
+          "Non-existent slot.";
+      }
+      enum zero {
+        value 0;
+        description
+          "Reserved slot number.";
+      }
+      enum lm1 {
+        value 1;
+        description
+          "Slot LM1.";
+      }
+      enum lm2 {
+        value 2;
+        description
+          "Slot LM2.";
+      }
+      enum lm3 {
+        value 3;
+        description
+          "Slot LM3.";
+      }
+      enum lm4 {
+        value 4;
+        description
+          "Slot LM4.";
+      }
+      enum lm5 {
+        value 5;
+        description
+          "Slot LM5.";
+      }
+      enum lm6 {
+        value 6;
+        description
+          "Slot LM6.";
+      }
+      enum lm7 {
+        value 7;
+        description
+          "Slot LM7.";
+      }
+      enum lm8 {
+        value 8;
+        description
+          "Slot LM8.";
+      }
+      enum lm9 {
+        value 9;
+        description
+          "Slot LM9.";
+      }
+      enum lm10 {
+        value 10;
+        description
+          "Slot LM10.";
+      }
+      enum lm11 {
+        value 11;
+        description
+          "Slot LM11.";
+      }
+      enum lm12 {
+        value 12;
+        description
+          "Slot LM12.";
+      }
+      enum lm13 {
+        value 13;
+        description
+          "Slot LM13.";
+      }
+      enum lm14 {
+        value 14;
+        description
+          "Slot LM14.";
+      }
+      enum lm15 {
+        value 15;
+        description
+          "Slot LM15.";
+      }
+      enum lm16 {
+        value 16;
+        description
+          "Slot LM16.";
+      }
+      enum lm17 {
+        value 17;
+        description
+          "Slot LM17.";
+      }
+      enum lm18 {
+        value 18;
+        description
+          "Slot LM18.";
+      }
+      enum lm19 {
+        value 19;
+        description
+          "Slot LM19.";
+      }
+      enum lm20 {
+        value 20;
+        description
+          "Slot LM20.";
+      }
+      enum lm21 {
+        value 21;
+        description
+          "Slot LM21.";
+      }
+      enum lm22 {
+        value 22;
+        description
+          "Slot LM22.";
+      }
+      enum lm23 {
+        value 23;
+        description
+          "Slot LM23.";
+      }
+      enum lm24 {
+        value 24;
+        description
+          "Slot LM24.";
+      }
+      enum lm25 {
+        value 25;
+        description
+          "Slot LM25.";
+      }
+      enum lm26 {
+        value 26;
+        description
+          "Slot LM26.";
+      }
+      enum lm27 {
+        value 27;
+        description
+          "Slot LM27.";
+      }
+      enum lm28 {
+        value 28;
+        description
+          "Slot LM28.";
+      }
+      enum lm29 {
+        value 29;
+        description
+          "Slot LM29.";
+      }
+      enum lm30 {
+        value 30;
+        description
+          "Slot LM30.";
+      }
+      enum ctm1 {
+        value 31;
+        description
+          "Slot CTM1 (CTX1).";
+      }
+      enum ctm2 {
+        value 32;
+        description
+          "Slot CTM2 (CTX2).";
+      }
+      enum ctx1 {
+        value 33;
+        description
+          "Slot CTX1. Non-existent alias sometimes used for ctm1.";
+      }
+      enum ctx2 {
+        value 34;
+        description
+          "Slot CTX2. Non-existent alias sometimes used for ctm1.";
+      }
+      enum sm1 {
+        value 35;
+        description
+          "Slot SM1. May be an alilas for CTX1.sm depending on the platform.";
+      }
+      enum sm2 {
+        value 36;
+        description
+          "Slot SM2. May be an alias for CTX2.sm depending on the platform.";
+      }
+      enum sm3 {
+        value 37;
+        description
+          "Slot SM3. May be an alias for SM depending on the platform.";
+      }
+      enum sm4 {
+        value 38;
+        description
+          "Slot SM4.";
+      }
+      enum sm5 {
+        value 39;
+        description
+          "Slot SM5.";
+      }
+      enum pdu1 {
+        value 40;
+        description
+          "Slot PDU1.  May be PDU-A1 or PDU-A depending of the platform.";
+      }
+      enum pdu2 {
+        value 41;
+        description
+          "Slot PDU2.  May be PDU-B1 or PDU-B depending of the platform.";
+      }
+      enum pdu3 {
+        value 42;
+        description
+          "Slot PDU3.";
+      }
+      enum pdu4 {
+        value 43;
+        description
+          "Slot PDU3.";
+      }
+      enum pdu5 {
+        value 44;
+        description
+          "Slot PDU3.";
+      }
+      enum pdu6 {
+        value 45;
+        description
+          "Slot PDU3.";
+      }
+      enum pdu7 {
+        value 46;
+        description
+          "Slot PDU3.";
+      }
+      enum pdu8 {
+        value 47;
+        description
+          "Slot PDU3.";
+      }
+      enum cfu1 {
+        value 48;
+        description
+          "Slot CFU1.";
+      }
+      enum cfu2 {
+        value 49;
+        description
+          "Slot CFU2.";
+      }
+      enum io {
+        value 50;
+        description
+          "Slot IO.";
+      }
+      enum chassis {
+        value 58;
+        description
+          "Chassis.";
+      }
+    }
+    description
+      "Chassis slot indexing";
+  }
+
+  /*
+   * Identities
+   */
+  
+  /*
+   * Features
+   */
+  feature saos-6x {
+    description
+      "This feature string is returned by the netconf server if running on a 6.x device.";
+  }
+  
+  feature saos-8x {
+    description
+      "This feature string is returned by the netconf server if running on a 8.x device.";
+  }
+
+  /////
+  // These may need to go into their feature specific YANG.
+  /////
+  feature pm {
+    description
+      "This feature string is returned by the netconf server if PM is supported.";
+  }
+
+  feature protocol-filters {
+    description
+      "This feature string is returned by the netconf server if protocol filters are supported.";
+  }
+
+  feature pwe-module {
+    description
+      "This feature string is returned by the netconf server if the PWE module is supported.";
+  }
+
+  feature vpls-fpga {
+    description
+      "This feature string is returned by the netconf server if the VPLS FPGA is supported.";
+  }
+
+  feature pbt {
+    description
+      "This feature string is returned by the netconf server if PBT is supported.";
+  }
+
+  feature mpls {
+    description
+      "This feature string is returned by the netconf server if MPLS is supported.";
+  }
+
+  feature max-vc-l2xforms {
+    description
+      "This feature string is returned by the netconf server if max VC L2 transforms are supported.";
+  }
+
+  feature max-queue-groups {
+    description
+      "This feature string is returned by the netconf server if max queue groups are supported.";
+  }
+
+  feature raps {
+    description
+      "This feature string is returned by the netconf server if ring protection is supported.";
+  }
+
+  feature network-sync {
+    description
+      "This feature string is returned by the netconf server if network sync is supported.";
+  }
+
+  feature bits-timing {
+    description
+      "This feature string is returned by the netconf server if bits timing is supported.";
+  }
+  
+  feature gps-timing {
+    description
+      "This feature string is returned by the netconf server if gps timing is supported.";
+  }
+
+  feature ptp-timing {
+    description
+      "This feature string is returned by the netconf server if ptp timing is supported.";
+  }
+
+  feature benchmark {
+    description
+      "This feature string is returned by the netconf server if the benchmark feature is supported.";
+  }
+
+  feature benchmark-reflector {
+    description
+      "This feature string is returned by the netconf server if the benchmark reflector feature is supported.";
+  }
+
+  feature benchmark-generator {
+    description
+      "This feature string is returned by the netconf server if the benchmark generator feature is supported.";
+  }
+
+  feature benchmark-non-fpga-reflector {
+    description
+      "This feature string is returned by the netconf server if the benchmark non-FPGA reflector feature is supported.";
+  }
+
+  feature benchmark-non-fpga-generator {
+    description
+      "This feature string is returned by the netconf server if the benchmark non-FPGA generator feature is supported.";
+  }
+
+  ////
+  // End feature specific
+  ////
+
+  /*
+   * Groupings
+   */
+
+  grouping security-password {
+    description
+      "Reusable grouping for security passwords and secrets.";
+    
+    choice security {
+      description
+        "Leafs for password or secret input.  These leafs will update the current-secret and may not return any data.";
+      
+      leaf password {
+        type string;
+        description
+          "The string used for the clear text password.  No data will be returned from this leaf.
+           This leaf will update the contents of the curent-secret leaf.";
+      }
+      leaf secret {
+        type string;
+        description
+          "The string used for the cipher text which may be encrypted or hashed.
+           This leaf will update the contents of the curent-secret leaf.";
+      }
+    }
+
+    leaf current-secret {
+      config false;
+      type string;
+      description
+        "The current string used for the cipher text which may be encrypted or hashed.";
+    }
+  }
+
+  grouping security-key {
+    description
+      "Reusable grouping for security keys and secrets.";
+    
+    choice security {
+      description
+        "Leafs for key or secret input.  These leafs will update the current-secret and may not return any data.";
+      
+      leaf key {
+        type string;
+        description
+          "The string used for the clear text key.  No data will be returned from this leaf.
+           This leaf will update the contents of the curent-secret leaf.";
+      }
+      leaf secret {
+        type string;
+        description
+          "The string used for the cipher text which may be encrypted or hashed.
+           This leaf will update the contents of the curent-secret leaf.";
+      }
+    }
+
+    leaf current-secret {
+      config false;
+      type string;
+      description
+        "The current string used for the cipher text which may be encrypted or hashed.";
+    }
+  }
+    
+  // Hostname and IP resolve.
+  grouping resolved-address {
+    description
+      ".";
+    leaf hostname {
+      type inet:host;
+      description
+        "Hostname of the device.";
+    }
+    leaf address {
+      type inet:ip-address;
+      description
+        "Resolved IP address of the device.";
+    }
+  }
+}


### PR DESCRIPTION
**ciena-mef-access-flow.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-access-flow
    +--rw acl-custom-destinations
    |  +--rw acl-custom-destination* [name]
    |     +--rw name           string
    |     +--rw description?   string
    |     +--rw destination?   enumeration
    +--rw acl-actions
    |  +--rw acl-action* [name]
    |     +--rw name            string
    |     +--rw description?    string
    |     +--rw action?         enumeration
    |     +--rw (destination)?
    |        +--:(logical-port-list)
    |        |  +--rw logical-port*   mef-logical-port:logical-port-ref
    |        +--:(flow-point-list)
    |        |  +--rw flow-point*     mef-fp:fp-ref
    |        +--:(custom-list)
    |           +--rw custom*         acl:custom-destination-ref
    +--rw access-flows
    |  +--rw access-flow* [name]
    |     +--rw name                     string
    |     +--rw description?             string
    |     +--rw classifier-list*         classifier:classifier-ref
    |     +--rw classifier-precedence?   uint32
    |     +--rw (parent-interface)?
    |     |  +--:(none)
    |     |  |  +--rw none?                    empty
    |     |  +--:(logical-port)
    |     |  |  +--rw parent-port*             mef-logical-port:logical-port-ref
    |     |  +--:(flow-point)
    |     |     +--rw parent-fp*               mef-fp:fp-ref
    |     +--rw filter-action?           enumeration
    |     +--rw augment-action*          acl:acl-action-ref
    |     +--rw stats-collection?        enumeration
    +--rw access-profiles
    |  +--rw access-profile* [name]
    |     +--rw name                     string
    |     +--rw description?             string
    |     +--rw access-flow-rule*        acl:access-flow-ref
    |     +--rw default-filter-action?   enumeration
    |     +--rw stats-collection?        enumeration
    +--ro access-flows-state
    |  +--ro access-flow* [name]
    |     +--ro name         string
    |     +--ro hitBytes?    uint64
    |     +--ro hitFrames?   uint64
    +--ro acl-actions-state
       +--ro access-action* [name]
       |  +--ro name                        string
       |  +--ro number-of-attached-rules?   uint16
       +--ro defined-acl-actions?               uint16
       +--ro remaining-acl-actions-available?   uint16
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-fd.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-fd
    +--rw fds
    |  +--rw fd* [name]
    |     +--rw name                                string
    |     +--rw description?                        string
    |     +--rw mode?                               enumeration
    |     +--rw vlan-id                             uint16
    |     +--rw mac-learning?                       enumeration
    |     +--rw l2cp-profile?                       mef-l2cp:l2cp-profile-ref
    |     +--rw flood-containment-profile?          mef-fc:flood-containment-profile-ref
    |     +--rw pfg-profile?                        mef-pfg:pfg-profile-ref
    |     +--rw cos-queue-map?                      mef-egress-qos:cos-queue-map-ref
    |     +--rw queue-group-indirection?            mef-egress-qos:queue-group-indirection-ref
    |     +--rw initiate-l2-transform
    |     |  +--rw (frame-type)?
    |     |     +--:(stack)
    |     |        +--rw vlan-stack* [tag]
    |     |           +--rw tag          uint8
    |     |           +--rw (action)?
    |     |              +--:(push)
    |     |                 +--rw push-tpid?   enumeration
    |     |                 +--rw push-pcp?    enumeration
    |     |                 +--rw push-dei?    enumeration
    |     |                 +--rw push-vid     vlan-id
    |     +--rw initiate-cos-to-frame-map?          ctf:cos-to-frame-ref
    |     +--rw (initiate-frame-to-cos)?
    |        +--:(map)
    |        |  +--rw initiate-frame-to-cos-map-policy?   enumeration
    |        |  +--rw initiate-frame-to-cos-map?          ftc:frame-to-cos-ref
    |        +--:(fixed)
    |           +--rw cos?                                uint8
    |           +--rw color?                              enumeration
    +--ro fds-state
       +--ro fd* [name]
          +--ro name    string
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-sat.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-sat
    +--rw sat
    |  +--rw sat-global
    |  |  +--rw admin-state?                          ciena:admin-state
    |  |  +--rw default-emix-sequence?                -> /sat/emix-sequence/name
    |  |  +--rw generator-default-kpi-profile?        -> /sat/kpi-profile/name
    |  |  +--rw generator-default-bw-alloc-profile?   -> /sat/bw-alloc-profile/name
    |  +--rw entity* [name]
    |  |  +--rw name                        name-string
    |  |  +--rw port?                       mef-logical-port:logical-port-ref
    |  |  +--rw role?                       enumeration
    |  |  +--rw generator-h-frame-size?     uint32
    |  |  +--rw assoc-gen-vendor-type?      enumeration
    |  |  +--rw reflection-level?           enumeration
    |  |  +--rw reflector-mac-validation?   boolean
    |  |  +--rw mode?                       enumeration
    |  |  +--rw admin-state?                ciena:admin-state
    |  +--rw emix-sequence* [name]
    |  |  +--rw name            name-string
    |  |  +--rw sequence?       string
    |  |  +--rw u-frame-size?   uint32
    |  +--rw kpi-profile* [name]
    |  |  +--rw name        name-string
    |  |  +--rw pcp* [pcp-value]
    |  |  |  +--rw pcp-value            priority
    |  |  |  +--rw throughput?          ciena-sat:throughput-kpi-percent
    |  |  |  +--rw frameloss?           ciena-sat:frameloss-kpi-percent
    |  |  |  +--rw latency?             uint32
    |  |  |  +--rw pdv?                 uint32
    |  |  |  +--rw single-outage-max?   uint32
    |  |  |  +--rw sum-outages-max?     uint32
    |  |  |  +--rw max-num-outages?     uint32
    |  |  +--rw untagged
    |  |     +--rw throughput?          ciena-sat:throughput-kpi-percent
    |  |     +--rw frameloss?           ciena-sat:frameloss-kpi-percent
    |  |     +--rw latency?             uint32
    |  |     +--rw pdv?                 uint32
    |  |     +--rw single-outage-max?   uint32
    |  |     +--rw sum-outages-max?     uint32
    |  |     +--rw max-num-outages?     uint32
    |  +--rw bw-alloc-profile* [name]
    |  |  +--rw name    name-string
    |  |  +--rw pcp* [pcp-value]
    |  |     +--rw pcp-value    priority
    |  |     +--rw ratio?       uint32
    |  +--rw test-profile* [name]
    |  |  +--rw name                  name-string
    |  |  +--rw bandwidth?            uint32
    |  |  +--rw excess-bandwidth?     uint32
    |  |  +--rw interval?             enumeration
    |  |  +--rw duration?             enumeration
    |  |  +--rw frame-size*           uint32
    |  |  +--rw max-searches?         uint8
    |  |  +--rw max-samples?          uint8
    |  |  +--rw sampling-interval?    uint16
    |  |  +--rw frameloss-start-bw?   enumeration
    |  |  +--rw vid-validation?       boolean
    |  |  +--rw pcp-validation?       boolean
    |  |  +--rw color-validation?     boolean
    |  |  +--rw kpi-profile-name?     -> /sat/kpi-profile/name
    |  |  +--rw bw-alloc-profile?     -> /sat/bw-alloc-profile/name
    |  |  +--rw emix-sequence?        -> /sat/emix-sequence/name
    |  |  +--rw encap-type?           enumeration
    |  |  +--rw pdu-type?             enumeration
    |  |  +--rw dst-mac?              yang:mac-address
    |  |  +--rw s-vid?                ieee:vlanid
    |  |  +--rw s-pcp?                ciena-sat:pcp-bitmap
    |  |  +--rw s-color?              ciena-sat:color
    |  |  +--rw c-vid?                ieee:vlanid
    |  |  +--rw c-pcp?                ciena-sat:pcp-bitmap
    |  |  +--rw c-color?              ciena-sat:color
    |  |  +--rw tpid?                 enumeration
    |  |  +--rw dscp?                 inet:dscp
    |  |  +--rw src-addr?             inet:ip-address
    |  |  +--rw dst-addr?             inet:ip-address
    |  |  +--rw custom-payload?       binary
    |  |  +--rw throughput-test?      boolean
    |  |  +--rw frameloss-test?       boolean
    |  |  +--rw latency-test?         boolean
    |  |  +--rw pdv-test?             boolean
    |  |  +--rw burst-test?           boolean
    |  |  +--rw rfc2544-suite?        boolean
    |  |  +--rw y1564-suite?          boolean
    |  |  +--rw outage-test?          boolean
    |  +--rw test-instance* [name]
    |     +--rw name             name-string
    |     +--rw flow-point-id?   mef-fp:fp-ref
    |     +--rw profile?         -> /sat/test-profile/name
    |     +--rw s-vid?           uint16
    |     +--rw c-vid?           uint16
    |     +--rw untagged?        boolean
    |     +--rw dst-mac?         yang:mac-address
    |     +--rw admin-state?     ciena:admin-state
    +--ro sat-state
       +--ro sat-global
       |  +--ro platform-max-config-entities?              uint16
       |  +--ro platform-max-config-test-intancess?        uint16
       |  +--ro platform-max-config-test-profiles?         uint16
       |  +--ro platform-max-config-kpi-profiles?          uint16
       |  +--ro platform-max-config-bw-alloc-profiles?     uint16
       |  +--ro platform-max-config-emix-sequences?        uint16
       |  +--ro platform-max-simultaneous-running-tests?   uint16
       |  +--ro configured-entities?                       uint16
       |  +--ro configured-test-intances?                  uint16
       |  +--ro configured-profiles?                       uint16
       |  +--ro configured-emix-sequences?                 uint16
       |  +--ro configured-kpi-profiles?                   uint16
       |  +--ro configured-bw-alloc-profiles?              uint16
       |  +--ro enabled-test-intancess?                    uint16
       |  +--ro generator-running-test-intancess?          uint16
       +--ro entity* [name]
       |  +--ro name                               name-string
       |  +--ro id?                                uint32
       |  +--ro oper-state?                        ciena:oper-state
       |  +--ro slot-id?                           uint32
       |  +--ro local-mac?                         yang:mac-address
       |  +--ro max-config-test-instances?         uint16
       |  +--ro max-simultaneous-test-instances?   uint16
       |  +--ro num-test-instances-configured?     uint16
       |  +--ro num-test-instances-enabled?        uint16
       |  +--ro gen-num-test-instances-running?    uint16
       |  +--ro bw-available?                      uint32
       |  +--ro gen-bw-used-by-running-tests?      uint32
       |  +--ro available-hw-sessions?             uint32
       |  +--ro allocated-hw-sessions?             uint32
       |  +--ro statistics
       |     +--ro tx-bytes?              yang:counter64
       |     +--ro tx-pkts?               yang:counter64
       |     +--ro rx-bytes?              yang:counter64
       |     +--ro rx-pkts?               yang:counter64
       |     +--ro miss-class-pkts?       yang:counter64
       |     +--ro crc-err-pkts?          yang:counter64
       |     +--ro udp-chksum-err-pkts?   yang:counter64
       +--ro emix-sequence* [name]
       |  +--ro name            name-string
       |  +--ro id?             uint8
       |  +--ro num-of-ref?     uint16
       |  +--ro user-created?   boolean
       +--ro gen-test-session-allocation* [entity-name test-instance-name untagged pcp color]
       |  +--ro entity-name              -> /sat/entity/name
       |  +--ro test-instance-name       -> /sat/test-instance/name
       |  +--ro untagged                 boolean
       |  +--ro pcp                      priority
       |  +--ro color                    basic-color
       |  +--ro session-id?              uint32
       |  +--ro emix-sequence-name?      -> /sat/emix-sequence/name
       |  +--ro current-frame-size?      uint32
       |  +--ro throughput-test-state?   ciena-sat:throughput-test-state-type
       |  +--ro frameloss-test-state?    ciena-sat:frameloss-test-state-type
       |  +--ro latency-test-state?      ciena-sat:latency-pdv-test-state-type
       |  +--ro pdv-test-state?          ciena-sat:latency-pdv-test-state-type
       |  +--ro rfc2544-test-state?      ciena-sat:rfc2544-test-state-type
       |  +--ro y1564-test-state?        ciena-sat:y1564-test-state-type
       |  +--ro outage-test-state?       ciena-sat:outage-test-state-type
       |  +--ro num-outages-so-far?      uint32
       |  +--ro outage-progress?         uint8
       |  +--ro current-rate?            uint32
       |  +--ro samples-completed?       uint32
       +--ro test-instance-statistics* [entity-name test-instance-name]
       |  +--ro entity-name                      -> /sat/entity/name
       |  +--ro test-instance-name               -> /sat/test-instance/name
       |  +--ro rx-pkts?                         yang:counter64
       |  +--ro rx-ipv4-pkts?                    yang:counter64
       |  +--ro rx-ipv4-udp-pkts?                yang:counter64
       |  +--ro rx-ipv6-pkts?                    yang:counter64
       |  +--ro rx-ipv6-udp-pkts?                yang:counter64
       |  +--ro rx-non-ip-pkts?                  yang:counter64
       |  +--ro rx-unrecognized-pkts?            yang:counter64
       |  +--ro rx-duplicate-pkts?               yang:counter64
       |  +--ro rx-duplicate-pkts-overflow?      boolean
       |  +--ro rx-ooo-pkts?                     yang:counter64
       |  +--ro rx-ooo-pkts-overflow?            boolean
       |  +--ro rx-disc-seq-num-pkts?            yang:counter64
       |  +--ro rx-disc-seq-num-pkts-overflow?   boolean
       |  +--ro tx-pkts?                         yang:counter64
       +--ro gen-test-session-throughput-results* [entity-name test-instance-name untagged pcp color profile-frame-size-index]
       |  +--ro entity-name                 -> /sat/entity/name
       |  +--ro test-instance-name          -> /sat/test-instance/name
       |  +--ro untagged                    boolean
       |  +--ro pcp                         priority
       |  +--ro color                       basic-color
       |  +--ro profile-frame-size-index    uint8
       |  +--ro frame-size?                 uint32
       |  +--ro emix-sequence?              -> /sat/emix-sequence/name
       |  +--ro min?                        ciena-sat:throughput-result
       |  +--ro max?                        ciena-sat:throughput-result
       |  +--ro avg?                        ciena-sat:throughput-result
       |  +--ro iterations?                 uint32
       |  +--ro kpi-result?                 ciena-sat:kpi-result-type
       +--ro gen-test-session-frameloss-results* [entity-name test-instance-name untagged pcp color profile-frame-size-index rate-index]
       |  +--ro entity-name                 -> /sat/entity/name
       |  +--ro test-instance-name          -> /sat/test-instance/name
       |  +--ro untagged                    boolean
       |  +--ro pcp                         priority
       |  +--ro color                       basic-color
       |  +--ro profile-frame-size-index    uint8
       |  +--ro rate-index                  uint8
       |  +--ro frame-size?                 uint32
       |  +--ro emix-sequence?              -> /sat/emix-sequence/name
       |  +--ro rate?                       uint32
       |  +--ro first?                      ciena-sat:frameloss-result
       |  +--ro second?                     ciena-sat:frameloss-result
       |  +--ro kpi-result?                 ciena-sat:kpi-result-type
       |  +--ro result?                     ciena-sat:frameloss-result
       +--ro gen-test-session-latency-results* [entity-name test-instance-name untagged pcp color profile-frame-size-index]
       |  +--ro entity-name                 -> /sat/entity/name
       |  +--ro test-instance-name          -> /sat/test-instance/name
       |  +--ro untagged                    boolean
       |  +--ro pcp                         priority
       |  +--ro color                       basic-color
       |  +--ro profile-frame-size-index    uint8
       |  +--ro frame-size?                 uint32
       |  +--ro emix-sequence?              -> /sat/emix-sequence/name
       |  +--ro min?                        uint32
       |  +--ro max?                        uint32
       |  +--ro avg?                        uint32
       |  +--ro samples?                    uint32
       |  +--ro kpi-result?                 ciena-sat:kpi-result-type
       +--ro gen-test-session-pdv-results* [entity-name test-instance-name untagged pcp color frame-size-index]
       |  +--ro entity-name           -> /sat/entity/name
       |  +--ro test-instance-name    -> /sat/test-instance/name
       |  +--ro untagged              boolean
       |  +--ro pcp                   priority
       |  +--ro color                 basic-color
       |  +--ro frame-size-index      uint8
       |  +--ro frame-size?           uint32
       |  +--ro emix-sequence?        -> /sat/emix-sequence/name
       |  +--ro avg?                  uint32
       |  +--ro samples?              uint32
       |  +--ro kpi-result?           ciena-sat:kpi-result-type
       +--ro gen-test-session-outage-results* [entity-name test-instance-name untagged pcp color frame-size-index]
       |  +--ro entity-name               -> /sat/entity/name
       |  +--ro test-instance-name        -> /sat/test-instance/name
       |  +--ro untagged                  boolean
       |  +--ro pcp                       priority
       |  +--ro color                     basic-color
       |  +--ro frame-size-index          uint8
       |  +--ro frame-size?               uint32
       |  +--ro emix-sequence?            -> /sat/emix-sequence/name
       |  +--ro outage-test-start-time?   yang:date-and-time
       |  +--ro outage-test-end-time?     yang:date-and-time
       |  +--ro total-outages?            uint32
       |  +--ro recorded-outages?         uint32
       |  +--ro sum-total-outages?        uint64
       |  +--ro sum-recorded-outages?     uint64
       |  +--ro average-throughput?       ciena-sat:throughput-result
       |  +--ro overall-kpi-result?       ciena-sat:kpi-result-type
       |  +--ro sum-outages-kpi-result?   ciena-sat:kpi-result-type
       |  +--ro max-outages-kpi-result?   ciena-sat:kpi-result-type
       |  +--ro per-outage* [outage-index]
       |     +--ro outage-index      uint8
       |     +--ro start-time?       yang:date-and-time
       |     +--ro end-time?         yang:date-and-time
       |     +--ro length?           uint64
       |     +--ro frames-dropped?   uint64
       |     +--ro kpi-result?       ciena-sat:kpi-result-type
       +--ro emix-character-set* [index]
       |  +--ro index         uint8
       |  +--ro character?    string
       |  +--ro frame-size?   string
       +--ro emix-frame-size-for-sat-entity* [entity-name emix-sequence]
       |  +--ro entity-name        -> /sat/entity/name
       |  +--ro emix-sequence      -> /sat/emix-sequence/name
       |  +--ro emix-frame-size*   uint32
       |  +--ro avg-frame-size?    uint32
       +--ro kpi-profile* [name]
       |  +--ro name          name-string
       |  +--ro id?           uint32
       |  +--ro num-of-ref?   uint32
       +--ro bw-alloc-profile* [name]
       |  +--ro name          name-string
       |  +--ro id?           uint32
       |  +--ro num-of-ref?   uint32
       +--ro test-profile* [name]
       |  +--ro name                    name-string
       |  +--ro id?                     uint32
       |  +--ro hw-sessions-required?   uint32
       |  +--ro num-of-ref?             uint32
       +--ro test-instance* [name]
          +--ro name                              name-string
          +--ro id?                               uint32
          +--ro current-interval?                 uint32
          +--ro total-intervals?                  uint32
          +--ro last-iteration-start-timestamp?   yang:date-and-time
          +--ro assoc-entity?                     -> /sat/entity/name
          +--ro oper-state?                       ciena:oper-state
          +--ro active-s-vid?                     uint32
          +--ro active-c-vid?                     uint32
          +--ro active-untagged-data?             boolean
          +--ro active-dst-mac?                   yang:mac-address
          +--ro active-start-bw?                  uint32

  rpcs:
    +---x entity-clear-statistics
    |  +---w input
    |  |  +---w entity-name    -> /sat/entity/name
    |  +--ro output
    |     +--ro status?   string
    +---x test-instance-start
    |  +---w input
    |  |  +---w test-instance-name    -> /sat/test-instance/name
    |  +--ro output
    |     +--ro status?   string
    +---x test-instance-stop
    |  +---w input
    |  |  +---w test-instance-name    -> /sat/test-instance/name
    |  +--ro output
    |     +--ro status?   string
    +---x test-instance-connectivity-test
    |  +---w input
    |  |  +---w test-instance-name    -> /sat/test-instance/name
    |  +--ro output
    |     +--ro status?   string
    +---x test-instance-clear-statistics
       +---w input
       |  +---w test-instance-name    -> /sat/test-instance/name
       +--ro output
          +--ro status?   string

  notifications:
    +---n test-started
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    |  +--ro port?                 mef-logical-port:logical-port-ref
    |  +--ro svid?                 ieee:vlanid
    |  +--ro cvid?                 ieee:vlanid
    |  +--ro dst-mac?              yang:mac-address
    +---n test-stopped
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    +---n test-completed
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    +---n test-iteration-completed
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    |  +--ro iteration?            uint32
    +---n test-throughput-kpi-failure
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    |  +--ro kpi-profile?          name-string
    |  +--ro kpi-pcp?              priority
    |  +--ro kpi-untagged?         boolean
    |  +--ro kpi-color?            basic-color
    |  +--ro current-pkt-size?     uint32
    |  +--ro emix-sequence?        name-string
    |  +--ro throughput-result?    uint32
    +---n test-frameloss-kpi-failure
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    |  +--ro kpi-profile?          name-string
    |  +--ro kpi-pcp?              priority
    |  +--ro kpi-untagged?         boolean
    |  +--ro kpi-color?            basic-color
    |  +--ro current-pkt-size?     uint32
    |  +--ro emix-sequence?        name-string
    |  +--ro frameloss-result?     uint32
    +---n test-latency-kpi-failure
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    |  +--ro kpi-profile?          name-string
    |  +--ro kpi-pcp?              priority
    |  +--ro kpi-untagged?         boolean
    |  +--ro kpi-color?            basic-color
    |  +--ro current-pkt-size?     uint32
    |  +--ro emix-sequence?        name-string
    |  +--ro latency-result?       uint32
    +---n test-pdv-kpi-failure
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    |  +--ro kpi-profile?          name-string
    |  +--ro kpi-pcp?              priority
    |  +--ro kpi-untagged?         boolean
    |  +--ro kpi-color?            basic-color
    |  +--ro current-pkt-size?     uint32
    |  +--ro emix-sequence?        name-string
    |  +--ro pdv-result?           uint32
    +---n test-outage-max-number-kpi-failure
    |  +--ro severity?             ciena:event-severity
    |  +--ro mac-address?          yang:mac-address
    |  +--ro test-instance-name    name-string
    |  +--ro kpi-profile?          name-string
    |  +--ro kpi-pcp?              priority
    |  +--ro kpi-untagged?         boolean
    |  +--ro kpi-color?            basic-color
    |  +--ro current-pkt-size?     uint32
    |  +--ro emix-sequence?        name-string
    |  +--ro num-outages?          uint32
    +---n test-outage-single-outage-kpi-failure
    |  +--ro severity?                     ciena:event-severity
    |  +--ro mac-address?                  yang:mac-address
    |  +--ro test-instance-name            name-string
    |  +--ro kpi-profile?                  name-string
    |  +--ro kpi-pcp?                      priority
    |  +--ro kpi-untagged?                 boolean
    |  +--ro kpi-color?                    basic-color
    |  +--ro current-pkt-size?             uint32
    |  +--ro emix-sequence?                name-string
    |  +--ro single-outage-max-duration?   uint64
    +---n test-outage-sum-outages-kpi-failure
       +--ro severity?               ciena:event-severity
       +--ro mac-address?            yang:mac-address
       +--ro test-instance-name      name-string
       +--ro kpi-profile?            name-string
       +--ro kpi-pcp?                priority
       +--ro kpi-untagged?           boolean
       +--ro kpi-color?              basic-color
       +--ro current-pkt-size?       uint32
       +--ro emix-sequence?          name-string
       +--ro sum-recorded-outages?   uint64
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-frame-to-cos-map.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-frame-to-cos-map
    +--rw frame-to-cos-maps
       +--rw frame-to-cos-map* [name]
          +--rw name           string
          +--rw description?   string
          +--rw map-entry* [name]
             +--rw name       string
             +--rw (frame-type)?
             |  +--:(vlan-tag)
             |  |  +--rw pcp?       uint8
             |  |  +--rw dei?       enumeration
             |  +--:(ip)
             |  |  +--rw ip-dscp?   uint8
             |  +--:(mpls)
             |     +--rw mpls-tc?   uint8
             +--rw cos?       uint8
             +--rw color?     enumeration
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ciena-mef-classifier.yang
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-classifier
    +--rw classifiers
       +--rw classifier* [name]
          +--rw name                string
          +--rw filter-operation?   enumeration
          +--rw filter-entry* [filter-parameter]
             +--rw filter-parameter                    identityref
             +--rw logical-not?                        boolean
             +--rw (filter-parameters)?
                +--:(vtag-stack)
                |  +--rw (vtag-stack-type)?
                |     +--:(untagged)
                |     |  +--rw untagged-exclude-priority-tagged?   boolean
                |     +--:(l2cp)
                |     |  +--rw l2cp-exclude-priority-tagged?       boolean
                |     +--:(tagged)
                |        +--rw vtags* [tag]
                |           +--rw tag             uint8
                |           +--rw tpid?           enumeration
                |           +--rw pcp?            uint8
                |           +--rw pcp-mask?       uint8
                |           +--rw dei?            enumeration
                |           +--rw vlan-id?        uint16
                |           +--rw vlan-id-max?    uint16
                |           +--rw vlan-id-mask?   uint16
                +--:(mpls-label-stack)
                |  +--rw mpls-labels* [label]
                |     +--rw label         uint32
                |     +--rw (labels)?
                |     |  +--:(any)
                |     |  |  +--rw label-any?    empty
                |     |  +--:(value)
                |     |     +--rw mpls-label?   uint32
                |     +--rw (tc)?
                |        +--:(any)
                |        |  +--rw tc-any?       empty
                |        +--:(value)
                |           +--rw tc-value?     uint8
                +--:(dscp)
                |  +--rw dscp-min?                           inet:dscp
                |  +--rw dscp-max?                           inet:dscp
                |  +--rw dscp-mask?                          inet:dscp
                +--:(source-ip)
                |  +--rw source-address?                     inet:ip-prefix
                +--:(destination-ip)
                |  +--rw destination-address?                inet:ip-prefix
                +--:(l4-source-port)
                |  +--rw source-min?                         inet:port-number
                |  +--rw source-max?                         inet:port-number
                +--:(l4-destination-port)
                |  +--rw destination-min?                    inet:port-number
                |  +--rw destination-max?                    inet:port-number
                +--:(ip-protocol)
                |  +--rw min-prot?                           uint16
                |  +--rw max-prot?                           uint16
                +--:(base-etype)
                |  +--rw base-ethertype?                     uint16
                +--:(any)
                |  +--rw any?                                empty
                +--:(ip-fragment)
                |  +--rw ip-fragment?                        boolean
                +--:(l4-application)
                |  +--rw l4-application?                     enumeration
                +--:(l4-dst-protocol)
                |  +--rw l4-dst-protocol?                    enumeration
                +--:(tcp-flags)
                |  +--rw syn?                                boolean
                |  +--rw ack?                                boolean
                |  +--rw rst?                                boolean
                |  +--rw urg?                                boolean
                |  +--rw psh?                                boolean
                |  +--rw fin?                                boolean
                +--:(source-mac)
                |  +--rw source-mac?                         yt:mac-address
                |  +--rw source-mac-mask?                    yt:mac-address
                +--:(destination-mac)
                   +--rw destination-mac?                    yt:mac-address
                   +--rw destination-mac-mask?               yt:mac-address
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-flood-containment-profile.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-flood-containment-profile
    +--rw flood-containment-profiles
       +--rw flood-containment-profile* [name]
          +--rw name           string
          +--rw description?   string
          +--rw containment* [frame-type]
             +--rw frame-type    bits
             +--rw rate?         uint64
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ciena-types.yang
Pyang Validation
No warnings or errors
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-ietf-twamp.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-ietf-twamp
    +--rw twamp
       +--rw twampClient! {controlClient}?
       |  +--rw clientAdminState             boolean
       |  +--rw modePreferenceChain* [priority]
       |  |  +--rw priority    uint16
       |  |  +--rw mode?       enumeration
       |  +--rw keyChain* [keyId]
       |  |  +--rw keyId        string
       |  |  +--rw secretKey?   string
       |  +--rw twampClientCtrlConnection* [ctrlConnectionName]
       |     +--rw ctrlConnectionName     string
       |     +--rw clientIp?              inet:ip-address
       |     +--rw serverIp?              inet:ip-address
       |     +--rw serverTcpPort?         inet:port-number
       |     +--rw dscp?                  inet:dscp
       |     +--rw keyId?                 string
       |     +--rw dkLen?                 uint32
       |     +--ro clientTcpPort?         inet:port-number
       |     +--ro serverStartTime?       uint64
       |     +--ro ctrlConnectionState?   enumeration
       |     +--ro selectedMode?          enumeration
       |     +--ro token?                 string
       |     +--ro clientIv?              string
       |     +--rw twampSessionRequest* [testSessionName]
       |        +--rw testSessionName     string
       |        +--rw senderIp?           inet:ip-address
       |        +--rw senderUdpPort?      inet:port-number
       |        +--rw reflectorIp?        inet:ip-address
       |        +--rw reflectorUdpPort?   inet:port-number
       |        +--rw timeout?            uint64
       |        +--rw paddingLength?      uint32
       |        +--rw startTime?          uint64
       |        +--rw repeat?             boolean
       |        +--rw repeatInterval?     uint32
       |        +--rw pmIndex?            uint16
       |        +--ro testSessionState?   enumeration
       |        +--ro sid?                string
       +--rw twampServer! {server}?
       |  +--rw serverAdminState             boolean
       |  +--rw serverTcpPort?               inet:port-number
       |  +--rw servwait?                    uint32
       |  +--rw dscp?                        inet:dscp
       |  +--rw count?                       uint32
       |  +--rw maxCount?                    uint32
       |  +--rw modes?                       bits
       |  +--ro salt?                        string
       |  +--ro serverIv?                    string
       |  +--ro challenge?                   string
       |  +--rw keyChain* [keyId]
       |  |  +--rw keyId        string
       |  |  +--rw secretKey?   string
       |  +--ro twampServerCtrlConnection* [clientIp clientTcpPort serverIp serverTcpPort]
       |     +--ro clientIp                     inet:ip-address
       |     +--ro clientTcpPort                inet:port-number
       |     +--ro serverIp                     inet:ip-address
       |     +--ro serverTcpPort                inet:port-number
       |     +--ro serverCtrlConnectionState?   enumeration
       |     +--ro dscp?                        inet:dscp
       |     +--ro selectedMode?                enumeration
       |     +--ro keyId?                       string
       |     +--ro dkLen?                       uint32
       |     +--ro count?                       uint32
       |     +--ro maxCount?                    uint32
       +--rw twampSessionSender {sessionSender}?
       |  +--rw twampSenderTestSession* [testSessionName]
       |     +--rw testSessionName         string
       |     +--ro ctrlConnectionName?     string
       |     +--rw dscp?                   inet:dscp
       |     +--rw dot1dPriority?          uint8
       |     +--rw fillMode?               enumeration
       |     +--rw numberOfPackets?        uint32
       |     +--rw (packetDistribution)?
       |     |  +--:(fixed)
       |     |  |  +--rw fixedInterval?          uint32
       |     |  |  +--rw fixedIntervalUnits?     enumeration
       |     |  +--:(poisson)
       |     |     +--rw lambda?                 uint32
       |     |     +--rw lambdaUnits?            uint32
       |     |     +--rw maxInterval?            uint32
       |     |     +--rw truncationPointUnits?   enumeration
       |     +--ro senderSessionState?     enumeration
       |     +--ro sentPackets?            uint32
       |     +--ro rcvPackets?             uint32
       |     +--ro lastSentSeq?            uint32
       |     +--ro lastRcvSeq?             uint32
       +--rw twampSessionReflector {sessionReflector}?
          +--rw refwait?                     uint32
          +--ro twampReflectorTestSession* [senderIp senderUdpPort reflectorIp reflectorUdpPort]
             +--ro sid?                             string
             +--ro senderIp                         inet:ip-address
             +--ro senderUdpPort                    inet:port-number
             +--ro reflectorIp                      inet:ip-address
             +--ro reflectorUdpPort                 inet:port-number
             +--ro parentConnectionClientIp?        inet:ip-address
             +--ro parentConnectionClientTcpPort?   inet:port-number
             +--ro parentConnectionServerIp?        inet:ip-address
             +--ro parentConnectionServerTcpPort?   inet:port-number
             +--ro dscp?                            inet:dscp
             +--ro sentPackets?                     uint32
             +--ro rcvPackets?                      uint32
             +--ro lastSentSeq?                     uint32
             +--ro lastRcvSeq?                      uint32
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-meter-profile.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-meter-profile
    +--rw meter-profiles
       +--rw meter-profile* [name]
          +--rw name             string
          +--rw description?     string
          +--rw cir?             uint32
          +--rw eir?             uint32
          +--rw cbs?             uint32
          +--rw ebs?             uint32
          +--rw color-aware?     boolean
          +--rw coupling-flag?   boolean
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-logical-port.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-logical-port
    +--rw logical-ports
    |  +--rw logical-port* [name]
    |     +--rw name                         string
    |     +--rw admin-state?                 lp-admin-state
    |     +--rw binding?                     if:interface-ref
    |     +--rw mtu?                         uint32
    |     +--rw meter-profile?               meter:meter-ref
    |     +--rw (frame-to-cos-policy)?
    |     |  +--:(map)
    |     |  |  +--rw policy?                      enumeration
    |     |  |  +--rw frame-to-cos-map?            ftc:frame-to-cos-ref
    |     |  +--:(fixed)
    |     |     +--rw cos?                         uint8
    |     |     +--rw color?                       enumeration
    |     +--rw cos-to-frame-map?            ctf:cos-to-frame-ref
    |     +--rw flood-containment-profile?   mef-fc:flood-containment-profile-ref
    |     +--rw description?                 string
    |     +--rw outer-tpid*                  enumeration
    |     +--rw inner-tpid*                  enumeration
    |     +--rw egress-qos?                  enumeration
    +--ro logical-port-oper-status
       +--ro logical-port-status* [name]
          +--ro name           string
          +--ro index?         uint32
          +--ro mac-address?   yt:mac-address
          +--ro oper-state?    lp-oper-state
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-egress-qos.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-egress-qos
    +--rw egress-qos
       +--rw cos-queue-map* [name]
       |  +--rw name         string
       |  +--rw cos-count?   uint32
       |  +--rw map-entry* [cos]
       |     +--rw cos                  uint32
       |     +--rw queue?               uint32
       |     +--rw green-wred-curve?    uint32
       |     +--rw yellow-wred-curve?   uint32
       +--rw congestion-avoidance-profile* [name]
       |  +--rw name    string
       |  +--rw type?   enumeration
       +--rw queue-group-profile* [name]
       |  +--rw name             string
       |  +--rw queue-count?     uint32
       |  +--rw cos-queue-map?   cos-queue-map-ref
       |  +--rw queue* [queue-number]
       |     +--rw queue-number                    uint32
       |     +--rw congestion-avoidance-profile?   congestion-avoidance-profile-ref
       |     +--rw cir?                            uint32
       |     +--rw cir-percent?                    uint32
       |     +--rw cbs?                            uint32
       |     +--rw eir?                            uint32
       |     +--rw eir-percent?                    uint32
       |     +--rw ebs?                            uint32
       +--rw scheduler-profile* [name]
       |  +--rw name                    string
       |  +--rw tap-point-count?        uint32
       |  +--rw scheduling-algorithm?   enumeration
       |  +--rw cir?                    uint32
       |  +--rw cir-percent?            uint32
       |  +--rw cbs?                    uint32
       |  +--rw eir?                    uint32
       |  +--rw eir-percent?            uint32
       |  +--rw ebs?                    uint32
       |  +--rw cir-policy?             enumeration
       |  +--rw eir-policy?             enumeration
       |  +--rw tap-point* [number]
       |     +--rw number      uint32
       |     +--rw priority?   uint32
       |     +--rw weight?     uint32
       +--rw queue-group* [name]
       |  +--rw name                       string
       |  +--rw queue-group-profile        queue-group-profile-ref
       |  +--rw instance-id?               uint32
       |  +--rw queue-group-indirection?   queue-group-indirection-ref
       |  +--rw parent-scheduler           scheduler-ref
       +--rw scheduler* [name]
       |  +--rw name                 string
       |  +--rw scheduler-profile    scheduler-profile-ref
       |  +--rw instance-id?         uint32
       |  +--rw parent-scheduler?    scheduler-ref
       |  +--rw parent-tap-point?    uint32
       |  +--rw parent-port?         mef-logical-port:logical-port-ref
       +--rw queue-group-indirection* [name]
          +--rw name              string
          +--rw indirection-id?   uint32
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-fp.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-fp
    +--rw fps
    |  +--rw fp* [name]
    |     +--rw name                          string
    |     +--rw description?                  string
    |     +--rw fd-name?                      -> /mef-fd:fds/fd/name
    |     +--rw logical-port?                 mef-logical-port:logical-port-ref
    |     +--rw (type)?
    |     |  +--:(q-in-q)
    |     |  |  +--rw svlan?                        uint32
    |     |  +--:(mpls-pw)
    |     |  |  +--rw mpls-pw?                      empty
    |     |  +--:(uni)
    |     |  |  +--rw uni?                          empty
    |     |  +--:(other)
    |     |     +--rw other?                        empty
    |     +--rw mtu-size?                     uint32
    |     +--rw admin-state?                  enumeration
    |     +--rw ingress-l2-transform* [ingress-name]
    |     |  +--rw ingress-name     string
    |     |  +--rw (frame-type)?
    |     |     +--:(stack)
    |     |     |  +--rw vlan-stack* [tag]
    |     |     |     +--rw tag                uint8
    |     |     |     +--rw (action)?
    |     |     |        +--:(push)
    |     |     |        |  +--rw push-tpid          enumeration
    |     |     |        |  +--rw push-pcp?          enumeration
    |     |     |        |  +--rw push-dei?          enumeration
    |     |     |        |  +--rw push-vid           vlan-id
    |     |     |        +--:(pop)
    |     |     |        |  +--rw pop-type?          empty
    |     |     |        +--:(stamp)
    |     |     |           +--rw stamp-tpid?        enumeration
    |     |     |           +--rw stamp-pcp?         enumeration
    |     |     |           +--rw stamp-dei?         enumeration
    |     |     |           +--rw (stamp-vid)?
    |     |     |              +--:(no-op)
    |     |     |              |  +--rw no-op?             empty
    |     |     |              +--:(vid-value)
    |     |     |                 +--rw stamp-vid-value?   vlan-id
    |     |     +--:(untagged)
    |     |        +--rw untagged-tpid?   enumeration
    |     |        +--rw untagged-pcp?    enumeration
    |     |        +--rw untagged-dei?    enumeration
    |     |        +--rw untagged-vid?    vlan-id
    |     +--rw egress-l2-transform* [egress-name]
    |     |  +--rw egress-name      string
    |     |  +--rw (frame-type)?
    |     |     +--:(stack)
    |     |     |  +--rw vlan-stack* [tag]
    |     |     |     +--rw tag                uint8
    |     |     |     +--rw (action)?
    |     |     |        +--:(push)
    |     |     |        |  +--rw push-tpid          enumeration
    |     |     |        |  +--rw push-pcp?          enumeration
    |     |     |        |  +--rw push-dei?          enumeration
    |     |     |        |  +--rw push-vid           vlan-id
    |     |     |        +--:(pop)
    |     |     |        |  +--rw pop-type?          empty
    |     |     |        +--:(stamp)
    |     |     |           +--rw stamp-tpid?        enumeration
    |     |     |           +--rw stamp-pcp?         enumeration
    |     |     |           +--rw stamp-dei?         enumeration
    |     |     |           +--rw (stamp-vid)?
    |     |     |              +--:(no-op)
    |     |     |              |  +--rw no-op?             empty
    |     |     |              +--:(vid-value)
    |     |     |                 +--rw stamp-vid-value?   vlan-id
    |     |     +--:(untagged)
    |     |        +--rw untagged-tpid?   enumeration
    |     |        +--rw untagged-pcp?    enumeration
    |     |        +--rw untagged-dei?    enumeration
    |     |        +--rw untagged-vid?    vlan-id
    |     +--rw (ingress-l3-transform)?
    |     |  +--:(map)
    |     |  |  +--rw ingress-l3-mapped?            empty
    |     |  +--:(remark-dscp)
    |     |     +--rw ingress-remark-dscp-value?    uint8
    |     +--rw (egress-l3-transform)?
    |     |  +--:(map)
    |     |  |  +--rw egress-l3-mapped?             empty
    |     |  +--:(remark-dscp)
    |     |     +--rw egress-remark-dscp-value?     uint8
    |     +--rw (frame-to-cos)?
    |     |  +--:(map)
    |     |  |  +--rw map-policy?                   enumeration
    |     |  |  +--rw frame-to-cos-map?             ftc:frame-to-cos-ref
    |     |  +--:(fixed)
    |     |     +--rw cos?                          uint8
    |     |     +--rw color?                        enumeration
    |     +--rw cos-to-frame-map?             ctf:cos-to-frame-ref
    |     +--rw flood-containment-profile?    mef-fc:flood-containment-profile-ref
    |     +--rw classifier-list*              classifier:classifier-ref
    |     +--rw classifier-list-precedence?   uint32
    |     +--rw mac-learning?                 enumeration
    |     +--rw meter-profile?                meter:meter-ref
    |     +--rw pfg-group?                    enumeration
    |     +--rw queue-group-instance?         mef-egress-qos:queue-group-ref
    |     +--rw stats-collection?             enumeration
    +--ro fps-state
       +--ro fp* [name]
          +--ro name                 string
          +--ro rxAcceptedBytes?     uint64
          +--ro rxAcceptedFrames?    uint64
          +--ro txForwardedBytes?    uint64
          +--ro txForwardedFrames?   uint64
          +--ro rxYellowBytes?       uint64
          +--ro rxYellowFrames?      uint64
          +--ro rxDroppedBytes?      uint64
          +--ro rxDroppedFrames?     uint64
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-egress-qos-binding.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-egress-qos-binding
    +--rw interface-qos-binding
       +--rw interface-qos-binding* [name]
          +--rw name                    string
          +--rw queue-group-instance?   mef-egress-qos:queue-group-ref
          +--rw logical-port?           mef-logical-port:logical-port-ref
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-pfg-profile.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-pfg-profile
    +--rw pfg-profiles
       +--rw pfg-profile* [name]
          +--rw name               string
          +--rw description?       string
          +--rw pfg-type?          PfgType
          +--rw pfg-group-count?   uint32
          +--rw group-A-policy?    group-policy
          +--rw group-B-policy?    group-policy
          +--rw group-C-policy?    group-policy
          +--rw group-D-policy?    group-policy
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-l2cp-profile.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-l2cp-profile
    +--rw l2cp-profiles
       +--rw l2cp-profile* [name]
          +--rw name                    string
          +--rw description?            string
          +--rw untagged-cos-policy?    enumeration
          +--rw fixed-cos?              uint8
          +--rw protocol-disposition* [protocol]
             +--rw protocol                enumeration
             +--rw untagged-disposition?   DispositionType
             +--rw tagged-disposition?     DispositionType
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-cos-to-frame-map.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-cos-to-frame-map
    +--rw cos-to-frame-maps
       +--rw cos-to-frame-map* [name]
          +--rw name           string
          +--rw description?   string
          +--rw map-entry* [cos color]
             +--rw cos                  uint8
             +--rw color                enumeration
             +--rw pcp?                 uint8
             +--rw dei?                 enumeration
             +--rw ip-dscp?             uint8
             +--rw mpls-tc?             uint8
             +--rw queue?               uint32
             +--rw green-wred-curve?    uint32
             +--rw yellow-wred-curve?   uint32
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-bw-calculation-mode.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-bw-calculation-mode
    +--rw bw-calculation-mode
       +--rw eqos-bw-calculation-mode?   identityref
       +--rw iqos-bw-calculation-mode?   identityref
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-mac-management.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-mac-management
    +--rw mac-management
    |  +--rw mac-aging?                       ciena:admin-state
    |  +--rw mac-aging-timeout?               uint32
    |  +--rw dynamic-mac-refresh-algorithm?   identityref
    |  +--rw (mac-maximum-table-size)?
    |     +--:(size)
    |     |  +--rw size?                            uint32
    |     +--:(maximum)
    |        +--rw maximum?                         empty
    +--rw fdbs
    |  +--rw fdb* [name]
    |     +--rw name            string
    |     +--rw description?    string
    |     +--rw mac-learning?   ciena:admin-state
    +--rw static-macs
    |  +--rw mac-entry* [mac-address fdb]
    |     +--rw mac-address         yt:mac-address
    |     +--rw mac-address-mask?   yt:mac-address
    |     +--rw fdb                 mef-mac-management:fdb-ref
    |     +--rw (destination-interface)?
    |     |  +--:(flow-point)
    |     |  |  +--rw flow-point?         mef-fp:fp-ref
    |     |  +--:(logical-port)
    |     |     +--rw logical-port?       mef-logical-port:logical-port-ref
    |     +--rw filter-action?      enumeration
    +--rw mac-access-controls
    |  +--rw mac-access-control* [logical-port]
    |     +--rw logical-port            mef-logical-port:logical-port-ref
    |     +--rw (mac-learn-limit)?
    |        +--:(on)
    |        |  +--rw maximum-dynamic-macs?   uint64
    |        |  +--rw forward-unlearned?      boolean
    |        +--:(off)
    |           +--rw mac-learn-limit-off?    empty
    +--ro fdbs-state
    |  +--ro fdb* [name]
    |     +--ro name                   string
    |     +--ro mac-learn-count?       uint64
    |     +--ro mac-max-learn-count?   uint64
    |     +--ro mac-entry* [mac-address]
    |        +--ro mac-address         yt:mac-address
    |        +--ro mac-address-mask?   yt:mac-address
    |        +--ro (destination-interface)?
    |        |  +--:(flow-point)
    |        |  |  +--ro flow-point?         mef-fp:fp-ref
    |        |  +--:(logical-port)
    |        |     +--ro logical-port?       mef-logical-port:logical-port-ref
    |        +--ro mac-learn-type?     enumeration
    +--ro mac-access-controls-state
       +--ro mac-access-control* [logical-port]
          +--ro logical-port                mef-logical-port:logical-port-ref
          +--ro mac-dynamic-access-count?   uint64
          +--ro high-water-mark?            uint64
          +--ro is-threshold-reached?       boolean

  rpcs:
    +---x dynamic-mac-flush
    |  +---w input
    |  |  +---w (flush-scope)?
    |  |     +--:(forwarding-domain)
    |  |     |  +---w forwarding-domain?   fd-ref
    |  |     +--:(flow-point)
    |  |     |  +---w flow-point?          mef-fp:fp-ref
    |  |     +--:(logical-port)
    |  |     |  +---w logical-port?        mef-logical-port:logical-port-ref
    |  |     +--:(all)
    |  |        +---w all?                 empty
    |  +--ro output
    |     +--ro status?   string
    +---x service-access-control-state-clear
       +---w input
       |  +---w logical-port?   mef-logical-port:logical-port-ref
       +--ro output
          +--ro status?   string
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ciena-mef-qos-flow.yang**
Pyang Validation
No warnings or errors
Pyang Output
module: ciena-mef-qos-flow
    +--rw qos-flows
    |  +--rw qos-flow* [name]
    |     +--rw name                     string
    |     +--rw description?             string
    |     +--rw classifier-list*         classifier:classifier-ref
    |     +--rw classifier-precedence?   uint32
    |     +--rw meter-profile?           meter:meter-ref
    |     +--rw (parent-interface)?
    |     |  +--:(port)
    |     |  |  +--rw parent-port*             mef-logical-port:logical-port-ref
    |     |  +--:(fp)
    |     |     +--rw parent-fp*               mef-fp:fp-ref
    |     +--rw cos-to-frame-map?        ctf:cos-to-frame-ref
    |     +--rw (frame-to-cos-map)?
    |     |  +--:(map)
    |     |  |  +--rw map-policy?              enumeration
    |     |  |  +--rw map-entry?               ftc:frame-to-cos-ref
    |     |  +--:(fixed)
    |     |     +--rw fixed-cos?               uint16
    |     |     +--rw fixed-color?             enumeration
    |     +--rw (ingress-l2-transform)?
    |     |  +--:(stamp)
    |     |     +--rw (dei-policy)?
    |     |     |  +--:(map)
    |     |     |  |  +--rw dei-map?                 empty
    |     |     |  +--:(fixed)
    |     |     |     +--rw dei-value?               boolean
    |     |     +--rw (pcp-policy)?
    |     |        +--:(map)
    |     |        |  +--rw pcp-map?                 empty
    |     |        +--:(fixed)
    |     |           +--rw pcp-value?               uint8
    |     +--rw (ingress-l3-transform)?
    |     |  +--:(stamp)
    |     |     +--rw (dscp-policy)?
    |     |        +--:(map)
    |     |        |  +--rw dscp-map?                ftc:frame-to-cos-ref
    |     |        +--:(fixed)
    |     |           +--rw dscp-value?              uint8
    |     +--rw stats-collection?        enumeration
    +--ro qos-flow-state
       +--ro qos-flow* [name]
          +--ro name    string
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors