### PR TITLE
Update CFM YANG modules

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-bridge.yang
@@ -1,0 +1,570 @@
+module ieee802-dot1q-cfm-bridge {
+  yang-version 1.1;
+  
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-cfm-bridge";
+  prefix "cfm-bridge";
+
+  import ieee802-dot1q-bridge { prefix "dot1q"; }
+  import ieee802-dot1q-cfm { prefix "dot1q-cfm"; }
+  import ieee802-dot1q-cfm-mip { prefix "cfm-mip"; }
+  import ietf-interfaces { prefix "if"; }
+  import ieee802-types { prefix "ieee"; }
+  import ieee802-dot1q-cfm-types { prefix "cfm-types"; }
+  import ieee802-dot1q-types { prefix "dot1q-types"; }
+
+  organization
+    "IEEE 802.1 Working Group";
+
+  contact
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+  
+    E-mail: STDS-802-1-L@IEEE.ORG";
+
+  description
+    "Connectivity Fault Management (CFM) comprises capabilities
+    for detecting, verifying, and isolating connectivity failures
+    in Virtual Bridged Local Area Networks. This module binds
+    the CFM modules to an IEEE 802.1Q Bridge.";
+  
+  revision 2018-04-10 {
+    description
+      "Initial creation for Task Group review.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  
+  typedef bridge-ref {
+    type leafref {
+      path "/dot1q:bridges/dot1q:bridge/dot1q:name";
+    }
+    description
+      "This type is used by data models that need to reference
+      a configured Bridge.";
+  }
+  
+  typedef port-ref {
+    type if:interface-ref;
+    description
+      "This type is used to represent interfaces that can be used
+      by a Bridge device.";
+  }
+  
+  /* -------------------------------------------------
+   * Grouping definitions used by 802.1Qcx YANG module
+   * -------------------------------------------------
+   */
+  
+  grouping service-id {
+    description
+      "The list of VIDs, I-SID, or the TE-SID monitored by 
+      this MA, or 0, if the MA is not attached to a VID, or
+      I-SID, or TE-SID. In the case of a list of VIDs, the 
+      first VID in the list is the MAs Primary VID (default 
+      none). The specification of I-SID is allowed only in
+      the case of I- or B- components. The TE-SID is allowed
+      only in the case that PBB-TE is supported.";
+    choice service-id {
+      default vid;
+      description
+        "The service identifiers types";
+      case none {
+        leaf zero {
+          type uint32 {
+            range "0";
+          }
+          description
+            "Represents no service identifier selected.";
+        }
+      }
+      case vid {
+        leaf-list vid {
+          type dot1q-types:vlanid;
+          description
+            "12-Bit identifier VLAN identifier.";
+        }
+      }
+      case isid {
+        leaf isid {
+          type uint32 {
+            range "1..16777215";
+          }
+          description
+            "24-Bit identifier I-SID identifier.";
+        }
+      }
+      case tesid {
+        leaf tesid {
+          type uint32 {
+            range "1..4294967295";
+          }
+          description
+            "The tesid is used as a service selector for MAs that are
+            present in Bridges that implement PBB-TE functionality.";
+        }
+      }
+      case segid {
+        leaf segid {
+          type uint32 {
+            range "1..4294967295";
+          }
+          description
+            "The segid is used as a service selector for MAs that are
+            present in Bridges that implement IPS functionality.";
+        }
+      }
+      case path-tesid {
+        leaf path-tesid {
+          type uint32 {
+            range "1..4294967295";
+          }
+          description
+            "The path-tesid is used as a service selector for SPBM 
+            path MAs.";
+        }
+      }
+      case group-isid {
+        leaf group-isid {
+          type uint32 {
+            range "1..4294967295";
+          }
+          description
+            "The group-isid is used as a service selector for SPBM 
+            group MAs.";
+        }
+      }
+    }
+  }
+  
+  /* -------------------------------------------------------------
+   *  Augmentations of objects defined in generic CFM YANG module
+   *  (ieee802-dot1q-cfm) and generic MEP YANG module 
+   *  (ieee802-dot1q-cfm-mep).
+   * -------------------------------------------------------------
+   */
+  
+  augment "/dot1q-cfm:cfm" {
+    description
+      "Augment the base/common CFM model with CFM IEEE 802.1Qcp 
+      Bridge configuration specific attributes.";
+    
+    container cfm-stacks {
+      description 
+        "The CFM Stack contains information about the Maintenance
+        Points configured on a particular Bridge Port (or
+        aggregated port). It contains all CFM Stack specific related
+        configuration and operational data.";
+      
+      list cfm-stack {
+        key "port md-level direction";
+        description
+          "The CFM Stack contains information about the Maintenance
+          Points configured on a particular Bridge Port (or
+          aggregated port). It contains all CFM Stack specific related
+          configuration and operational data.
+          
+          Upon a restart of the system, the system SHALL, if necessary,
+          change the value of this variable, and rearrange the
+          cfm-stack, so that it indexes the entry in the
+          interface table with the same value of interface-ref that it
+          indexed before the system restart. If no such entry exists,
+          then the system SHALL delete all entries in the
+          cfm-stack with the interface index.";     
+        leaf port {
+          type port-ref;
+          description
+            "An interface on which maintenance points might be 
+            configured. This object represents the Bridge Port or 
+            aggregated port on which MEPs or MHFs might be 
+            configured.";
+          reference
+            "12.14.2.1.2a of IEEE Std 802.1Q-2018";
+        }
+        leaf md-level {
+          type cfm-types:md-level-type;
+          description
+            "The MD level of the maintenance point";
+          reference
+            "12.14.2.1.2b  of IEEE Std 802.1Q-2018";
+        }
+        leaf direction {
+          type cfm-types:mp-direction-type;
+          description
+            "The direction in which the maintenance point faces on the 
+            Bridge Port.";
+          reference
+            "12.14.2.1.2c of IEEE Std 802.1Q-2018";     
+        }
+        container service-id {
+          config false;
+          description 
+            "A specific VID, I-SID, Traffic Engineering service 
+            instance Identifier (TE-SID), or Segment Identifier
+            (SEG-ID) associated with an MP, or 0, in the case that
+            the MP is associated with no VID, I-SID, TE-SID, or SEG-ID";
+          uses service-id;
+        }
+        leaf maintenance-group {
+          type leafref {
+            path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list'
+              + '/dot1q-cfm:maintenance-group';
+          }
+          config false;
+          description
+            "The maintenance group to which the Maintenance Points
+            is associated with.";
+        }
+        leaf md-id {
+          type cfm-types:name-key-type;
+          config false;
+          description
+            "The Maintenance Domain reference to which the Maintenance
+            Points Maintenance Association is associated. If none,
+            then null string.";
+          reference
+            "12.14.2.1.3b of IEEE Std 802.1Q-2018";
+        }
+        leaf ma-id {
+          type leafref {
+            path '/dot1q-cfm:cfm'
+              + '/dot1q-cfm:maintenance-domains'
+              + '/dot1q-cfm:maintenance-domain'
+              + '[dot1q-cfm:md-id = current()/../md-id]'
+              + '/dot1q-cfm:maintenance-association'
+              + '/dot1q-cfm:ma-id';
+          }
+          config false;
+          description
+            "The Maintenance Association reference to which the 
+            Maintenance Point is associated. If none, then 0.";
+          reference
+            "12.14.2.1.3c of IEEE Std 802.1Q-2018";
+        }
+        leaf mep-id {
+          type leafref {
+            path '/dot1q-cfm:cfm'
+              + '/dot1q-cfm:maintenance-group-list'
+              + '[dot1q-cfm:maintenance-group = current()'
+              + '/../maintenance-group]'
+              + '/dot1q-cfm:mep/dot1q-cfm:mep-id';
+          }
+          config false;
+          description
+            "The MEP identifier if a MEP is configured. Otherwise is 0.";
+          reference
+            "12.14.2.1.3d of IEEE Std 802.1Q-2018";
+        }
+        leaf mac-address {
+          type ieee:mac-address;
+          config false;
+          description
+            "The MAC address of the maintenance point.";
+          reference
+            "12.14.2.1.3e of IEEE Std 802.1Q-2018";
+        }
+      }  // cfm-stack
+    } // cfm-stacks
+    
+    container default-md-levels {
+      description
+        "There is a single Default MD Level managed object per Bridge
+        Component. It controls MIP Half Function (MHF) creation for
+        VIDs or I-SIDs of I- or B-components that are not contained in
+        the list of VIDs attached to any specific Maintenance 
+        Association managed object, and the transmission of the Sender
+        ID TLV by those MHFs.";
+      
+      list default-md-level {
+        key "bridge-id component-id";
+        description
+          "For each bridge component, the Default MD Level Managed 
+          Object controls MHF creation for VIDs that are not attached
+          to a specific Maintenance Association Managed Object, and
+          Sender ID TLV transmission by those MHFs.
+          
+          For each Bridge Port, and for each VLAN ID whose data can
+          pass through that Bridge Port, an entry in this table is
+          used by the algorithm in subclause 22.2.3 only if there is no
+          entry in the Maintenance Association table defining an MA
+          for the same VLAN ID and MD Level as this table's entry, and
+          on which MA an Up MEP is defined. If there exists such an
+          MA, that MA's objects are used by the algorithm in
+          subclause 22.2.3 in place of this table entry objects.
+          
+          The agent maintains the value of md-status to indicate
+          whether this entry is overridden by an MA. When first
+          initialized, the agent creates this table automatically with
+          entries for all VLAN IDs, with the default values specified
+          for each object. After this initialization, the writable
+          objects in this table need to be persistent upon reboot or
+          restart of a device.";
+        leaf bridge-id {
+          type bridge-ref;
+          description
+            "The reference to the IEEE 802.1Q Bridge associated with
+            the CFM objects.";
+        }
+        leaf component-id {
+          type leafref {
+            path '/dot1q:bridges/dot1q:bridge'
+              + '[dot1q:name = current()/../bridge-id]'
+              + '/dot1q:component/dot1q:name';
+          }
+          description
+            "The Bridge component within the system to which the
+            information in this entry applies. If the system is not a
+            Bridge, or if only one component is present in the Bridge,
+            then this variable (index) MUST be equal to 1.";
+          reference
+            "12.3l of IEEE Std 802.1Q-2018";
+        }
+        container primary-service-id {
+          description
+            "A vid or isid in an I or B component.";
+          uses service-id;
+          reference
+            "12.14.3.1.2a of IEEE Std 802.1Q-2018";
+        }
+        container associated-service-ids {
+          description
+            "A list of VIDs associated with any MHF on the VID, always
+            including that VID, or the Backbone-SID of the B-component
+            or VIP-SID of the I-component associated with any MHF on
+            the I-SID. The first VID is the MAs Primary VID.
+            
+            List is empty if no primary VID specified.";
+          uses service-id;
+          reference
+            "12.14.3.1.3a of IEEE Std 802.1Q-2018";
+        }
+        leaf md-status {
+          type boolean;
+          config false;
+          description
+            "State of this Default MD Level table entry. True if there
+            is no entry in the Maintenance Association table defining
+            an MA for the same VLAN ID and MD Level as this tables
+            entry, and on which MA an Up MEP is defined, else false.";
+          reference
+            "12.14.3.1.3b of IEEE Std 802.1Q-2018";
+        }
+        leaf md-level {
+          type cfm-types:md-level-or-none-type;
+          default -1;
+          description
+            "A value indicating the MD Level at which MHFs are to be
+            created, and Sender ID TLV transmission by those MHFs is to
+            be controlled, for the VLAN to which this entry's objects
+            apply.";
+          reference
+            "12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf mhf-creation {
+          type cfm-types:mhf-creation-type;
+          default "mhf-defer";
+          description
+            "A value indicating if the Management entity can create MHFs
+            (MIP Half Function) for this VID at this MD Level. If this
+            object has the value mhf-defer, MHF creation for this VLAN
+            is controlled by md-mhf-creation. The value of this variable
+            is meaningless if the values of md-status is false.";
+          reference
+            "12.14.3.1.3d of IEEE Std 802.1Q-2018";
+          
+        }
+        leaf id-permission {
+          type cfm-types:sender-id-permission-type;
+          default "send-id-defer";
+          description
+            "Enumerated value indicating what, if anything, is to be
+            included in the Sender ID TLV transmitted by MHFs
+            created by the Default Maintenance Domain. If this object
+            has the value send-if-defer, Sender ID TLV transmission 
+            for this VLAN is controlled by md-id-permission-type. The
+            value of this variable is meaningless if the values of
+            md-status is false.";
+          reference
+            "12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
+        }
+      } // default-md-level
+    } // default-md-levels
+    
+    container config-errors {
+      description
+        "The Configuration Error List managed object is a list of
+        {identifier, port} pairs configured in error together with
+        the identity of the configuration error.";
+
+      list config-error {
+        key "port";
+        description
+          "The CFM Configuration Error List table provides a list of
+          Interfaces and VIDs that are incorrectly configured.";
+        leaf port {
+          type port-ref;
+          description
+            "The interface index of the interface (i.e., Bridge 
+            Port).
+            
+            Upon a restart of the system, the system SHALL, if 
+            necessary, change the value of this variable so that it
+            indexes the entry in the interface table with the same
+            value of the index that it indexed before the system
+            restart. If no such entry exists, then the system SHALL
+            delete any entries in config-error-list indexed by that
+            interface-ref.";
+          reference
+            "12.14.4.1.2b of IEEE Std 802.1Q-2018";
+        }
+        container service-id {
+          config false;
+          description 
+            "The Service Selector Identifier of the Service with 
+            interfaces in error.";
+          uses service-id;
+          reference
+            "12.14.4.1.2a of IEEE Std 802.1Q-2018";
+        }
+        leaf error-type {
+          type cfm-types:config-error-type;
+          config false;
+          description
+            "vector of Boolean error conditions from 22.2.4.";
+          reference
+            "12.14.4.1.3b of IEEE Std 802.1Q-2018";
+        }
+      } // config-error
+    } // config-errors
+  }
+  
+  augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-domains"
+        + "/dot1q-cfm:maintenance-domain"
+        + "/dot1q-cfm:maintenance-association" {
+    description
+      "Augment the Maintenance Association object defined in
+      the ieee802-dot1q-cfm (CFM common/base) YANG module with
+      IEEE 802.1Qcp bridge specific attributes.";
+    list maintenance-association-component {
+      key ma-component-id;
+      description
+        "This is the part of the complete MA table that is
+        variable across the Bridges in a Maintenance Domain, or
+        across the components of a single Bridge.";
+      leaf ma-component-id {
+        type leafref {
+          path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list'
+            + '[dot1q-cfm:maintenance-group = current()'
+            + '/../maintenance-group]'
+            + '/component-name';
+        }
+        description
+          "The Bridge component within the system to which the
+          information applies. If the system is not a Bridge, or
+          if only one component is present in the Bridge, then
+          this variable (index) MUST be equal to 1";
+        reference
+          "12.3l of IEEE Std 802.1Q-2018";
+      }
+      leaf maintenance-group {
+        type leafref {
+          path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list'
+             + '/dot1q-cfm:maintenance-group';
+        }
+        config false;
+        description
+          "The maintenance group provides a handle for the MD, MA, and
+          MA-component combination. The value is derived from an
+          element in the maintanance-group-list.";
+      }
+      uses service-id;
+      leaf mhf-creation {
+        type cfm-types:mhf-creation-type;
+        default mhf-defer;
+        description
+          "Value indicating whether the management entity can
+          create MHFs (MIP Half Function) for this Maintenance
+          Domain. Since there is no encompassing Maintenance
+          Domain, the value mhf-defer is not allowed.";
+        reference
+          "3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
+      }
+      leaf id-permission {
+        type cfm-types:sender-id-permission-type;
+        default "send-id-defer";
+        description
+          "Enumerated value indicating what, if anything, is to
+          be included in the Sender ID TLV (21.5.3) transmitted
+          by MPs configured in this MA.";
+        reference
+          "12.14.3.1.3d of IEEE Std 802.1Q-2018";
+      }
+    } // maintenance-association-component
+  }
+  
+  augment "/dot1q-cfm:cfm/cfm-mip:mips/cfm-mip:mip" {
+    description
+      "Augment the MIP object defined in the ieee802-dot1q-mip
+      (CFM MIP) YANG module with IEEE 802.1Qcp bridge specific
+      attributes.";
+    leaf port {
+      type port-ref;
+      description
+        "The interface index of the interface (e.g., Bridge 
+        Port) to which the MIP is attached.";
+      reference
+        "12.14.7.1.3b of IEEE Std 802.1Q-2018";
+    }
+    uses service-id;
+  }
+  
+  augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list" {
+    description
+      "Augment the maintenance group list object with the
+      maintenance association component identifier, since the 
+      maintenance association component is an IEEE 802.1Qcp bridge
+      specific attributes.";
+    leaf bridge-id {
+      type bridge-ref;
+      description
+        "The reference to the IEEE 802.1Q Bridge associated with
+        the CFM objects.";
+    }
+    leaf component-name {
+      type leafref {
+        path '/dot1q:bridges/dot1q:bridge'
+          + '[dot1q:name = current()/../cfm-bridge:bridge-id]'
+          + '/dot1q:component/dot1q:name';
+      }
+      description
+        "A reference to the maintenance association component within
+        the provided maintenance domain and maintenance association
+        values.";
+    }
+  }
+  
+  augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list"
+        + "/dot1q-cfm:mep" {
+    description
+      "Augment the MEP object defined in the ieee802-dot1q-mep
+      (CFM MEP) YANG module with IEEE 802.1Qcp bridge specific
+      attributes.";
+    leaf port {
+      type port-ref;
+      description
+        "The interface index of the interface (e.g., Bridge 
+        Port) to which the MEP is attached.";
+      reference
+        "12.14.7.1.3b of IEEE Std 802.1Q-2018";
+    }
+  }
+  
+} // ieee802-cfm-bridge

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-mep.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-mep.yang
@@ -1,0 +1,1303 @@
+module ieee802-dot1q-cfm-mep {
+  yang-version 1.1;
+  
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-cfm-mep";
+  prefix "cfm-mep";
+  
+  import ieee802-dot1q-cfm { prefix "dot1q-cfm"; }
+  import ieee802-dot1q-types { prefix "dot1q-types"; }
+  import ieee802-types { prefix "ieee"; }
+  import ietf-yang-types { prefix "yang"; }
+  import ieee802-dot1q-cfm-types { prefix "cfm-types"; }
+
+  organization
+    "IEEE 802.1 Working Group";
+
+  contact
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+  
+    E-mail: STDS-802-1-L@IEEE.ORG";
+
+  description
+    "TBD.";
+  
+  revision 2018-04-10 {
+    description
+      "Initial creation for Task Group review.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  
+  grouping meps {
+    description
+      "Grouping of MEPs and MEP attributes.";
+    list mep {
+      key "mep-id";
+      description 
+        "A list of local Maintenance association End Points (MEPs).
+        A MEP is an actively managed CFM entity, associated with
+        a specific DoSAP of a service instance, which can
+        generate and receive CFM PDUs and track any responses.
+        It is an end point of a single Maintenance Association
+        (MA) and is an end point of a separate Maintenance
+        Entity for each of the other MEPs in the same MA.";
+      leaf mep-id {
+        type leafref {
+          path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-domains'
+            + '/dot1q-cfm:maintenance-domain'
+            + '[md-id = current()/../../md-name]'
+            + '/dot1q-cfm:maintenance-association'
+            + '[ma-id = current()/../../ma-name]'
+            + '/dot1q-cfm:maintenance-association-mep-list'
+            + '/dot1q-cfm:mep-id';
+        }
+        description
+          "Integer that is unique among all the MEPs in the
+          same Maintenance Association.";
+        reference
+          "3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf direction {
+        type cfm-types:mp-direction-type;
+        description
+          "The direction in which the MEP faces on the Bridge
+          Port. Example, up or down.";
+        reference
+          "12.14.7.1.3c, 19.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf primary-vid {
+        type uint32 {
+          range "0..16777215";
+        }
+        default 0;
+        description
+          "An integer indicating the Primary VID of the MEP. It
+          is always one of the VIDs assigned to the MEPs MA. A
+          value of 0 indicates that either the Primary VID is
+          that of the MEPs MA, or that the MEPs MA is 
+          associated with no VID.";
+        reference
+          "12.14.7.1.3d of IEEE Std 802.1Q-2018"; 
+      }
+      leaf admin-state {
+        type boolean;
+        default "false";
+        description
+          "The administrative state of the MEP. TRUE indicates
+          that the MEP is to functional normally, and FALSE
+          indicates that it is to cease functioning.";
+        reference
+          "12.14.7.1.3e, 20.9.1 of IEEE Std 802.1Q-2018";
+      }
+      leaf fng-state {
+        type cfm-types:fng-state-type;
+        default "fng-reset";
+        config false;
+        description
+          "The current state of the MEP Fault Notification 
+          Generator state machine.";
+        reference
+          "12.14.7.1.3f, 20.35 of IEEE Std 802.1Q-2018";
+      }
+      leaf ccm-ltm-priority {
+        type dot1q-types:priority-type;
+        description
+          "The priority value for CCMs and LTMs transmitted by
+          the MEP. The default value is the highest priority 
+          allowed to pass through the Bridge Port for any of
+          the MEPs VID(s).";
+        reference
+          "12.14.7.1.3h of IEEE Std 802.1Q-2018";
+      }
+      leaf mac-address {
+        type ieee:mac-address;
+        config false;
+        description
+          "The MAC address of the MEP.";
+        reference
+          "12.14.7.1.3i, 19.4 of IEEE Std 802.1Q-2018";
+      }
+      leaf fault-alarm-address {
+        type cfm-types:fault-alarm-address-type;
+        default "not-specified";
+        description
+          "A value indicating whether Fault Alarms are to be 
+          transmitted or not. The default is not specified, 
+          which implies that the disposition of the fault-alarm
+          used by the MD should be used.";
+        reference
+          "3.122, 12.14.7.1.3j of IEEE Std 802.1Q-2018";
+      }
+      leaf lowest-priority-defect {
+        type cfm-types:lowest-alarm-priority-type;
+        default "mac-remote-error-xcon";
+        description
+          "The lowest priority defect that is allowed to
+          generate fault alarms.";
+        reference
+          "12.14.7.1.3k, 20.9.5 of IEEE Std 802.1Q-2018";
+      }
+      leaf fng-alarm-time {
+        type yang:zero-based-counter32 {
+          range "250..1000";
+        }
+        units deciseconds;
+        default 250;
+        description
+          "The time that defect must be present before a Fault
+          Alarm is issued.";
+        reference
+          "12.14.7.1.3l, 20.35.3 of IEEE Std 802.1Q-2018";
+      }
+      leaf fng-reset-time {
+        type yang:zero-based-counter32 {
+          range "250..1000";
+        }
+        units deciseconds;
+        default 1000;
+        description
+          "The time that defects must be absent before 
+          resetting a Fault Alarm.";
+        reference
+          "12.14.7.1.3m, 20.35.4 of IEEE Std 802.1Q-2018";
+      }
+      leaf highest-priority-defect {
+        type cfm-types:highest-defect-priority-type;
+        config false;
+        description
+          "The highest priority defect that has been present
+          sicne the MEPs Fault Notification Generator state
+          machine was last in the FNG_RESET state.";
+        reference
+          "12.14.7.1.3n, 20.35.9 of IEEE Std 802.1Q-2018";
+      }
+      leaf defects {
+        type cfm-types:mep-defects-type;
+        config false;
+        description
+          "Vector of boolean error conditions";
+        reference
+          "12.14.7.1.3o-s, 20.21.3,
+          20.23.3, 20.35.5, 20.35.6, 20.35.7 of IEEE Std 802.1Q-2018";
+      }
+      leaf error-ccm-last-failure {
+        type string {
+          length "1..2000";
+        }
+        config false;
+        description
+          "The last received CCM that triggered a def-error-ccm
+          fault.";
+        reference
+          "12.14.7.1.3t, 20.21.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf xcon-ccm-last-failure {
+        type string {
+          length "1..2000";
+        }
+        config false;
+        description
+          "The last received CCM that triggered a def-xcon-ccm
+          fault.";
+        reference
+          "12.14.7.1.3u, 20.23.2 of IEEE Std 802.1Q-2018";
+      }
+      
+      list mep-db {
+        key rmep-id;
+        description
+          "The MEP CCM Database. A database, maintained by every 
+          MEP, that maintains received information about other MEPs
+          in the Maintenance Domain.";
+        leaf rmep-id {
+          type leafref {
+            path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-domains'
+              + '/dot1q-cfm:maintenance-domain'
+              + '[md-id = current()/../../md-name]'
+              + '/dot1q-cfm:maintenance-association'
+              + '[ma-id = current()/../../ma-name]'
+              + '/dot1q-cfm:maintenance-association-mep-list'
+              + '/dot1q-cfm:mep-id';
+          }
+          description
+            "Maintenance association Endpoint Identifier of a
+            remote MEP whose information from the MEP Database
+            is to be returned.";
+          reference
+            "12.14.7.6.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf rmep-state {
+          type cfm-types:remote-mep-state-type;
+          config false;
+          description 
+            "The operational state of the remote MEP  state
+            machine";
+          reference
+            "12.14.7.6.3b, 20.20 of IEEE Std 802.1Q-2018";
+        }
+        leaf rmep-failed-ok-time {
+          type yang:zero-based-counter32;
+          units seconds;
+          config false;
+          description
+            "The time (SysUpTime) at which the Remote MEP state
+            machine last entered either the RMEP_FAILED or
+            RMEP_OK state";
+          reference
+            "12.14.7.6.3c of IEEE Std 802.1Q-2018";
+        }
+        leaf mac-address {
+          type ieee:mac-address;
+          config false;
+          description
+            "The MAC address of the remote MEP.";
+          reference
+            "12.14.7.6.3d, 20.19.7 of IEEE Std 802.1Q-2018";
+        }
+        leaf rdi {
+          type boolean;
+          config false;
+          description
+            "State of the RDI bit in the last received CCM
+            (true for RDI=1), or false if none has been 
+            received.";
+          reference
+            "12.14.7.6.3e, 20.19.2 of IEEE Std 802.1Q-2018";
+        }
+        leaf port-status-tlv {
+          type cfm-types:port-status-tlv-value;
+          default "no-port-state-tlv";
+          config false;
+          description
+            "An enumerated value of the Port status TLV 
+            received in the last CCM from the remote MEP or 
+            the default value no-port-state-tlv indicating
+            either no CCM has been received, or that no port
+            status TLV was received in the last CCM.";
+          reference
+            "12.14.7.6.3f, 20.19.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf interface-status-tlv {
+          type cfm-types:interface-status-tlv-value;
+          default "is-no-interface-status-tlv";
+          config false;
+          description
+            "An enumerated value of the Interface status TLV
+            received in the last CCM from the remote MEP or the
+            default value is-no-interface-status-tlv indicating
+            either no CCM has been received, or that no 
+            interface status TLV was received in the last 
+            CCM.";
+          reference
+            "12.14.7.6.3g, 20.19.4 of IEEE Std 802.1Q-2018";
+        }
+        leaf chassis-id-subtype {
+          type cfm-types:lldp-chassis-id-subtype;
+          config false;
+          description
+            "This object specifies the format of the Chassis ID
+            received in the last CCM.";
+          reference
+            "12.14.7.6.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
+        }
+        leaf chassis-id {
+          type cfm-types:lldp-chassis-id;
+          config false;
+          description
+            "The Chassis ID. The format of this object is
+            determined by the value of the 
+            ltr-chassis-id-subtype object.";
+          reference
+            "12.14.7.6.3h, 21.5.3.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf man-address-domain {
+          type cfm-types:transport-service-domain;
+          config false;
+          description
+            "The transport-service-domain that identifies the
+            type and format of the related mep-db-man-address
+            object, used to access the YANG agent of the system
+            transmitting the CCM. Received in the CCM Sender ID
+            TLV from that system.
+            
+            The value zeroDotZero (from RFC2578) indicates no
+            management address was present in the LTR, in which
+            case the related mep-db-man-address object MUST
+            have a zero-length OCTET STRING as a value.";
+          reference
+            "12.14.7.6.3h, 21.5.3.5,
+            21.6.7 of IEEE Std 802.1Q-2018";
+        }
+        leaf man-address {
+          type cfm-types:transport-service-address;
+          config false;
+          description
+            "The transport-service-address that can be used to 
+            access the YANG agent of the system transmitting
+            the CCM, received in the CCM Sender ID TLV from
+            that system. If the related 
+            mep-db-man-address-domain object contains the 
+            value zeroDotZero, this object mep-db-man-address
+            MUST have a zero-length OCTET STRING as a value.";
+          reference
+            "12.14.7.6.3h, 21.5.3.7,
+            21.6.7 of IEEE Std 802.1Q-2018";
+        }
+        leaf rmep-is-active {
+          type boolean;
+          description
+            "A Boolean value statign if the remote MEP is 
+            active.";
+          reference
+            "12.14.7.1.3ae";
+        }
+      } // mep-db
+      
+      container continuity-check {
+        description
+          "Continuity check protocol";
+        leaf ccm-enabled {
+          type boolean;
+          default "false";
+          description
+            "Indicates whether the MEP can generate CCMs. If 
+            TRUE, the MEP will generate CCM PDUs.";
+          reference
+            "12.14.7.1.3g, 20.10.1 of IEEE Std 802.1Q-2018";
+        }
+        leaf priority {
+          type dot1q-types:priority-type;
+          description
+            "The priority value for CCMs and LTMs transmitted by
+            the MEP. The default value is the highest priority 
+            allowed to pass through the Bridge Port for any of
+            the MEPs VID(s).";
+          reference
+            "12.14.7.1.3h of IEEE Std 802.1Q-2018";
+        }
+        leaf ccm-interval {
+          type cfm-types:cfm-interval-type;
+          description
+            "The interval between CCM transmissions to be used by all
+            MEPs in the Maintenance Association.";
+          reference
+            "12.14.6.1.3e of IEEE Std 802.1Q-2018";
+        }
+      } // continuity-check
+      
+      container loopback {
+        description
+          "Loopback protocol";
+        leaf status {
+          type boolean;
+          default "false";
+          description
+            "A Boolean flag set to TRUE by the MEP Loopback
+            Initiator state machine or YANG network configuration
+            manager to indicate that another LBM is being 
+            transmitted. Reset to FALSE by the MEP Loopback
+            initiator state machine.";
+          reference
+            "20.32, Figure 20-11 of IEEE Std 802.1Q-2018";
+        }
+        leaf interval {
+          type cfm-types:cfm-interval-type;
+          default 1sec;
+          description
+            "The interval between LBM transmissions to be used by all
+            MEPs in the Maintenance Association.";
+        }
+        leaf dest-mac-address {
+          type ieee:mac-address;
+          description
+            "The target MAC Address field to be transmitted.
+            A unicast destination MAC address. This address
+            is used if node mep-transmit-lbm-dest-is-mep-id
+            is FALSE.";
+          reference
+            "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf dest-mep-id {
+          type cfm-types:mep-id-or-zero-type;
+          description
+            "The identifier of a remote MEP in the same MA to
+            which the LBM is to be sent. This address
+            is used if node mep-transmit-lbm-dest-is-mep-id
+            is TRUE.";
+          reference
+            "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf dest-is-mep-id {
+          type boolean;
+          default "false";
+          description
+            "TRUE indicates that MEP ID of the target MEP is used
+            for Loopback transmissions. FALSE indicates that
+            unicast destination MAC address of the target MEP is
+            used for Loopback transmissions.";
+          reference
+            "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf message-count {
+          type uint32 {
+            range "1..1024";
+          }
+          default 1;
+          description
+            "The number of Loopback messages to be transmitted.";
+          reference
+            "12.14.7.3.2c of IEEE Std 802.1Q-2018";
+        }
+        leaf data-tlv {
+          type cfm-types:lbm-data-tlv-type;
+          description
+            "An arbitrary amount of data to be included in the
+            Data TLV, if the Data TLV is selected to be sent. The
+            intent is to be able to fill the frame carrying the
+            CFM PDU to its maximum length.";
+          reference
+            "12.14.7.3.2d of IEEE Std 802.1Q-2018";
+        }
+        leaf priority {
+          type dot1q-types:priority-type;
+          description
+            "Priority. 3 bit value to be used in the VLAN tag, if
+            present in the transmitted frame. The default value
+            should be the CCM priority.";
+          reference
+            "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+        }
+        leaf vlan-drop-eligible {
+          type boolean;
+          default "false";
+          description
+            "Drop eligible bit value to be used in the VLAN tag,
+            if present in the transmitted frame";
+          reference
+            "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+        }
+        leaf result-ok {
+          type boolean;
+          default "true";
+          config false;
+          description
+            "Indicates the result of the operation:
+               TRUE - The LBM will be (or has been) sent.
+               FALSE - The LBM will not be sent.";
+          reference
+            "12.14.7.3.3a of IEEE Std 802.1Q-2018";
+        }
+        leaf seq-number {
+          type cfm-types:seq-number-type;
+          config false;
+          description
+            "The Loopback transaction identifier
+            (mep-next-lbm-trans-id) of the first LBM (to be) 
+            sent. The value returned is undefined if 
+            mep-transmit-lbm-result-ok is FALSE.";
+          reference
+            "12.14.7.3.3b of IEEE Std 802.1Q-2018";
+        }
+        leaf next-lbm-trans-id {
+          type cfm-types:seq-number-type;
+          config false;
+          description
+            "Next sequence number identifier to be sent in a
+            Loopback message. This sequence number can be zero
+            since it can wrap around.";
+          reference
+            "12.14.7.1.3x, 20.28.2 of IEEE Std 802.1Q-2018";
+        }
+      } // loopback
+      
+      container linktrace {
+        description
+          "Linktrace protocol";
+        leaf status {
+          type boolean;
+          default "false";
+          description
+            "A Boolean flag set to TRUE by the Bridge Port to 
+            indicate that another LTM may be transmitted. Reset
+            to FALSE by the MEP Linktrace initiator state 
+            machine.";
+          reference
+            "20.49, Figure 20-17 of IEEE Std 802.1Q-2018";
+        }
+        leaf interval {
+          type cfm-types:cfm-interval-type;
+          default 1sec;
+          description
+            "The interval between LTM transmissions to be used by all
+            MEPs in the Maintenance Association.";
+        }
+        leaf priority {
+          type dot1q-types:priority-type;
+          description
+            "The priority value for CCMs and LTMs transmitted by
+            the MEP. The default value is the highest priority 
+            allowed to pass through the Bridge Port for any of
+            the MEPs VID(s).";
+          reference
+            "12.14.7.1.3h of IEEE Std 802.1Q-2018";
+        }
+        leaf flags {
+          type cfm-types:mep-tx-ltm-flags-type;
+          default use-fdb-only;
+          description
+            "The flags field for the LTMs transmitted by the 
+            MEP.";
+          reference
+            "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
+          
+        }
+        leaf target-mac-address {
+          type ieee:mac-address;
+          description
+            "The target MAC address field to be transmitted. A
+            unicast MAC address. This address will be used if the
+            value of mep-transmit-ltm-target-is-mep-id is FALSE.";
+          reference
+            "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+        }
+        leaf target-mep-id {
+          type cfm-types:mep-id-or-zero-type;
+          description
+            "The target MAC address field to be transmitted. The
+            MEP identifier of another MEP in the same MA. This
+            address will be used if the value of 
+            mep-transmit-ltm-target-is-mep-id is TRUE.";
+          reference
+            "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+        }
+        leaf target-is-mep-id {
+          type boolean;
+          default "false";
+          description
+            "TRUE indicates that MEP id of the target MEP is used
+            for Linktrace transmission. FALSE indicates that
+            unicast destination MAC address of the target MEP is
+            used for LinkTrace transmission.";
+          reference
+            "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+        }
+        leaf ttl {
+          type uint32 {
+            range "0..255";
+          }
+          default 64;
+          description
+            "The LTM TTL field. Indicates the number of hops 
+            remaining to the LTM. Decremented by 1 by each
+            Linktrace Responder that handles the LTM. The value
+            returned in the LTR is one less than that received in
+            the LTM. If the LTM TTL is 0 or 1, the LTM is not
+            forwarded to the next hop, and if 0, no LTR is 
+            generated.";
+          reference
+            "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
+        }
+        leaf result {
+          type boolean;
+          default "true";
+          config false;
+          description
+            "Indicates the result of the operation:
+               TRUE - The Linktrace message will be (or has been) 
+                      sent.
+               FALSE - The Linktrace message will not be sent.";
+          reference
+            "12.14.7.4.3a of IEEE Std 802.1Q-2018";
+        }
+        leaf seq-number {
+          type cfm-types:seq-number-type;
+          config false;
+          description
+            "The LTM transaction identifier 
+            (mep-ltm-next-seq-number) of the LTM sent. The value
+            returned is undefined if mep-transmit-ltm-result is 
+            FALSE.";
+          reference
+            "12.14.7.4.3b of IEEE Std 802.1Q-2018";
+        }
+        leaf egress-identifier {
+          type string {
+            length "8";
+          }
+          config false;
+          description
+            "Identifies the MEP Linktrace Initiator that is 
+            originating, or the Linktrace Responder that is
+            forwarding, this LTM.
+            
+            The low-order six octets contain a 48-bit IEEE MAC
+            address unique to the system in which the MEP 
+            Linktrace Initiator or Linktrace Responder resides.
+            The high-order two octets contain a value sufficient
+            to uniquely identify the MEP Linktrace Initiator or 
+            Linktrace Responder within that system.
+            
+            For most Bridges, the address of any MAC attached to
+            the Bridge will suffice for the low-order six octets,
+            and 0 for the high-order octets. In some situations,
+            e.g., if multiple virtual Bridges utilizing emulated
+            LANs are implemented in a single physical system, the
+            high-order two octets can be used to differentiate
+            among the transmitting entities.
+            
+            The value returned is undefined if 
+            mep-transmit-ltm-result is FALSE.";
+          reference
+            "12.14.7.4.3c of IEEE Std 802.1Q-2018";
+        }
+        leaf next-seq-number {
+          type cfm-types:seq-number-type;
+          config false;
+          description
+            "Next transaction identifier to be sent in a 
+            LinkTrace message.This sequence number can be zero
+            since it can wrap around.";
+          reference
+            "12.14.7.1.3ab, 20.41.1 of IEEE Std 802.1Q-2018";
+        }
+      } // linktrace
+      
+      container stats {
+        config false;
+        description
+          "Contains the counters associated with the MEP.";
+        leaf mep-ccm-sequence-errors {
+          type yang:counter64;
+          description
+            "The total number of out-of-sequence CCMs received
+            from all remote MEPs.";
+          reference
+            "12.14.7.1.3v, 20.16.12 of IEEE Std 802.1Q-2018";
+        }
+        leaf mep-ccms-sent {
+          type yang:counter64;
+          description
+            "Total number of CCMs transmitted";
+          reference
+            "12.14.7.1.3w, 20.10.2 of IEEE Std 802.1Q-2018";
+        }
+        leaf mep-lbr-in {
+          type yang:counter64;
+          description
+            "Total number of valid, in-order Loopback Replies
+            received.";
+          reference
+            "12.14.7.1.3y, 20.31.1 of IEEE Std 802.1Q-2018";
+        }
+        leaf mep-lbr-in-out-of-order {
+          type yang:counter64;
+          description
+            "The total number of valid, out-of-order
+            Loopback Replies received";
+          reference
+            "12.14.7.1.3z, 20.31.1 of IEEE Std 802.1Q-2018";
+        }
+        leaf mep-lbr-bad-msdu {
+          type yang:counter64;
+          description
+            "The total number of LBRs received whose
+            mac_service_data_unit did not match (except for the
+            OpCode) that of the corresponding LBM.";
+          reference
+            "12.14.7.1.3aa, 20.2.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf mep-unexpected-ltr-in {
+          type yang:counter64;
+          description
+            "The total number of unexpected LTRs received.";
+          reference
+            "12.14.7.1.3ac, 20.44.1 of IEEE Std 802.1Q-2018";
+        }
+        leaf mep-lbr-out {
+          type yang:counter64;
+          description
+            "Total number of Loopback Replies transmitted.";
+          reference
+            "12.14.7.1.3ad, 20.28.2 of IEEE Std 802.1Q-2018";
+        }
+      } // stats
+      
+      notification mep-fault-alarm {
+        description
+          "To alert the Manager to the existence of a fault in a
+          monitored MA by issuing a Fault Alarm.";
+        leaf mep-priority-defect {
+          type leafref {
+            path "../../highest-priority-defect";
+          }
+          description
+            "The highest priority defect that has been present
+            since the MEPs Fault Notification Generator state
+            machine was last in the FNG_RESET state.";
+        }
+      } // mep-fault-alarm
+    } // mep
+  } // meps
+  
+  grouping cfm-operations {
+    description
+      "Grouping of CFM commands.";
+    list cfm-operation {
+      key "maintenance-group mep-id";
+      description 
+        "A list of CFM commands that can be performed.";
+      leaf maintenance-group {
+        type leafref {
+          path '/cfm/maintenance-group-list/maintenance-group';
+        }
+        description
+          "A reference to the maintenance group.";
+      }
+      leaf mep-id {
+        type leafref {
+          path '/cfm'
+            + '/maintenance-group-list'
+            + '[maintenance-group = current()/../maintenance-group]'
+            + '/mep/mep-id';
+        }
+        description
+          "A reference to a MEP associated with the maintenance
+          group.";
+      }
+      
+      action transmit-loopback {
+        description
+          "To signal to the MEP to transmit some number of LBMs.";
+        input {
+          leaf lbm-dest-is-mep-id {
+            type boolean;
+            default "false";
+            description
+              "TRUE indicates that MEP ID of the target MEP is used
+              for Loopback transmissions. FALSE indicates that
+              unicast destination MAC address of the target MEP is
+              used for Loopback transmissions.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-dest-mac-address {
+            type ieee:mac-address;
+            description
+              "The target MAC Address field to be transmitted.
+              A unicast destination MAC address. This address
+              is used if node lbm-dest-is-mep-id is FALSE.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-dest-mep-id {
+            type cfm-types:mep-id-or-zero-type;
+            default 0;
+            description
+              "The identifier of a remote MEP in the same MA to
+              which the LBM is to be sent. This address
+              is used if node mep-transmit-lbm-dest-is-mep-id
+              is TRUE.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf interval {
+            type cfm-types:cfm-interval-type;
+            default 1sec;
+            description
+              "The interval between LBM transmissions to be used by all
+              MEPs in the Maintenance Association.";
+          }
+          leaf lbm-messages {
+            type uint32 {
+              range "1..1024";
+            }
+            default 1;
+            description
+              "The number of Loopback messages to be transmitted.";
+            reference
+              "12.14.7.3.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-priority {
+            type dot1q-types:priority-type;
+            description
+              "Priority. 3 bit value to be used in the VLAN tag, if
+              present in the transmitted frame. The default value
+              should be the CCM priority.";
+            reference
+              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-drop-eligible {
+            type boolean;
+            default "false";
+            description
+              "Drop eligible bit value to be used in the VLAN tag, if
+              present in the transmitted frame";
+            reference
+              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-data-tlv {
+            type cfm-types:lbm-data-tlv-type;
+            description
+              "An arbitrary amount of data to be included in the
+              Data TLV, if the Data TLV is selected to be sent. The
+              intent is to be able to fill the frame carrying the
+              CFM PDU to its maximum length.";
+            reference
+              "12.14.7.3.2d of IEEE Std 802.1Q-2018";
+          }
+        } // input
+        output {
+          leaf lbm-result-ok {
+            type boolean;
+            default "true";
+            description
+              "Indicates the result of the operation:
+                 TRUE - The LBM will be (or has been) sent.
+                 FALSE - The LBM will not be sent.";
+            reference
+              "12.14.7.3.3a of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-seq-number {
+            type cfm-types:seq-number-type;
+            description
+              "The Loopback transaction identifier
+              (mep-next-lbm-trans-id) of the first LBM (to be) sent.
+              The value returned is undefined if 
+              mep-transmit-lbm-result-ok is FALSE.";
+            reference
+              "12.14.7.3.3b of IEEE Std 802.1Q-2018";
+          }     
+        } // output        
+      } // transmit-loopback
+      
+      action transmit-linktrace {
+        description
+          "To signal to the MEP to transmit an LTM and to create an LTM
+          entry in the MEPs Linktrace Database.";
+        input {
+          leaf interval {
+            type cfm-types:cfm-interval-type;
+            default 1sec;
+            description
+              "The interval between LTM transmissions to be used by all
+              MEPs in the Maintenance Association.";
+          }
+          leaf ltm-target-is-mep-id {
+            type boolean;
+            default "false";
+            description
+              "TRUE indicates that MEP id of the target MEP is used
+              for Linktrace transmission. FALSE indicates that
+              unicast destination MAC address of the target MEP is
+              used for LinkTrace transmission.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-target-mac-address {
+            type ieee:mac-address;
+            description
+              "The target MAC address field to be transmitted. A
+              unicast MAC address. This address will be used if the
+              value of mep-transmit-ltm-target-is-mep-id is FALSE.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-target-mep-id {
+            type cfm-types:mep-id-or-zero-type;
+            default 0;
+            description
+              "The target MAC address field to be transmitted. The
+              MEP identifier of another MEP in the same MA. This
+              address will be used if the value of 
+              mep-transmit-ltm-target-is-mep-id is TRUE.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-priority {
+            type dot1q-types:priority-type;
+            description
+              "Priority. 3 bit value to be used in the VLAN tag, if
+              present in the transmitted frame. The default value
+              should be the CCM priority.";
+          }
+          leaf ltm-drop-eligible {
+            type boolean;
+            default "false";
+            description
+              "Drop eligible bit value to be used in the VLAN tag, if
+              present in the transmitted frame";
+          }
+          leaf ltm-ttl {
+            type uint32 {
+              range "0..255";
+            }
+            default 64;
+            description
+              "The LTM TTL field. Indicates the number of hops 
+              remaining to the LTM. Decremented by 1 by each
+              Linktrace Responder that handles the LTM. The value
+              returned in the LTR is one less than that received in
+              the LTM. If the LTM TTL is 0 or 1, the LTM is not
+              forwarded to the next hop, and if 0, no LTR is 
+              generated.";
+            reference
+              "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-flags {
+            type cfm-types:mep-tx-ltm-flags-type;
+            default use-fdb-only;
+            description
+              "The flags field for the LTMs transmitted by the MEP.";
+            reference
+              "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
+            
+          }
+        } // input
+        output {
+          leaf ltm-result-ok {
+            type boolean;
+            default "true";
+            description
+              "Indicates the result of the operation:
+                 TRUE - The Linktrace message will be (or has been) 
+                        sent.
+                 FALS - The Linktrace message will not be sent.";
+            reference
+              "12.14.7.4.3a of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-seq-number {
+            type cfm-types:seq-number-type;
+            description
+              "The LTM transaction identifier 
+              (mep-ltm-next-seq-number) of the LTM sent. The value
+              returned is undefined if mep-transmit-ltm-result is 
+              FALSE.";
+            reference
+              "12.14.7.4.3b of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-egress-identifier {
+            type string {
+              length "8";
+            }
+            description
+              "Identifies the MEP Linktrace Initiator that is 
+              originating, or the Linktrace Responder that is
+              forwarding, this LTM.
+              
+              The low-order six octets contain a 48-bit IEEE MAC
+              address unique to the system in which the MEP Linktrace
+              Initiator or Linktrace Responder resides. The 
+              high-order two octets contain a value sufficient to 
+              uniquely identify the MEP Linktrace Initiator or 
+              Linktrace Responder within that system.
+              
+              For most Bridges, the address of any MAC attached to
+              the Bridge will suffice for the low-order six octets,
+              and 0 for the high-order octets. In some situations,
+              e.g., if multiple virtual Bridges utilizing emulated
+              LANs are implemented in a single physical system, the
+              high-order two octets can be used to differentiate
+              among the transmitting entities.
+              
+              The value returned is undefined if 
+              mep-transmit-ltm-result is FALSE.";
+            reference
+              "12.14.7.4.3c of IEEE Std 802.1Q-2018";
+          }
+        } // output
+      } // transmit-linktrace
+      
+      list loopback-reply {
+        key "lbr-seq-number lbr-receive-order";
+        description 
+          "This table extends the MEP table and contains a list
+          of Loopback replies received by a specific MEP in
+          response to a loopback message.";
+        leaf lbr-seq-number {
+          type cfm-types:seq-number-type;
+          description
+            "The Loopback transaction identifier
+            (mep-next-lbm-trans-id) of the first LBM (to be) 
+            sent. The value returned is undefined if 
+            mep-transmit-lbm-result-ok is FALSE.";
+          reference
+            "12.14.7.3.3b of IEEE Std 802.1Q-2018";
+        }
+        leaf lbr-receive-order {
+          type uint32 {
+            range "1..4294967295";
+          }
+          description
+            "An index to distinguish among multiple LBRs with
+            the same LBR Transaction Identifier field value. 
+            Assigned sequentially from 1, in the order that the 
+            Loopback Initiator received the LBRs.";
+        }
+        leaf result-ok {
+          type boolean;
+          default "true";
+          config false;
+          description
+            "Indicates the result of the operation:
+               TRUE - The LBM will be (or has been) sent.
+               FALSE - The LBM will not be sent.";
+          reference
+            "12.14.7.3.3a of IEEE Std 802.1Q-2018";
+        }
+      } // loopback-reply
+      
+      list linktrace-reply {
+        key "ltr-seq-number ltr-receive-order";
+        description
+          "This table extends the MEP table and contains a list
+          of Linktrace replies received by a specific MEP in
+          response to a linktrace message.";
+        leaf ltr-seq-number {
+          type cfm-types:seq-number-type;
+          description
+            "Transaction identifier returned by a previous
+            transmit linktrace message command, indicating
+            which LTMs response is going to be returned.";
+          reference
+            "12.14.7.5.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-receive-order {
+          type uint32 {
+            range "1..4294967295";
+          }
+          description
+            "An index to distinguish among multiple LTRs with
+            the same LTR Transaction Identifier field value. 
+            Assigned sequentially from 1, in the order that the 
+            Linktrace Initiator received the LTRs.";
+        }
+        leaf ltr-ttl {
+          type uint32 {
+            range "0..255";
+          }
+          config false;
+          description
+            "TTL field value for a returned LTR.";
+          reference
+            "12.14.7.5, 20.41.2.2 of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-forwarded {
+          type boolean;
+          config false;
+          description
+            "Indicates if a LTM was forwarded by the responding
+            MP, as returned in the FwdYes flag of the flags 
+            field.";
+          reference
+            "12.14.7.5.3c, 20.41.2.1 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-terminal-mep {
+          type boolean;
+          config false;
+          description
+            "A Boolean value stating whether the forwarded LTM
+            reached a MEP enclosing its MA, as returned in the
+            Terminal MEP flag of the Flags field";
+          reference
+            "12.14.7.5.3d, 20.41.2.1 of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-last-egress-identifier {
+          type string {
+            length "8";
+          }
+          config false;
+          description
+            "An octet field holding the Last Egress Identifier
+            returned in the LTR Egress Identifier TLV of the
+            LTR. The Last Egress Identifier identifies the MEP
+            Linktrace Initiator that originated, or the 
+            Linktrace Responder that forwarded, the LTM to
+            which this LTR is the response. This is the same
+            value as the Egress Identifier TLV of that LTM.";
+          reference
+            "12.14.7.5.3e, 20.41.2.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-next-egress-identifier {
+          type string {
+            length "8";
+          }
+          config false;
+          description
+            "An octet field holding the Next Egress Identifier
+            returned in the LTR Egress Identifier TLV of the 
+            LTR. The Next Egress Identifier Identifies the
+            Linktrace Responder that transmitted this LTR, and
+            can forward the LTM to the next hop. This is the
+            same value as the Egress Identifier TLV of the
+            forwarded LTM, if any. If the FwdYes bit of the
+            Flags field is false, the contents of this field
+            are undefined, i.e., any value can be transmitted,
+            and the field is ignored by the receiver.";
+          reference
+            "12.14.7.5.3f, 20.41.2.4 of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-relay {
+          type cfm-types:relay-action-field-value;
+          config false;
+          description
+            "Value returned in the Relay Action field.";
+          reference
+            "12.14.7.5.3g, 20.41.2.5 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-chassis-id-subtype {
+          type cfm-types:lldp-chassis-id-subtype;
+          config false;
+          description
+            "Specifies the format of the Chassis ID returned
+            in the Sender ID TLV of the LTR, if any. This value
+            is meaningless if the ltr-chassis-id has a length
+            of 0.";
+          reference
+            "12.14.7.5.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-chassis-id {
+          type cfm-types:lldp-chassis-id;
+          config false;
+          description
+            "The Chassis ID returned in the Sender ID TLV of 
+            the LTR, if any. The format of this object is
+            determined by the value of the 
+            ltr-chassis-id-subtype object.";
+          reference
+            "12.14.7.5.3i, 21.5.3.2 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-man-address-domain {
+          type cfm-types:transport-service-domain;
+          config false;
+          description
+            "The transport-service-domain that identifies the
+            type and format of the related mep-db-man-address
+            object, used to access the YANG agent of the system
+            transmitting the LTR. Received in the LTR Sender ID
+            TLV from that system.";
+          reference
+            "12.14.7.5.3j, 21.5.3.5,
+            21.9.6 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-man-address {
+          type cfm-types:transport-service-address;
+          config false;
+          description
+            "The transport-service-address that can be used to
+            access the YANG agent of the system transmitting
+            the CCM, received in the CCM Sender ID TLV from
+            that system.
+            
+            If the related object ltr-man-address-domain
+            contains the value zeroDotZero, this object
+            ltr-man-address MUST have a zero-length OCTET 
+            STRING as a value.";
+          reference
+            "12.14.7.5.3j, 21.5.3.7,
+            21.9.6 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-ingress {
+          type cfm-types:ingress-action-field-value;
+          config false;
+          description
+            "The value returned in the Ingress Action Field of
+            the LTM. The value ingress-no-tlv indicates that no
+            Reply Ingress TLV was returned in the LTM.";
+          reference
+            "12.14.7.5.3k, 20.41.2.6 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-ingress-mac {
+          type ieee:mac-address;
+          config false;
+          description
+            "MAC address returned in the ingress MAC address
+            field. If the ltr-ingress object contains the value 
+            ingress-no-tlv, then the contents of this object
+            are meaningless.";
+          reference
+            "12.14.7.5.3l, 20.41.2.7 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-ingress-port-id-subtype {
+          type cfm-types:lldp-port-id-subtype;
+          config false;
+          description
+            "Ingress Port ID. The format of this object is 
+            determined by the value of the 
+            ltr-ingress-port-id-subtype object. If the
+            ltr-ingress object contains the value 
+            ingress-no-tlv, then the contents of this object
+            are meaningless.";
+          reference
+            "12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-egress {
+          type cfm-types:egress-action-field-value;
+          config false;
+          description
+            "The value returned in the Egress Action Field of
+            the LTM. The value egress-no-tlv indicates that 
+            no Reply Egress TLV was returned in the LTM.";
+          reference
+            "12.14.7.5.3o, 20.41.2.10 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-egress-mac {
+          type ieee:mac-address;
+          config false;
+          description
+            "MAC address returned in the egress MAC address
+            field. If the ltr-egress object contains the value
+            egress-no-tlv, then the contents of this object are
+            meaningless.";
+          reference
+            "12.14.7.5.3p, 20.41.2.11 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-egress-port-id-subtype {
+          type cfm-types:lldp-port-id-subtype;
+          config false;
+          description
+            "Format of the egress Port ID. If the ltr-egress
+            object contains the value egress-no-tlv, then the
+            contents of this object are meaningless.";
+          reference
+            "12.14.7.5.3q, 20.41.2.12 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-egress-port-id {
+          type cfm-types:lldp-port-id;
+          config false;
+          description
+            "Egress Port ID. The format of this object is
+            determined by the value of the
+            ltr-egress-port-id-subtype object. If the 
+            ltr-egress object contains the value egress-no-tlv,
+            then the contents of this object are meaningless.";
+          reference
+            "12.14.7.5.3r, 20.41.2.13 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-organization-specific-tlv {
+          type string {
+            length "0 | 4..1500";
+          }
+          config false;
+          description
+            "All Organization specific TLVs returned in the 
+            LTR, if any. Includes all octets including and
+            following the TLV Length field of each TLV, 
+            concatenated together.";
+          reference
+            "12.14.7.5.3s, 21.5.2 of IEEE Std 802.1Q-2018";
+        }
+      } // linktrace-reply
+    } // cfm-operation
+  } // cfm-operations
+  
+} // ieee802-cfm-mep

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-mip.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-mip.yang
@@ -1,0 +1,82 @@
+module ieee802-dot1q-cfm-mip {
+  yang-version 1.1;
+  
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-cfm-mip";
+  prefix "cfm-mip";
+  
+  import ieee802-dot1q-cfm { prefix "dot1q-cfm"; }
+  import ieee802-dot1q-cfm-types { prefix "cfm-types"; }
+
+  organization
+    "IEEE 802.1 Working Group";
+
+  contact
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+  
+    E-mail: STDS-802-1-L@IEEE.ORG";
+
+  description
+    "TBD.";
+  
+  revision 2018-04-10 {
+    description
+      "Initial creation for Task Group review.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  
+  
+  augment "/dot1q-cfm:cfm" {
+    description
+      "Augment the CFM (base/common) YANG module (ieee802-dot1q-cfm)
+      with explicit MIP configuration specific attributes.";
+    
+    container mips {
+      description
+        "Maintenance Association Intermediate Points";
+      list mip {
+        key "mip-id";
+        description
+          "A list of MIPs associated with device interface.";
+        leaf mip-id {
+          type cfm-types:name-key-type;
+          description
+            "The index into the MIP list which identifies the MIP.";
+        }
+        leaf md-level {
+          type cfm-types:md-level-type;
+          default 0;
+          description
+            "A value indicating the MD Level at which MHFs are to be
+            created, and Sender ID TLV transmission by those MHFs is to
+            be controlled, for the VLAN to which this entry's objects
+            apply.";
+          reference
+            "12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf id-permission {
+          type cfm-types:sender-id-permission-type;
+          default "send-id-none";
+          description
+            "Enumerated value indicating what, if anything, is to be
+            included in the Sender ID TLV transmitted by MHFs
+            created by the Default Maintenance Domain. If this object
+            has the value send-if-defer, Sender ID TLV transmission 
+            for this VLAN is controlled by md-id-permission-type.";
+          reference
+            "12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
+        }
+      } // mip
+    } // mips
+  }
+} // ieee802-cfm-mip

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-types.yang
@@ -1,0 +1,988 @@
+module ieee802-dot1q-cfm-types {
+  yang-version 1.1;
+  
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-cfm-types";
+  prefix "cfm-types";
+  
+  import ietf-yang-types { prefix "yang"; }
+
+  organization
+    "IEEE 802.1 Working Group";
+
+  contact
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+  
+    E-mail: STDS-802-1-L@IEEE.ORG";
+
+  description
+    "Common types used within ieee802-dot1q-cfm modules.";
+  
+  revision 2018-04-10 {
+    description
+      "Initial creation for Task Group review.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  
+  /* -----------------------------------------------------
+   * Type definitions used by 802.1AB -LLDP YANG module.
+   *
+   *   NOTE: These types will be moved to the IEEE 802.1AB
+   *         YANG module at the appropriate time.
+   * -----------------------------------------------------
+   */
+  
+  typedef lldp-chassis-id-subtype {
+    type enumeration {
+      enum chassis-component {
+        value 1;
+        description
+          "Represents a chassis identifier based on the value of
+          entPhysicalAlias object (defined in IETF RFC 2737) for a
+          chassis component (i.e., an entPhysicalClass value of
+          chassis(3))";
+      }
+      enum interface-alias {
+        value 2;
+        description
+          "Represents a chassis identifier based on the value of
+          ifAlias object (defined in IETF RFC 2863) for an interface
+          on the containing chassis.";
+      }
+      enum port-component {
+        value 3;
+        description
+          "Represents a chassis identifier based on the value of
+          entPhysicalAlias object (defined in IETF RFC 2737) for a
+          port or backplane component (i.e., entPhysicalClass value of
+          port(10) or backplane(4)), within the containing chassis.";
+      }
+      enum mac-address {
+        value 4;
+        description
+          "Represents a chassis identifier based on the value of a
+          unicast source address (encoded in network byte order and
+          IEEE 802.3 canonical bit order), of a port on the containing
+          chassis as defined in IEEE Std 802-2001.";
+      }
+      enum network-address {
+        value 5;
+        description
+          "Represents a chassis identifier based on a network address,
+          associated with a particular chassis.  The encoded address is
+          actually composed of two fields.  The first field is a
+          single octet, representing the IANA AddressFamilyNumbers
+          value for the specific address type, and the second field is
+          the network address value.";
+      }
+      enum interface-name {
+        value 6;
+        description
+          "Represents a chassis identifier based on the value of
+          ifName object (defined in IETF RFC 2863) for an interface
+          on the containing chassis.";
+      }
+      enum local {
+        value 7;
+        description
+          "Represents a chassis identifier based on a locally defined
+          value.";
+      }
+    }
+    description
+      "The source of a chassis identifier.";
+    reference
+      "LLDP MIB 20050506";
+  }
+  
+  typedef lldp-chassis-id {
+    type string {
+      length "1..255";
+    }
+    description
+      "The format of a chassis identifier string. Objects of this type
+      are always used with an associated lldp-chassis-is-subtype
+      object, which identifies the format of the particular
+      lldp-chassis-id object instance.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      chassis-component, then the octet string identifies
+      a particular instance of the entPhysicalAlias object
+      (defined in IETF RFC 2737) for a chassis component (i.e.,
+      an entPhysicalClass value of chassis(3)).
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of interface-alias, then the octet string identifies
+      a particular instance of the ifAlias object (defined in
+      IETF RFC 2863) for an interface on the containing chassis.
+      If the particular ifAlias object does not contain any values,
+      another chassis identifier type should be used.
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of port-component, then the octet string identifies a
+      particular instance of the entPhysicalAlias object (defined
+      in IETF RFC 2737) for a port or backplane component within
+      the containing chassis.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      mac-address, then this string identifies a particular
+      unicast source address (encoded in network byte order and
+      IEEE 802.3 canonical bit order), of a port on the containing
+      chassis as defined in IEEE Std 802-2001.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      network-address, then this string identifies a particular
+      network address, encoded in network byte order, associated
+      with one or more ports on the containing chassis.  The first
+      octet contains the IANA Address Family Numbers enumeration
+      value for the specific address type, and octets 2 through
+      N contain the network address value in network byte order.
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of interface-name, then the octet string identifies
+      a particular instance of the ifName object (defined in
+      IETF RFC 2863) for an interface on the containing chassis.
+      If the particular ifName object does not contain any values,
+      another chassis identifier type should be used.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      local, then this string identifies a locally assigned
+      Chassis ID.";
+    reference
+      "LLDP MIB 20050506";
+  }
+  
+  typedef lldp-port-id-subtype {
+    type enumeration {
+      enum interface-alias {
+        value 1;
+        description
+          "Represents a port identifier based on the ifAlias
+          MIB object, defined in IETF RFC 2863.";
+      }
+      enum port-component {
+        value 2;
+        description
+          "Represents a port identifier based on the value of
+          entPhysicalAlias (defined in IETF RFC 2737) for a port
+          component (i.e., entPhysicalClass value of port(10)), 
+          within the containing chassis.";
+      }
+      enum mac-address {
+        value 3;
+        description
+          "Represents a port identifier based on a unicast source
+          address (encoded in network byte order and IEEE 802.3
+          canonical bit order), which has been detected by the agent
+          and associated with a particular port (IEEE Std 802-2001).";
+      }
+      enum network-address {
+        value 4;
+        description
+          "Represents a port identifier based on a network address,
+          detected by the agent and associated with a particular 
+          port.";
+      }
+      enum interface-name {
+        value 5;
+        description
+          "Represents a port identifier based on the ifName MIB object,
+          defined in IETF RFC 2863.";
+      }
+      enum agent-circuit-id {
+        value 6;
+        description
+          "Represents a port identifier based on the agent-local
+          identifier of the circuit (defined in RFC 3046), detected by
+          the agent and associated with a particular port.";
+      }
+      enum local {
+        value 7;
+        description
+          "Represents a port identifier based on a value locally
+          assigned.";
+      }
+    }
+    description
+      "The source of a particular type of port identifier used
+      in the LLDP YANG module.";
+  }
+  
+  typedef lldp-port-id {
+    type string {
+      length "8";
+    }
+    description
+      "The format of a port identifier string. Objects of this type
+      are always used with an associated lldp-port-id-subtype object,
+      which identifies the format of the particular lldp-port-id
+      object instance.
+
+      If the associated lldp-port-id-subtype object has a value of
+      interface-alias, then the octet string identifies a
+      particular instance of the ifAlias object (defined in IETF
+      RFC 2863).  If the particular ifAlias object does not contain
+      any values, another port identifier type should be used.
+
+      If the associated lldp-port-id-subtype object has a value of
+      port-component, then the octet string identifies a
+      particular instance of the entPhysicalAlias object (defined
+      in IETF RFC 2737) for a port or backplane component.
+
+      If the associated lldp-port-id-subtype object has a value of
+      mac-address, then this string identifies a particular
+      unicast source address (encoded in network byte order
+      and IEEE 802.3 canonical bit order) associated with the port
+      (IEEE Std 802-2001).
+
+      If the associated lldp-port-id-subtype object has a value of
+      network-address, then this string identifies a network
+      address associated with the port.  The first octet contains
+      the IANA AddressFamilyNumbers enumeration value for the
+      specific address type, and octets 2 through N contain the
+      networkAddress address value in network byte order.
+
+      If the associated lldp-port-id-subtype object has a value of
+      interface-name, then the octet string identifies a
+      particular instance of the ifName object (defined in IETF
+      RFC 2863).  If the particular ifName object does not contain
+      any values, another port identifier type should be used.
+
+      If the associated lldp-port-id-subtype object has a value of
+      agent-circuit-id, then this string identifies a agent-local
+      identifier of the circuit (defined in RFC 3046).
+
+      If the associated lldp-port-id-subtype object has a value of
+      local, then this string identifies a locally assigned port ID.";
+  }
+  
+  /* -------------------------------------------------------
+   * Type definitions used by RFC 2579 SNMP v2 YANG module.
+   *
+   *   NOTE: These types will be moved to a more generic
+   *         IEEE YANG types module. For example, perhaps
+   *         ieee802-types.
+   * -------------------------------------------------------
+   */
+ 
+  typedef transport-service-domain {
+    type yang:object-identifier;
+    description
+      "Denotes a kind of transport service";
+    reference
+      "RFC2579 - Textual Conventions for SMIv2";
+  }
+  
+  typedef transport-service-address {
+    type string {
+      length "1..255";
+    }
+    description
+      "Denotes a transport service address";
+  }
+
+  /* ------------------------------------------------------
+   * Type definitions used by 802.1Qcx YANG module.
+   * ------------------------------------------------------
+   */
+  
+  typedef mhf-creation-type {
+    type enumeration {
+      enum mhf-none {
+        value 1;
+        description
+          "No MHFs can be created for designated VID(s) or ISID.";
+      }
+      enum mhf-default {
+        value 2;
+        description
+          "MHFs can be created for designated VID(s) or ISID on any
+          Bridge Port through which the VID(s) or ISID can pass, where:
+            i) There are no lower active MD levels; or
+           ii) There is a MEP at the next lower active MD level on 
+               the port.";
+      }
+      enum mhf-explicit {
+        value 3;
+        description
+          "MHFs can be created for designated VID(s) or ISID only
+          on Bridge Ports through which the VID(s) or ISID can pass, 
+          and onlyh if there is a MEP at the next lower active 
+          MD level on the port.";
+      }
+      enum mhf-defer {
+        value 4;
+        description
+          "In the Maintenance Association only, the control of MHF
+          creation is deferred to the corresponding variable in
+          the enclosing Maintenance Domain.";
+      }
+    }
+    description
+      "Indicates if the Management Entity can create MHFs.";
+  }
+  
+  typedef mp-direction-type {
+    type enumeration {
+      enum down {
+        value 1;
+        description
+          "Down maintenance point, where CFM protocol messages
+          are dispatched away from the MAC Relay entity.";
+      }
+      enum up {
+        value 2;
+        description
+          "Up maintenance point, where CFM protocol messages 
+          are dispatched towards the MAC Relay entity.";
+      }
+    }
+    description
+      "Indicates the direction in which the Maintenance
+      association (MEP or MIP) faces on the Bridge Port.";
+  }
+  
+  typedef mep-id-type {
+    type uint32 {
+      range "1..8191";
+    }
+    description
+      "Maintenance association End Point Identifier, which is
+      unique over a given Maintenance Association.";
+  }
+  
+  typedef mep-id-or-zero-type {
+    type uint32 {
+      range "0 | 1..8191";
+    }
+    description
+      "Maintenance association End Point Identifier, which is
+      unique over a given Maintenance Association.
+      
+      The special value 0 is allowed to indicate a special case when
+      there is no MEPID configured.";
+  }
+  
+  typedef md-level-type {
+    type uint32 {
+      range "0..7";
+    }
+    description
+      "Integer identifying the Maintenance Domain Level (MD Level).
+      Higher numbers correspond to higher Maintenance Domains,
+      those with the greatest physical reach, with the highest
+      values for customers' CFM PDUs. Lower numbers correspond
+      to lower Maintenance Domains, those with more limited
+      physical reach, with the lowest values for CFM PDUs
+      protecting single bridges or physical links.";
+  }
+  
+  typedef md-level-or-none-type {
+    type int32 {
+      range "-1 | 0..7";
+    }
+    description
+      "Integer identifying the Maintenance Domain Level (MD Level).
+      Higher numbers correspond to higher Maintenance Domains,
+      those with the greatest physical reach, with the highest
+      values for customers CFM packets. Lower numbers correspond
+      to lower Maintenance Domains, those with more limited
+      physical reach, with the lowest values for CFM PDUs
+      protecting single bridges or physical links.
+      The value (-1) is reserved to indicate that no MA Level has
+      been assigned.";
+  }
+  
+  typedef component-identifier-type {
+    type uint32 {
+      range "1..4294967295";
+    }
+    description
+      "The component identifier is used to distinguish between the
+      multiple virtual Bridge instances within a PB or PBB. Each
+      virtual Bridge instance is called a component. In simple
+      situations where there is only a single component the default
+      value is 1. The component is identified by a component
+      identifier unique within the BEB and by a MAC address unique
+      within the PBBN. Each component is associated with a Backbone
+      Edge Bridge (BEB) Configuration managed object.";
+  }
+  
+  typedef port-status-tlv-value {
+    type enumeration {
+      enum no-port-state-tlv {
+        value 0;
+        description
+          "Indicates either that no CCM has been received or that
+          no port status TLV was present in the last CCM received.";
+      }
+      enum blocked {
+        value 1;
+        description
+          "Ordinary data cannot pass freely through the port on
+          which the remote MEP resides.";
+      }
+      enum up {
+        value 2;
+        description
+          "Ordinaty data can pass freely through the port on which
+          the remote MEP resides.";
+      }
+    }
+    description
+      "An enumerated value from he Port Status TLV from the last CCM
+      received from the last MEP. It indicates the ability of the
+      Bridge Port on which the transmitting MEP resides to pass
+      ordinary data, regardless of the status of the MAC.";
+  }
+  
+  typedef interface-status-tlv-value {
+    type enumeration {
+      enum is-no-interface-status-tlv {
+        value 0;
+        description
+          "Indicates either that no CCM has been received or that
+          no interface status TLV was present in the last CCM
+          received.";
+      }
+      enum is-up {
+        value 1;
+        description
+          "The interface is ready to pass packets.";
+      }
+      enum is-down {
+        value 2;
+        description
+          "The interface can not pass packets.";
+      }
+      enum is-testing {
+        value 3;
+        description
+          "The interface is in same test mode.";
+      }
+      enum is-unknown {
+        value 4;
+        description
+          "The interface status cannot be determined for some
+          reason.";
+      }
+      enum is-dormant {
+        value 5;
+        description
+          "The interface is not in a state to pass packets but is in
+          a pending state, waiting for some extrnal event.";
+      }
+      enum is-not-present {
+        value 6;
+        description
+          "Some component of the interface is mssing.";
+      }
+      enum is-lower-layer-down {
+        value 7;
+        description
+          "The interface is down due to state of the lower layer
+          interface.";
+      }
+    }
+    description
+      "An enumerated value from the Interface Status TLV from the
+      last CCM received from the last MEP. It indicates the status
+      of the Interface within which the MEP transmitting the CCM
+      is configured, or the next lower Interface in the Interface
+      Stack, if the MEP is not configured within an Interface.";
+  }
+  
+  typedef highest-defect-priority-type {
+    type enumeration {
+      enum none {
+        value 0;
+        description
+          "No defects since Fault Notification Generator state
+          machine reset.";
+      }
+      enum def-rdi-ccm {
+        value 1;
+        description
+          "The last CCM received by this MEP from some remote MEP
+          contained the RDI bit set.";
+      }
+      enum def-mac-status {
+        value 2;
+        description
+          "The last CCM received by this MEP from some remote MEP
+          indicating that the transmitting MEP's associated MAC is
+          reporting an error status via the Port Status TLV or
+          Interface Status TLV is set.";
+      }
+      enum def-remote-ccm {
+        value 3;
+        description
+          "This MEP is not receiving CCMs from some other MEP in its
+          configured list.";
+      }
+      enum def-error-ccm {
+        value 4;
+        description
+          "This MEP is receiving invalid CCMs.";
+      }
+      enum def-xcon-ccm {
+        value 5;
+        description
+          "This MEP is receiving CCMs that could be from some other 
+          MA.";
+      }
+    }
+    description
+      "An enumerated value, equal to the contents of the variable
+      highestDefect (20.35.9 and Table 20-1), indicating the
+      highest-priority defect that has been present since the MEP
+      Fault Notification Generator State Machine was last in the
+      FNG_RESET state.";
+  }
+  
+  typedef lowest-alarm-priority-type {
+    type enumeration {
+      enum all-def {
+        value 1;
+        description
+          "Includes def-rid-ccm, def-mac-status, def-remote-ccm,
+          def-error-ccm, and def-xcon-ccm.";
+      }
+      enum mac-remote-error-xcon {
+        value 2;
+        description
+          "Only includes def-mac-status, def-remote-ccm, def-error-ccm,
+          and def-xcon-ccm.";
+      }
+      enum remote-error-xcon {
+        value 3;
+        description
+          "Includes def-remote-ccm, def-error-ccm, and def-xcon-ccm.";
+      }
+      enum error-xcon {
+        value 4;
+        description
+          "Includes def-error-ccm and def-xcon-ccm.";
+      }
+      enum xcon {
+        value 5;
+        description
+          "Only def-xcon-ccm";
+      }
+      enum no-xcon {
+        value 6;
+        description
+          "No defects def-xcon or lower are to be reported.";
+      }
+    }
+    description
+      "An integer value specifying the lowest priority defect
+      that is allowed to generate a Fault Alarm (20.9.5).";
+  }
+  
+  typedef sender-id-permission-type {
+    type enumeration {
+      enum send-id-none {
+        value 1;
+        description 
+          "The Sender ID TLV is not to be sent.";
+      }
+      enum send-id-chassis {
+        value 2;
+        description
+          "The Chassis ID Length, Chassis ID Subtype, and Chassis ID
+          fields of te Sender ID TLV are to be sent.";
+      }
+      enum send-id-manage {
+        value 3;
+        description
+          "The Management Address Length and Management Address
+          of the Sender ID TLV are to be sent.";
+      }
+      enum send-id-chassis-manage {
+        value 4;
+        description
+          "The Chassis ID Length, Chassis ID Subtype, Chassis ID, 
+          Management Address Length and Management Address fields are
+          all to be sent.";
+      }
+      enum send-id-defer {
+        value 5;
+        description
+          "The content of the Sender ID TLV are determined by the
+          corresponding Maintenance Domain variable.";
+      }
+    }
+    description
+      "Indicates what, if anything, is to be included in the Sender
+      ID TLV transmitted in CCMs, LBMs, LTMs, and LTRs.";
+  }
+  
+  typedef cfm-interval-type {
+    type enumeration {
+      enum invalid {
+        value 0;
+        description
+          "No CFM PDUs are to be sent";
+      }
+      enum 300hz {
+        value 1;
+        description
+          "CFM PDUs are sent every 3 1/3 milliseconds (300Hz).";
+      }
+      enum 10ms {
+        value 2;
+        description
+          "CFM PDUs are sent every 10 milliseconds.";
+      }
+      enum 100ms {
+        value 3;
+        description
+          "CFM PDUs are sent every 100 milliseconds.";
+      }
+      enum 1sec {
+        value 4;
+        description
+          "CFM PDUs are sent every second.";
+      }
+      enum 10sec {
+        value 5;
+        description
+          "CFm PDUs are sent every 10 seconds.";
+      }
+      enum 1min {
+        value 6;
+        description
+          "CFM PDUs are sent every minute.";
+      }
+      enum 10min {
+        value 7;
+        description
+          "CFM PDUs are sent every 10 minutes.";
+      }
+    }
+    description
+      "Indicates the interval at which CFM PDUs are sent by a MEP.";
+  }
+  
+  typedef fng-state-type {
+    type enumeration {
+      enum fng-reset {
+        value 1;
+        description
+          "No defect has been present since the mep-fng-reset-time
+          timer expired, or since the state machine was last reset.";
+      }
+      enum fng-defect {
+        value 2;
+        description
+          "A defect is present, but not for a long enough time to be
+          reported.";
+      }
+      enum fng-report-defect {
+        value 3;
+        description
+          "A momentary state during which the defect is reported by sending a
+          fault-alarm notification, if that action is enabled.";
+      }
+      enum fng-defect-reported {
+        value 4;
+        description
+          "A defect is present, and some defect has been reported.";
+      }
+      enum fng-defect-clearing {
+        value 5;
+        description
+          "No defect is present, but the mep-fng-reset-time timer
+          has not yet expired.";
+      }
+    }
+    description
+      "Indicates the different states of the MEP Fault Notification
+      Generator State Machine.";
+  }
+  
+  typedef relay-action-field-value {
+    type enumeration {
+      enum relay-hit {
+        value 1;
+        description
+          "The LTM reached a Maintenance Point whose MAC address
+          matches the target address.";
+      }
+      enum relay-fdb {
+        value 2;
+        description
+          "The Egress Port was determined by consulting the Filtering
+          Database.";
+      }
+      enum relay-mpdb {
+        value 3;
+        description
+          "The Egress Port was determined by consulting the MIP CCM
+          Database.";
+      }
+    }
+    description
+      "Possible values the Relay action field can take.";
+  }
+  
+  typedef ingress-action-field-value {
+    type enumeration {
+      enum ingress-no-tlv {
+        value 0;
+        description
+          "Indicates that no Reply Ingress TLV was returned in the LTM.";
+      }
+      enum ingress-ok {
+        value 1;
+        description
+          "The target data frame would be passed through to the MAC 
+          Relay Entity.";
+      }
+      enum ingress-down {
+        value 2;
+        description
+          "The Bridge Ports MAC_Operational parameter is false.";
+      }
+      enum ingress-blocked {
+        value 3;
+        description
+          "The target data frame would not be forwarded if received on
+          this Port due to active topology enforcement.";
+      }
+      enum ingress-vid {
+        value 4;
+        description
+          "The ingress port is not in the member set of the LTMs VID,
+          and ingress filtering is enabled, so the target data frame
+          would be filtered by ingress filtering.";
+      }
+    }
+    description
+      "Possible values returned in the ingress action field.";
+  }
+  
+  typedef egress-action-field-value {
+    type enumeration {
+      enum egress-no-tlv {
+        value 0;
+        description
+          "Indicates that no Reply Egress TLV was returned in the LTM.";
+      }
+      enum egress-okay {
+        value 1;
+        description
+          "The targeted data frame would be forwarded.";
+      }
+      enum egress-down {
+        value 2;
+        description
+          "The Egress Port can be identified, but that Bridge Port
+          MAC_Operational parameter is false.";
+      }
+      enum egress-blocked {
+        value 3;
+        description
+          "The Egress Port can be identified, but the data frame would
+          not pass through the Egress Port due to active topology 
+          management (i.e., the Bridge Port is not in the 
+          Forwardin state.";
+      }
+      enum egress-vid {
+        value 4;
+        description
+          "The Egress Port can be identified, but the Bridge Port is not
+          in the LTMs VIDs member set, so would be filtered by
+          egress filtering.";
+      }
+    }
+    description
+      "Possible values returned in the egress action field.";
+  }
+  
+  typedef remote-mep-state-type {
+    type enumeration {
+      enum rmep-idle {
+        value 1;
+        description
+          "Momentary state during reset.";
+      }
+      enum rmep-start {
+        value 2;
+        description
+          "The timer has not expired since the state machine
+          was reset, and no valid CCM has yet been received.";
+      }
+      enum rmep-failed {
+        value 3;
+        description
+          "The timer has expired, both since the state machine was
+          reset, and since a valid CCM was received.";
+      }
+      enum rmep-ok {
+        value 4;
+        description
+          "The timer has not expired since a valid CCM was received.";
+      }
+    }
+    description
+      "Operational state of the remote MEP state machine. This
+      state machine monitors the reception of valid CCMs from a
+      remote MEP with a specific MEPID. It uses a timer that
+      expires in 3.5 times the length of time indicated by the
+      ma-ccm-interval object.";
+  }
+  
+  typedef mep-defects-type {
+    type bits {
+      bit def-rdi-ccm {
+        position 0;
+        description
+          "A remote MEP reported that RDI bit in its last CCM.";
+      }
+      bit def-mac-status {
+        position 1;
+        description
+          "Either some remote MEP is reporting its Interface Status
+          TLV as not isUp, or all remote MEPs are reporting a Port 
+          Status TLV that contains some value other than psUp.";
+      }
+      bit def-remote-ccm {
+        position 2;
+        description
+          "The MEP is not receiving valid VCMs from at least one of
+          the remote MEPs.";
+      }
+      bit def-error-ccm {
+        position 3;
+        description
+          "The MEP has received at least one invalid CCM whose CCM
+          Interval has not yet timed out.";
+      }
+      bit def-xcon-ccm {
+        position 4;
+        description
+          "The MEP has received at last one CCM from either another 
+          MAID or a lower MD level whose CCm Interval has not yet 
+          timed out.";
+      }
+    }
+    description
+      "A MEP can detect and report a number of defects, and multiple
+      defects can be present at the same time.";
+  }
+  
+  typedef config-error-type {
+    type bits {
+      bit cfm-leaf {
+        position 0;
+        description
+          "MA x is associated with a specific VID list, one or more 
+          of the VIDs in MA x can pass through the Bridge Port,
+          no Down MEP is configured on any Bridge Port for MA x,
+          and some other MA y, at a higher MD Level than MA x, and
+          associated with at least one of the VID(s) also in MA x,
+          does have a MEP configured on the Bridge Port.";
+      }
+      bit conflicting-vids {
+        position 1;
+        description
+          "MA x is associated with a specific VID list, an Up MEP is
+          configured on MA x on the Bridge Port, and some other MA y,
+          associated with at least one of the VID(s) also in MA x,
+          also has an Up MEP configured on some Bridge Port.";
+      }
+      bit excessive-levels {
+        position 2;
+        description
+          "The number of different MD Levels at which MIPs are to be
+          created on this port exceeds the Bridge's capabilities.";
+      }
+      bit overlapped-levels {
+        position 3;
+        description
+          "A MEP is created for one VID at one MD Level, but a MEP is
+          configured on another VID at that MD Level or higher,
+          exceeding the Bridges capabilities.";
+      }
+    }
+    description
+      "While making the MIP creation evaluation described in
+      22.2.3, the management entity can encounter errors in
+      the configuration.";
+  }
+  
+  typedef mep-tx-ltm-flags-type {
+    type bits {
+      bit use-fdb-only {
+        position 0;
+        description
+          "Use FDB only";
+      }
+    }
+    description
+      "The flags field for LTMs transmitted by the MEP.";
+  }
+  
+  typedef fault-alarm-address-type {
+    type enumeration {
+      enum address {
+        value 1;
+        description
+          "Indicates that a Network address to which Fault Alarms
+          are to be transmitted should be used.";
+      }
+      enum not-specified {
+        value 2;
+        description
+          "Indicates not specified. In the case of a MA, then the
+          selection used by the MD should be used.";
+      }
+      enum not-transmitted {
+        value 3;
+        description
+          "Indicates that Fault alarms are not to be transmitted.";
+      }
+    }
+    description
+      "The Fault Alarm address indicators.";
+  }
+  
+  typedef lbm-data-tlv-type {
+    type string {
+      length "1..1480";
+    }
+    description
+      "The loopback message Data TLV type.";
+  }
+  
+  typedef name-key-type {
+    type string {
+      length "1..255";
+      pattern "[0-9a-zA-Z]*";
+    }
+    description
+      "The maintenance domains and maintenance association list key type.";
+  }
+  
+  
+  typedef seq-number-type {
+    type uint32 {
+      range "0..4294967295";
+    }
+    description
+      "The transaction identifer or sequence number of the CFM PDU.";
+  }
+  
+} // ieee802-dot1q-cfm-types

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -1,14 +1,14 @@
 module ieee802-dot1q-cfm {
+  yang-version 1.1;
 
-  namespace "urn:ieee:std:802.1X:yang:ieee802-dot1q-cfm";
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1q-cfm";
   prefix "dot1q-cfm";
-
+  
+  import ieee802-dot1q-cfm-types { prefix "cfm-types"; }
+  import ieee802-dot1q-types { prefix "dot1q-types"; }
   import ieee802-types { prefix "ieee"; }
   import ietf-yang-types { prefix "yang"; }
-  import ietf-interfaces { prefix "if"; }
-  import ieee802-dot1q-types { prefix "dot1q-types"; }
-  import ieee802-dot1q-bridge { prefix "dot1q"; }
-
+  
   organization
     "IEEE 802.1 Working Group";
 
@@ -35,1151 +35,21 @@ module ieee802-dot1q-cfm {
     organizations, each wit restricted management access to each others
     equipment.";
   
-  revision 2017-12-20 {
+  revision 2018-04-10 {
     description
       "Initial creation for Task Group review.";
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
   
-  /* --------------------------------------------------
-   * Type definitions used by 802.1AB -LLDP YANG module
-   * --------------------------------------------------
-   */
-  
-  typedef lldp-chassis-id-subtype {
-    type enumeration {
-      enum chassis-component {
-        value 1;
-        description
-          "Represents a chassis identifier based on the value of
-          entPhysicalAlias object (defined in IETF RFC 2737) for a
-          chassis component (i.e., an entPhysicalClass value of
-          chassis(3))";
-      }
-      enum interface-alias {
-        value 2;
-        description
-          "Represents a chassis identifier based on the value of
-          ifAlias object (defined in IETF RFC 2863) for an interface
-          on the containing chassis.";
-      }
-      enum port-component {
-        value 3;
-        description
-          "Represents a chassis identifier based on the value of
-          entPhysicalAlias object (defined in IETF RFC 2737) for a
-          port or backplane component (i.e., entPhysicalClass value of
-          port(10) or backplane(4)), within the containing chassis.";
-      }
-      enum mac-address {
-        value 4;
-        description
-          "Represents a chassis identifier based on the value of a
-          unicast source address (encoded in network byte order and
-          IEEE 802.3 canonical bit order), of a port on the containing
-          chassis as defined in IEEE Std 802-2001.";
-      }
-      enum network-address {
-        value 5;
-        description
-          "Represents a chassis identifier based on a network address,
-          associated with a particular chassis.  The encoded address is
-          actually composed of two fields.  The first field is a
-          single octet, representing the IANA AddressFamilyNumbers
-          value for the specific address type, and the second field is
-          the network address value.";
-      }
-      enum interface-name {
-        value 6;
-        description
-          "Represents a chassis identifier based on the value of
-          ifName object (defined in IETF RFC 2863) for an interface
-          on the containing chassis.";
-      }
-      enum local {
-        value 7;
-        description
-          "Represents a chassis identifier based on a locally defined
-          value.";
-      }
-    }
-    description
-      "The source of a chassis identifier.";
-    reference
-      "LLDP MIB 20050506";
-  }
-  
-  typedef lldp-chassis-id {
-    type string {
-      length "1..255";
-    }
-    description
-      "The format of a chassis identifier string. Objects of this type
-      are always used with an associated lldp-chassis-is-subtype
-      object, which identifies the format of the particular
-      lldp-chassis-id object instance.
-
-      If the associated lldp-chassis-id-subtype object has a value of
-      chassis-component, then the octet string identifies
-      a particular instance of the entPhysicalAlias object
-      (defined in IETF RFC 2737) for a chassis component (i.e.,
-      an entPhysicalClass value of chassis(3)).
-
-      If the associated lldp-chassis-id-subtype object has a value
-      of interface-alias, then the octet string identifies
-      a particular instance of the ifAlias object (defined in
-      IETF RFC 2863) for an interface on the containing chassis.
-      If the particular ifAlias object does not contain any values,
-      another chassis identifier type should be used.
-
-      If the associated lldp-chassis-id-subtype object has a value
-      of port-component, then the octet string identifies a
-      particular instance of the entPhysicalAlias object (defined
-      in IETF RFC 2737) for a port or backplane component within
-      the containing chassis.
-
-      If the associated lldp-chassis-id-subtype object has a value of
-      mac-address, then this string identifies a particular
-      unicast source address (encoded in network byte order and
-      IEEE 802.3 canonical bit order), of a port on the containing
-      chassis as defined in IEEE Std 802-2001.
-
-      If the associated lldp-chassis-id-subtype object has a value of
-      network-address, then this string identifies a particular
-      network address, encoded in network byte order, associated
-      with one or more ports on the containing chassis.  The first
-      octet contains the IANA Address Family Numbers enumeration
-      value for the specific address type, and octets 2 through
-      N contain the network address value in network byte order.
-
-      If the associated lldp-chassis-id-subtype object has a value
-      of interface-name, then the octet string identifies
-      a particular instance of the ifName object (defined in
-      IETF RFC 2863) for an interface on the containing chassis.
-      If the particular ifName object does not contain any values,
-      another chassis identifier type should be used.
-
-      If the associated lldp-chassis-id-subtype object has a value of
-      local, then this string identifies a locally assigned
-      Chassis ID.";
-    reference
-      "LLDP MIB 20050506";
-  }
-  
-  typedef lldp-port-id-subtype {
-    type enumeration {
-      enum interface-alias {
-        value 1;
-        description
-          "Represents a port identifier based on the ifAlias
-          MIB object, defined in IETF RFC 2863.";
-      }
-      enum port-component {
-        value 2;
-        description
-          "Represents a port identifier based on the value of
-          entPhysicalAlias (defined in IETF RFC 2737) for a port
-          component (i.e., entPhysicalClass value of port(10)), 
-          within the containing chassis.";
-      }
-      enum mac-address {
-        value 3;
-        description
-          "Represents a port identifier based on a unicast source
-          address (encoded in network byte order and IEEE 802.3
-          canonical bit order), which has been detected by the agent
-          and associated with a particular port (IEEE Std 802-2001).";
-      }
-      enum network-address {
-        value 4;
-        description
-          "Represents a port identifier based on a network address,
-          detected by the agent and associated with a particular 
-          port.";
-      }
-      enum interface-name {
-        value 5;
-        description
-          "Represents a port identifier based on the ifName MIB object,
-          defined in IETF RFC 2863.";
-      }
-      enum agent-circuit-id {
-        value 6;
-        description
-          "Represents a port identifier based on the agent-local
-          identifier of the circuit (defined in RFC 3046), detected by
-          the agent and associated with a particular port.";
-      }
-      enum local {
-        value 7;
-        description
-          "Represents a port identifier based on a value locally
-          assigned.";
-      }
-    }
-    description
-      "The source of a particular type of port identifier used
-      in the LLDP YANG module.";
-  }
-  
-  typedef lldp-port-id {
-    type string {
-      length "8";
-    }
-    description
-      "The format of a port identifier string. Objects of this type
-      are always used with an associated lldp-port-id-subtype object,
-      which identifies the format of the particular lldp-port-id
-      object instance.
-
-      If the associated lldp-port-id-subtype object has a value of
-      interface-alias, then the octet string identifies a
-      particular instance of the ifAlias object (defined in IETF
-      RFC 2863).  If the particular ifAlias object does not contain
-      any values, another port identifier type should be used.
-
-      If the associated lldp-port-id-subtype object has a value of
-      port-component, then the octet string identifies a
-      particular instance of the entPhysicalAlias object (defined
-      in IETF RFC 2737) for a port or backplane component.
-
-      If the associated lldp-port-id-subtype object has a value of
-      mac-address, then this string identifies a particular
-      unicast source address (encoded in network byte order
-      and IEEE 802.3 canonical bit order) associated with the port
-      (IEEE Std 802-2001).
-
-      If the associated lldp-port-id-subtype object has a value of
-      network-address, then this string identifies a network
-      address associated with the port.  The first octet contains
-      the IANA AddressFamilyNumbers enumeration value for the
-      specific address type, and octets 2 through N contain the
-      networkAddress address value in network byte order.
-
-      If the associated lldp-port-id-subtype object has a value of
-      interface-name, then the octet string identifies a
-      particular instance of the ifName object (defined in IETF
-      RFC 2863).  If the particular ifName object does not contain
-      any values, another port identifier type should be used.
-
-      If the associated lldp-port-id-subtype object has a value of
-      agent-circuit-id, then this string identifies a agent-local
-      identifier of the circuit (defined in RFC 3046).
-
-      If the associated lldp-port-id-subtype object has a value of
-      local, then this string identifies a locally assigned port ID.";
-  }
-  
-  /* -----------------------------------------------------
-   * Type definitions used by RFC 2579 SNMP v2 YANG module
-   * -----------------------------------------------------
-   */
- 
-  typedef transport-service-domain {
-    type yang:object-identifier;
-    description
-      "Denotes a kind of transport service";
-    reference
-      "RFC2579 - Textual Conventions for SMIv2";
-  }
-  
-  typedef transport-service-address {
-    type string {
-      length "1..255";
-    }
-    description
-      "Denotes a transport service address";
-  }
-
-  /* ----------------------------------------------
-   * Type definitions used by 802.1Qcx YANG module
-   * ----------------------------------------------
-   */
-  
-  typedef bridge-ref {
-    type leafref {
-      path "/dot1q:bridges/dot1q:bridge/dot1q:name";
-    }
-    description
-      "This type is used by data models that need to reference
-      a configured Bridge.";
-  }
-  
-  typedef bridge-component-ref {
-    type leafref {
-      path "/dot1q:bridges/dot1q:bridge/dot1q:component/dot1q:name";
-    }
-    description
-      "This type is used by data models that need to reference
-      a configured Bridge Component.";
-  }
-  
-  typedef md-name-format-type {
-    type enumeration {
-      enum ieee-reserved-0 {
-        value 0;
-        description
-          "Reserved for definition by IEEE 802.1 recommend to not
-          use zero unless absolutely needed.";
-      }
-      enum none {
-        value 1;
-        description
-          "No format specified, usually because there is not a 
-          Maintenance Domain Name. In this case, a zero length
-          OCTET string for the Domain name field is acceptable.";
-      }
-      enum dns-like-name {
-        value 2;
-        description
-          "Domain name like string, globally unique text string 
-          derived from a DNS name.";
-      }
-      enum mac-address-and-uint {
-        value 3;
-        description
-          "MAC address plus 2-octet (unsigned) integer.";
-      }
-      enum char-string {
-        value 4;
-        description
-          "RFC2579 DisplayString, except that the character codes
-          0-31 (decimal) are not used.";
-      }
-    }
-    description
-      "A value that represents a type (and thereby the format)
-      of a md-name.";
-  }
-  
-  typedef md-name-type {
-    type string {
-      length "0..43";
-    }
-    description
-      "The Maintenance Domain name type";
-  }
-  
-  typedef ma-name-format-type {
-    type enumeration {
-      enum ieee-reserved-0 {
-        value 0;
-        description
-          "Reserved for definition by IEEE 802.1. Recommend not to use
-          zero unless absolutely needed.";
-      }
-      enum primary-vid {
-        value 1;
-        description
-          "Primary VLAN ID. 12 bits represented in a 2-octet integer.";
-      }
-      enum char-string {
-        value 2;
-        description
-          "RFC2579 DisplayString, except that the character codes
-          0-31 (decimal) are not used. (1..45) octets.";
-      }
-      enum unsigned-int16 {
-        value 3;
-        description
-          "2-octet integer/big endian.";
-      }
-      enum rfc2865-vpn-id {
-        value 4;
-        description
-          "RFC2685 VPN ID. 3 octet VPN authority Organizationally
-          Unique Identifier followed by 4 octet VPN index identifying
-          VPN according to the OUI.";
-      }
-      enum icc-format {
-        value 32;
-        description
-          "ICC-based format as specified in ITU-T Y.1731.";
-      }
-    }
-    description
-      "A value that represents a type (and thereby the format)
-      of a ma-name.";
-  }
-  
-  typedef ma-name-type {
+  typedef maintenance-group-type {
     type string {
       length "1..45";
+      pattern "[0-9a-zA-Z]*";
     }
-    description
-      "The Maintenance Association name type";
-  }
-  
-  typedef maintenance-group-type {
-    type string;
     description
       "The Maintenance Group type";
   }
-  
-  typedef mhf-creation-type {
-    type enumeration {
-      enum mhf-none {
-        value 1;
-        description
-          "No MHFs can be created for designated VID(s) or ISID.";
-      }
-      enum mhf-default {
-        value 2;
-        description
-          "MHFs can be created for designated VID(s) or ISID on any
-          Bridge Port through which the VID(s) or ISID can pass, where:
-            i) There are no lower active MD levels; or
-           ii) There is a MEP at the next lower active MD level on 
-               the port.";
-      }
-      enum mhf-explicit {
-        value 3;
-        description
-          "MHFs can be created for designated VID(s) or ISID only
-          on Bridge Ports through which the VID(s) or ISID can pass, 
-          and onlyh if there is a MEP at the next lower active 
-          MD level on the port.";
-      }
-      enum mhf-defer {
-        value 4;
-        description
-          "In the Maintenance Association only, the control of MHF
-          creation is deferred to the corresponding variable in
-          the enclosing Maintenance Domain.";
-      }
-    }
-    description
-      "Indicates if the Management Entity can create MHFs.";
-  }
-  
-  typedef mp-direction-type {
-    type enumeration {
-      enum down {
-        value 1;
-        description
-          "Down maintenance point, where CFM protocol messages
-          are dispatched away from the MAC Relay entity.";
-      }
-      enum up {
-        value 2;
-        description
-          "Up maintenance point, where CFM protocol messages 
-          are dispatched towards the MAC Relay entity.";
-      }
-    }
-    description
-      "Indicates the direction in which the Maintenance
-      association (MEP or MIP) faces on the Bridge Port.";
-  }
-  
-  typedef service-selector-type {
-    type enumeration {
-      enum ieee-reserved-0 {
-        value 0;
-        description
-          "Reserved for definition by IEEE 802.1 recommend to not
-          use zero unless absolutely needed.";
-      }
-      enum vlan-id {
-        value 1;
-        description
-          "12-bit identifier found in a VLAN tag.";
-      }
-      enum isid {
-        value 2;
-        description
-          "24-bit identifier found in an I-TAG.";
-      }
-      enum tesid {
-        value 3;
-        description 
-          "32-bit identifier";
-      }
-      enum segid {
-        value 4;
-        description
-          "32-bit identifier";
-      }
-      enum path-tesid {
-        value 5;
-        description
-          "32-bit identifier";
-      }
-      enum group-isid {
-        value 6;
-        description
-          "24 bit identifier";
-      }
-      enum ieee-reserved {
-        value 7;
-        description
-          "Reserved for definition by IEEE 802.1";
-      }
-    }
-    description
-      "A value that represents a type (and thereby the format)
-      of a service-selector-value.";
-  }
-  
-  typedef service-selector-value {
-    type uint32 {
-      range "1..4294967295";
-    }
-    description
-      "An integer that uniquely identifies a generic MAC Service,
-      or none. Examples of service selectors are a VLAN-ID
-      (IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
-      
-      An service-selector-value value is always interpreted
-      within the context of an service-selector-type value.
-      Every usage of the service-selector-value textual
-      convention is required to specify the
-      service-selector-type object that provides the context.
-      
-      The value of an service-selector-value object must
-      always be consistent with the value of the associated
-      service-selector-type object. Attempts to set an
-      service-selector-value object to a value inconsistent
-      with the associated service-selector-type must fail
-      with an inconsistent-value error.";
-  }
-  
-  typedef service-selector-value-or-none {
-    type uint32 {
-      range "0 | 1..4294967295";
-    }
-    description
-      "An integer that uniquely identifies a generic MAC Service,
-      or none. Examples of service selectors are a VLAN-ID
-      (IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
-      
-      An service-selector-value value is always interpreted
-      within the context of an service-selector-type value.
-      Every usage of the service-selector-value textual
-      convention is required to specify the
-      service-selector-type object that provides the context.
-      
-      The value of an service-selector-value object must
-      always be consistent with the value of the associated
-      service-selector-type object. Attempts to set an
-      service-selector-value object to a value inconsistent
-      with the associated service-selector-type must fail
-      with an inconsistent-value error.
-      
-      The special value of zero is used to indicate that no
-      service selector is present or used. This can be used in
-      any situation where an object or a table entry MUST either
-      refer to a specific service, or not make a selection.";
-  }
-  
-  typedef mep-id-type {
-    type uint32 {
-      range "1..8191";
-    }
-    description
-      "Maintenance association End Point Identifier, which is
-      unique over a given Maintenance Association.";
-  }
-  
-  typedef mep-id-or-zero-type {
-    type uint32 {
-      range "0 | 1..8191";
-    }
-    description
-      "Maintenance association End Point Identifier, which is
-      unique over a given Maintenance Association.
-      
-      The special value 0 is allowed to indicate a special case when
-      there is no MEPID configured.";
-  }
-  
-  typedef md-level-type {
-    type uint32 {
-      range "0..7";
-    }
-    description
-      "Integer identifying the Maintenance Domain Level (MD Level).
-      Higher numbers correspond to higher Maintenance Domains,
-      those with the greatest physical reach, with the highest
-      values for customers' CFM PDUs. Lower numbers correspond
-      to lower Maintenance Domains, those with more limited
-      physical reach, with the lowest values for CFM PDUs
-      protecting single bridges or physical links.";
-  }
-  
-  typedef md-level-or-none-type {
-    type int32 {
-      range "-1 | 0..7";
-    }
-    description
-      "Integer identifying the Maintenance Domain Level (MD Level).
-      Higher numbers correspond to higher Maintenance Domains,
-      those with the greatest physical reach, with the highest
-      values for customers CFM packets. Lower numbers correspond
-      to lower Maintenance Domains, those with more limited
-      physical reach, with the lowest values for CFM PDUs
-      protecting single bridges or physical links.
-      The value (-1) is reserved to indicate that no MA Level has
-      been assigned.";
-  }
-  
-  typedef component-identifier-type {
-    type uint32 {
-      range "1..4294967295";
-    }
-    description
-      "The component identifier is used to distinguish between the
-      multiple virtual Bridge instances within a PB or PBB. Each
-      virtual Bridge instance is called a component. In simple
-      situations where there is only a single component the default
-      value is 1. The component is identified by a component
-      identifier unique within the BEB and by a MAC address unique
-      within the PBBN. Each component is associated with a Backbone
-      Edge Bridge (BEB) Configuration managed object.";
-  }
-  
-  typedef port-status-tlv-value {
-    type enumeration {
-      enum no-port-state-tlv {
-        value 0;
-        description
-          "Indicates either that no CCM has been received or that
-          no port status TLV was present in the last CCM received.";
-      }
-      enum blocked {
-        value 1;
-        description
-          "Ordinary data cannot pass freely through the port on
-          which the remote MEP resides.";
-      }
-      enum up {
-        value 2;
-        description
-          "Ordinaty data can pass freely through the port on which
-          the remote MEP resides.";
-      }
-    }
-    description
-      "An enumerated value from he Port Status TLV from the last CCM
-      received from the last MEP. It indicates the ability of the
-      Bridge Port on which the transmitting MEP resides to pass
-      ordinary data, regardless of the status of the MAC.";
-  }
-  
-  typedef interface-status-tlv-value {
-    type enumeration {
-      enum is-no-interface-status-tlv {
-        value 0;
-        description
-          "Indicates either that no CCM has been received or that
-          no interface status TLV was present in the last CCM
-          received.";
-      }
-      enum is-up {
-        value 1;
-        description
-          "The interface is ready to pass packets.";
-      }
-      enum is-down {
-        value 2;
-        description
-          "The interface can not pass packets.";
-      }
-      enum is-testing {
-        value 3;
-        description
-          "The interface is in same test mode.";
-      }
-      enum is-unknown {
-        value 4;
-        description
-          "The interface status cannot be determined for some
-          reason.";
-      }
-      enum is-dormant {
-        value 5;
-        description
-          "The interface is not in a state to pass packets but is in
-          a pending state, waiting for some extrnal event.";
-      }
-      enum is-not-present {
-        value 6;
-        description
-          "Some component of the interface is mssing.";
-      }
-      enum is-lower-layer-down {
-        value 7;
-        description
-          "The interface is down due to state of the lower layer
-          interface.";
-      }
-    }
-    description
-      "An enumerated value from the Interface Status TLV from the
-      last CCM received from the last MEP. It indicates the status
-      of the Interface within which the MEP transmitting the CCM
-      is configured, or the next lower Interface in the Interface
-      Stack, if the MEP is not configured within an Interface.";
-  }
-  
-  typedef highest-defect-priority-type {
-    type enumeration {
-      enum none {
-        value 0;
-        description
-          "No defects since Fault Notification Generator state
-          machine reset.";
-      }
-      enum def-rdi-ccm {
-        value 1;
-        description
-          "The last CCM received by this MEP from some remote MEP
-          contained the RDI bit set.";
-      }
-      enum def-mac-status {
-        value 2;
-        description
-          "The last CCM received by this MEP from some remote MEP
-          indicating that the transmitting MEP's associated MAC is
-          reporting an error status via the Port Status TLV or
-          Interface Status TLV is set.";
-      }
-      enum def-remote-ccm {
-        value 3;
-        description
-          "This MEP is not receiving CCMs from some other MEP in its
-          configured list.";
-      }
-      enum def-error-ccm {
-        value 4;
-        description
-          "This MEP is receiving invalid CCMs.";
-      }
-      enum def-xcon-ccm {
-        value 5;
-        description
-          "This MEP is receiving CCMs that could be from some other 
-          MA.";
-      }
-    }
-    description
-      "An enumerated value, equal to the contents of the variable
-      highestDefect (20.35.9 and Table 20-1), indicating the
-      highest-priority defect that has been present since the MEP
-      Fault Notification Generator State Machine was last in the
-      FNG_RESET state.";
-  }
-  
-  typedef lowest-alarm-priority-type {
-    type enumeration {
-      enum all-def {
-        value 1;
-        description
-          "Includes def-rid-ccm, def-mac-status, def-remote-ccm,
-          def-error-ccm, and def-xcon-ccm.";
-      }
-      enum mac-remote-error-xcon {
-        value 2;
-        description
-          "Only includes def-mac-status, def-remote-ccm, def-error-ccm,
-          and def-xcon-ccm.";
-      }
-      enum remote-error-xcon {
-        value 3;
-        description
-          "Includes def-remote-ccm, def-error-ccm, and def-xcon-ccm.";
-      }
-      enum error-xcon {
-        value 4;
-        description
-          "Includes def-error-ccm and def-xcon-ccm.";
-      }
-      enum xcon {
-        value 5;
-        description
-          "Only def-xcon-ccm";
-      }
-      enum no-xcon {
-        value 6;
-        description
-          "No defects def-xcon or lower are to be reported.";
-      }
-    }
-    description
-      "An integer value specifying the lowest priority defect
-      that is allowed to generate a Fault Alarm (20.9.5).";
-  }
-  
-  typedef sender-id-permission-type {
-    type enumeration {
-      enum send-id-none {
-        value 1;
-        description 
-          "The Sender ID TLV is not to be sent.";
-      }
-      enum send-id-chassis {
-        value 2;
-        description
-          "The Chassis ID Length, Chassis ID Subtype, and Chassis ID
-          fields of te Sender ID TLV are to be sent.";
-      }
-      enum send-id-manage {
-        value 3;
-        description
-          "The Management Address Length and Management Address
-          of the Sender ID TLV are to be sent.";
-      }
-      enum send-id-chassis-manage {
-        value 4;
-        description
-          "The Chassis ID Length, Chassis ID Subtype, Chassis ID, 
-          Management Address Length and Management Address fields are
-          all to be sent.";
-      }
-      enum send-id-defer {
-        value 5;
-        description
-          "The content of the Sender ID TLV are determined by the
-          corresponding Maintenance Domain variable.";
-      }
-    }
-    description
-      "Indicates what, if anything, is to be included in the Sender
-      ID TLV transmitted in CCMs, LBMs, LTMs, and LTRs.";
-  }
-  
-  typedef cfm-interval-type {
-    type enumeration {
-      enum invalid {
-        value 0;
-        description
-          "No CFM PDUs are to be sent";
-      }
-      enum 300hz {
-        value 1;
-        description
-          "CFM PDUs are sent every 3 1/3 milliseconds (300Hz).";
-      }
-      enum 10ms {
-        value 2;
-        description
-          "CFM PDUs are sent every 10 milliseconds.";
-      }
-      enum 100ms {
-        value 3;
-        description
-          "CFM PDUs are sent every 100 milliseconds.";
-      }
-      enum 1sec {
-        value 4;
-        description
-          "CFM PDUs are sent every second.";
-      }
-      enum 10sec {
-        value 5;
-        description
-          "CFm PDUs are sent every 10 seconds.";
-      }
-      enum 1min {
-        value 6;
-        description
-          "CFM PDUs are sent every minute.";
-      }
-      enum 10min {
-        value 7;
-        description
-          "CFM PDUs are sent every 10 minutes.";
-      }
-    }
-    description
-      "Indicates the interval at which CFM PDUs are sent by a MEP.";
-  }
-  
-  typedef fng-state-type {
-    type enumeration {
-      enum fng-reset {
-        value 1;
-        description
-          "No defect has been present since the mep-fng-reset-time
-          timer expired, or since the state machine was last reset.";
-      }
-      enum fng-defect {
-        value 2;
-        description
-          "A defect is present, but not for a long enough time to be
-          reported.";
-      }
-      enum fng-report-defect {
-        value 3;
-        description
-          "A momentary state during which the defect is reported by sending a
-          fault-alarm notification, if that action is enabled.";
-      }
-      enum fng-defect-reported {
-        value 4;
-        description
-          "A defect is present, and some defect has been reported.";
-      }
-      enum fng-defect-clearing {
-        value 5;
-        description
-          "No defect is present, but the mep-fng-reset-time timer
-          has not yet expired.";
-      }
-    }
-    description
-      "Indicates the different states of the MEP Fault Notification
-      Generator State Machine.";
-  }
-  
-  typedef relay-action-field-value {
-    type enumeration {
-      enum relay-hit {
-        value 1;
-        description
-          "The LTM reached a Maintenance Point whose MAC address
-          matches the target address.";
-      }
-      enum relay-fdb {
-        value 2;
-        description
-          "The Egress Port was determined by consulting the Filtering
-          Database.";
-      }
-      enum relay-mpdb {
-        value 3;
-        description
-          "The Egress Port was determined by consulting the MIP CCM
-          Database.";
-      }
-    }
-    description
-      "Possible values the Relay action field can take.";
-  }
-  
-  typedef ingress-action-field-value {
-    type enumeration {
-      enum ingress-no-tlv {
-        value 0;
-        description
-          "Indicates that no Reply Ingress TLV was returned in the LTM.";
-      }
-      enum ingress-ok {
-        value 1;
-        description
-          "The target data frame would be passed through to the MAC 
-          Relay Entity.";
-      }
-      enum ingress-down {
-        value 2;
-        description
-          "The Bridge Ports MAC_Operational parameter is false.";
-      }
-      enum ingress-blocked {
-        value 3;
-        description
-          "The target data frame would not be forwarded if received on
-          this Port due to active topology enforcement.";
-      }
-      enum ingress-vid {
-        value 4;
-        description
-          "The ingress port is not in the member set of the LTMs VID,
-          and ingress filtering is enabled, so the target data frame
-          would be filtered by ingress filtering.";
-      }
-    }
-    description
-      "Possible values returned in the ingress action field.";
-  }
-  
-  typedef egress-action-field-value {
-    type enumeration {
-      enum egress-no-tlv {
-        value 0;
-        description
-          "Indicates that no Reply Egress TLV was returned in the LTM.";
-      }
-      enum egress-okay {
-        value 1;
-        description
-          "The targeted data frame would be forwarded.";
-      }
-      enum egress-down {
-        value 2;
-        description
-          "The Egress Port can be identified, but that Bridge Port
-          MAC_Operational parameter is false.";
-      }
-      enum egress-blocked {
-        value 3;
-        description
-          "The Egress Port can be identified, but the data frame would
-          not pass through the Egress Port due to active topology 
-          management (i.e., the Bridge Port is not in the 
-          Forwardin state.";
-      }
-      enum egress-vid {
-        value 4;
-        description
-          "The Egress Port can be identified, but the Bridge Port is not
-          in the LTMs VIDs member set, so would be filtered by
-          egress filtering.";
-      }
-    }
-    description
-      "Possible values returned in the egress action field.";
-  }
-  
-  typedef remote-mep-state-type {
-    type enumeration {
-      enum rmep-idle {
-        value 1;
-        description
-          "Momentary state during reset.";
-      }
-      enum rmep-start {
-        value 2;
-        description
-          "The timer has not expired since the state machine
-          was reset, and no valid CCM has yet been received.";
-      }
-      enum rmep-failed {
-        value 3;
-        description
-          "The timer has expired, both since the state machine was
-          reset, and since a valid CCM was received.";
-      }
-      enum rmep-ok {
-        value 4;
-        description
-          "The timer has not expired since a valid CCM was received.";
-      }
-    }
-    description
-      "Operational state of the remote MEP state machine. This
-      state machine monitors the reception of valid CCMs from a
-      remote MEP with a specific MEPID. It uses a timer that
-      expires in 3.5 times the length of time indicated by the
-      ma-ccm-interval object.";
-  }
-  
-  typedef mep-defects-type {
-    type bits {
-      bit def-rdi-ccm {
-        position 0;
-        description
-          "A remote MEP reported that RDI bit in its last CCM.";
-      }
-      bit def-mac-status {
-        position 1;
-        description
-          "Either some remote MEP is reporting its Interface Status
-          TLV as not isUp, or all remote MEPs are reporting a Port 
-          Status TLV that contains some value other than psUp.";
-      }
-      bit def-remote-ccm {
-        position 2;
-        description
-          "The MEP is not receiving valid VCMs from at least one of
-          the remote MEPs.";
-      }
-      bit def-error-ccm {
-        position 3;
-        description
-          "The MEP has received at least one invalid CCM whose CCM
-          Interval has not yet timed out.";
-      }
-      bit def-xcon-ccm {
-        position 4;
-        description
-          "The MEP has received at last one CCM from either another 
-          MAID or a lower MD level whose CCm Interval has not yet 
-          timed out.";
-      }
-    }
-    description
-      "A MEP can detect and report a number of defects, and multiple
-      defects can be present at the same time.";
-  }
-  
-  typedef config-errors {
-    type bits {
-      bit cfm-leaf {
-        position 0;
-        description
-          "MA x is associated with a specific VID list, one or more 
-          of the VIDs in MA x can pass through the Bridge Port,
-          no Down MEP is configured on any Bridge Port for MA x,
-          and some other MA y, at a higher MD Level than MA x, and
-          associated with at least one of the VID(s) also in MA x,
-          does have a MEP configured on the Bridge Port.";
-      }
-      bit conflicting-vids {
-        position 1;
-        description
-          "MA x is associated with a specific VID list, an Up MEP is
-          configured on MA x on the Bridge Port, and some other MA y,
-          associated with at least one of the VID(s) also in MA x,
-          also has an Up MEP configured on some Bridge Port.";
-      }
-      bit excessive-levels {
-        position 2;
-        description
-          "The number of different MD Levels at which MIPs are to be
-          created on this port exceeds the Bridge's capabilities.";
-      }
-      bit overlapped-levels {
-        position 3;
-        description
-          "A MEP is created for one VID at one MD Level, but a MEP is
-          configured on another VID at that MD Level or higher,
-          exceeding the Bridges capabilities.";
-      }
-    }
-    description
-      "While making the MIP creation evaluation described in
-      22.2.3, the management entity can encounter errors in
-      the configuration.";
-  }
-  
-  typedef mep-tx-ltm-flags-type {
-    type bits {
-      bit use-fdb-only {
-        position 0;
-        description
-          "Use FDB only";
-      }
-    }
-    description
-      "The flags field for LTMs transmitted by the MEP.";
-  }
-  
-  typedef fault-alarm-address-type {
-    type enumeration {
-      enum address {
-        value 1;
-        description
-          "Indicates that a Network address to which Fault Alarms
-          are to be transmitted should be used.";
-      }
-      enum not-specified {
-        value 2;
-        description
-          "Indicates not specified. In the case of a MA, then the
-          selection used by the MD should be used.";
-      }
-      enum not-transmitted {
-        value 3;
-        description
-          "Indicates that Fault alarms are not to be transmitted.";
-      }
-    }
-    description
-      "The Fault Alarm address indicators.";
-  }
-  
   
   /* -------------------------------------------------
    * Grouping definitions used by 802.1Qcx YANG module
@@ -1203,87 +73,6 @@ module ieee802-dot1q-cfm {
           "The additional 2-octet (unsigned) integer.";
       }
     }   
-  }
-  
-  grouping service-id {
-    description
-      "The list of VIDs, I-SID, or the TE-SID monitored by 
-      this MA, or 0, if the MA is not attached to a VID, or
-      I-SID, or TE-SID. In the case of a list of VIDs, the 
-      first VID in the list is the MAs Primary VID (default 
-      none). The specification of I-SID is allowed only in
-      the case of I- or B- components. The TE-SID is allowed
-      only in the case that PBB-TE is supported.";
-    choice service-id {
-      default vid;
-      description
-        "The service identifiers types";
-      case none {
-        leaf zero {
-          type uint32 {
-            range "0";
-          }
-          description
-            "Represents no service identifier selected.";
-        }
-      }
-      case vid {
-        leaf-list vid {
-          type dot1q-types:vlanid;
-          description
-            "12-Bit identifier VLAN identifier.";
-        }
-      }
-      case isid {
-        leaf isid {
-          type uint32 {
-            range "1..16777215";
-          }
-          description
-            "24-Bit identifier I-SID identifier.";
-        }
-      }
-      case tesid {
-        leaf tesid {
-          type uint32 {
-            range "1..4294967295";
-          }
-          description
-            "The tesid is used as a service selector for MAs that are
-            present in Bridges that implement PBB-TE functionality.";
-        }
-      }
-      case segid {
-        leaf segid {
-          type uint32 {
-            range "1..4294967295";
-          }
-          description
-            "The segid is used as a service selector for MAs that are
-            present in Bridges that implement IPS functionality.";
-        }
-      }
-      case path-tesid {
-        leaf path-tesid {
-          type uint32 {
-            range "1..4294967295";
-          }
-          description
-            "The path-tesid is used as a service selector for SPBM 
-            path MAs.";
-        }
-      }
-      case group-isid {
-        leaf group-isid {
-          type uint32 {
-            range "1..4294967295";
-          }
-          description
-            "The group-isid is used as a service selector for SPBM 
-            group MAs.";
-        }
-      }
-    }
   }
   
   grouping md-name-choice {
@@ -1406,8 +195,7 @@ module ieee802-dot1q-cfm {
       }
     }
   }
-
-
+  
   /* ---------------------------------------------------
    * Configuration objects used by 802.1Qcx YANG module
    * ---------------------------------------------------
@@ -1417,345 +205,6 @@ module ieee802-dot1q-cfm {
     description
       "Connectivity Fault Management configuration and operational
       information.";
-    
-    choice device-reference {
-      description
-        "This type is intended to be used as a generic reference. 
-       An instance of the reference is a pointer to a Bridge object
-       defined by IEEE 802.1Qcp. 
-       
-       However, to allow non-802.1Q compliant devices that
-       wants to utilize IEEE 802.1Q standardized CFM and the 
-       accompanying CFM YANG model, this node can be augmented
-       with a different device reference.
-        
-       For example, another type of device could create a new
-       device type with reference in their YANG module. Then
-       they could augment this module, and the cfm/device-reference
-       in particular to include a new case statement with
-       their device reference.";
-      case bridge {
-        leaf bridge-ref {
-          type bridge-ref;
-          description
-            "A 802.1Q compliant Bridge reference on which the CFM 
-            configuration and operational information are 
-            associated with.";
-        }     
-      }
-      //case other-device-ref {
-      //  leaf other-device-ref {
-      //    type other-module:other-device-ref;
-      //    description
-      //      "An other device reference which the CFM configuration
-      //      and operational information are associated with.";
-      //  }
-      //}
-    }
-    
-    container cfm-stacks {
-      description 
-        "The CFM Stack contains information about the Maintenance
-        Points configured on a particular Bridge Port (or
-        aggregated port). It contains all CFM Stack specific related
-        configuration and operational data.";
-      
-      list cfm-stack {
-        key "port md-level direction";
-        description
-          "The CFM Stack contains information about the Maintenance
-          Points configured on a particular Bridge Port (or
-          aggregated port). It contains all CFM Stack specific related
-          configuration and operational data.
-          
-          Upon a restart of the system, the system SHALL, if necessary,
-          change the value of this variable, and rearrange the
-          cfm-stack, so that it indexes the entry in the
-          interface table with the same value of interface-ref that it
-          indexed before the system restart. If no such entry exists,
-          then the system SHALL delete all entries in the
-          cfm-stack with the interface index.";     
-        leaf port {
-          type if:interface-ref;
-          description
-            "An interface on which maintenance points might be 
-            configured. This object represents the Bridge Port or 
-            aggregated port on which MEPs or MHFs might be 
-            configured.";
-          reference
-            "12.14.2.1.2a of IEEE Std 802.1Q-2018";
-        }
-        leaf md-level {
-          type md-level-type;
-          description
-            "The MD level of the maintenance point";
-          reference
-            "12.14.2.1.2b  of IEEE Std 802.1Q-2018";
-        }
-        leaf direction {
-          type mp-direction-type;
-          description
-            "The direction in which the maintenance point faces on the 
-            Bridge Port.";
-          reference
-            "12.14.2.1.2c of IEEE Std 802.1Q-2018";     
-        }
-        container service-id {
-          description 
-            "A specific VID, I-SID, Traffic Engineering service 
-            instance Identifier (TE-SID), or Segment Identifier
-            (SEG-ID) associated with an MP, or 0, in the case that
-            the MP is associated with no VID, I-SID, TE-SID, or SEG-ID";
-          uses service-id;
-        }
-        leaf maintenance-group {
-          type maintenance-group-type;
-          config false;
-          description
-            "The maintenance group to which the Maintenance Points
-            is associated with.";
-        }
-        leaf maintenance-domain-index {
-          type uint32;
-          config false;
-          description
-            "The Maintenance Domain reference to which the Maintenance
-            Points Maintenance Association is associated. If none,
-            then 0.";
-          reference
-            "12.14.2.1.3b of IEEE Std 802.1Q-2018";
-        }
-        leaf maintenance-association-index {
-          type uint32;
-          config false;
-          description
-            "The Maintenance Association reference to which the 
-            Maintenance Point is associated. If none, then 0.";
-          reference
-            "12.14.2.1.3c of IEEE Std 802.1Q-2018";
-        }
-        leaf mep-id {
-          type mep-id-or-zero-type;
-          config false;
-          description
-            "The MEP identifier is a MEP is configured. Otherwise is 0.";
-          reference
-            "12.14.2.1.3d of IEEE Std 802.1Q-2018";
-        }
-        leaf mac-address {
-          type ieee:mac-address;
-          config false;
-          description
-            "The MAC address of the maintenance point.";
-          reference
-            "12.14.2.1.3e of IEEE Std 802.1Q-2018";
-        }
-      }  // cfm-stack
-    } // cfm-stacks
-    
-    container default-md-levels {
-      description
-        "There is a single Default MD Level managed object per Bridge
-        Component. It controls MIP Half Function (MHF) creation for
-        VIDs or I-SIDs of I- or B-components that are not contained in
-        the list of VIDs attached to any specific Maintenance 
-        Association managed object, and the transmission of the Sender
-        ID TLV by those MHFs.";
-      
-      list default-md-level {
-        key "component-id";
-        description
-          "For each bridge component, the Default MD Level Managed 
-          Object controls MHF creation for VIDs that are not attached
-          to a specific Maintenance Association Managed Object, and
-          Sender ID TLV transmission by those MHFs.
-          
-          For each Bridge Port, and for each VLAN ID whose data can
-          pass through that Bridge Port, an entry in this table is
-          used by the algorithm in subclause 22.2.3 only if there is no
-          entry in the Maintenance Association table defining an MA
-          for the same VLAN ID and MD Level as this table's entry, and
-          on which MA an Up MEP is defined. If there exists such an
-          MA, that MA's objects are used by the algorithm in
-          subclause 22.2.3 in place of this table entry objects.
-          
-          The agent maintains the value of md-status to indicate
-          whether this entry is overridden by an MA. When first
-          initialized, the agent creates this table automatically with
-          entries for all VLAN IDs, with the default values specified
-          for each object. After this initialization, the writable
-          objects in this table need to be persistent upon reboot or
-          restart of a device.";
-        leaf component-id {
-          type component-identifier-type;
-          description
-            "The Bridge component within the system to which the
-            information in this entry applies. If the system is not a
-            Bridge, or if only one component is present in the Bridge,
-            then this variable (index) MUST be equal to 1.";
-          reference
-            "12.3l of IEEE Std 802.1Q-2018";
-        }
-        container primary-service-id {
-          description
-            "A vid or isid in an I or B component.";
-          uses service-id;
-          reference
-            "12.14.3.1.2a of IEEE Std 802.1Q-2018";
-        }
-        container associated-service-ids {
-          description
-            "A list of VIDs associated with any MHF on the VID, always
-            including that VID, or the Backbone-SID of the B-component
-            or VIP-SID of the I-component associated with any MHF on
-            the I-SID. The first VID is the MAs Primary VID.
-            
-            List is empty if no primary VID specified.";
-          uses service-id;
-          reference
-            "12.14.3.1.3a of IEEE Std 802.1Q-2018";
-        }
-        leaf md-status {
-          type boolean;
-          config false;
-          description
-            "State of this Default MD Level table entry. True if there
-            is no entry in the Maintenance Association table defining
-            an MA for the same VLAN ID and MD Level as this tables
-            entry, and on which MA an Up MEP is defined, else false.";
-          reference
-            "12.14.3.1.3b of IEEE Std 802.1Q-2018";
-        }
-        leaf md-level {
-          type md-level-or-none-type;
-          default -1;
-          description
-            "A value indicating the MD Level at which MHFs are to be
-            created, and Sender ID TLV transmission by those MHFs is to
-            be controlled, for the VLAN to which this entry's objects
-            apply.";
-          reference
-            "12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
-        }
-        leaf mhf-creation {
-          type mhf-creation-type;
-          default "mhf-defer";
-          description
-            "A value indicating if the Management entity can create MHFs
-            (MIP Half Function) for this VID at this MD Level. If this
-            object has the value mhf-defer, MHF creation for this VLAN
-            is controlled by md-mhf-creation. The value of this variable
-            is meaningless if the values of md-status is false.";
-          reference
-            "12.14.3.1.3d of IEEE Std 802.1Q-2018";
-          
-        }
-        leaf id-permission {
-          type sender-id-permission-type;
-          default "send-id-defer";
-          description
-            "Enumerated value indicating what, if anything, is to be
-            included in the Sender ID TLV transmitted by MHFs
-            created by the Default Maintenance Domain. If this object
-            has the value send-if-defer, Sender ID TLV transmission 
-            for this VLAN is controlled by md-id-permission-type. The
-            value of this variable is meaningless if the values of
-            md-status is false.";
-          reference
-            "12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
-        }
-      } // default-md-level
-    } // default-md-levels
-    
-    container mip {
-      description
-        "Maintenance Association Intermediate Point";
-      leaf port {
-        type if:interface-ref;
-        description
-          "The interface index of the interface (i.e., Bridge 
-          Port) to which the MEP is attached.";
-        reference
-          "12.14.7.1.3b of IEEE Std 802.1Q-2018";
-      }
-      container service-ids {
-        description
-          "A list of VIDs associated with any MHF on the VID, always
-          including that VID, or the Backbone-SID of the B-component
-          or VIP-SID of the I-component associated with any MHF on
-          the I-SID. The first VID is the MAs Primary VID.";
-        uses service-id;
-      }
-      leaf md-level {
-        type md-level-type;
-        default 0;
-        description
-          "A value indicating the MD Level at which MHFs are to be
-          created, and Sender ID TLV transmission by those MHFs is to
-          be controlled, for the VLAN to which this entry's objects
-          apply.";
-        reference
-          "12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
-      }
-      leaf id-permission {
-        type sender-id-permission-type;
-        default "send-id-none";
-        description
-          "Enumerated value indicating what, if anything, is to be
-          included in the Sender ID TLV transmitted by MHFs
-          created by the Default Maintenance Domain. If this object
-          has the value send-if-defer, Sender ID TLV transmission 
-          for this VLAN is controlled by md-id-permission-type.";
-        reference
-          "12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
-      }
-    } // mip
-    
-    container config-errors {
-      description
-        "The Configuration Error List managed object is a list of
-        {identifier, port} pairs configured in error together with
-        the identity of the configuration error.";
-
-      list config-error {
-        key "port";
-        description
-          "The CFM Configuration Error List table provides a list of
-          Interfaces and VIDs that are incorrectly configured.";
-        leaf port {
-          type if:interface-ref;
-          description
-            "The interface index of the interface (i.e., Bridge 
-            Port).
-            
-            Upon a restart of the system, the system SHALL, if 
-            necessary, change the value of this variable so that it
-            indexes the entry in the interface table with the same
-            value of the index that it indexed before the system
-            restart. If no such entry exists, then the system SHALL
-            delete any entries in config-error-list indexed by that
-            interface-ref.";
-          reference
-            "12.14.4.1.2b of IEEE Std 802.1Q-2018";
-        }
-        container service-id {
-          description 
-            "The Service Selector Identifier of the Service with 
-            interfaces in error.";
-          uses service-id;
-          reference
-            "12.14.4.1.2a of IEEE Std 802.1Q-2018";
-        }
-        leaf error-type {
-          type config-errors;
-          config false;
-          description
-            "vector of Boolean error conditions from 22.2.4.";
-          reference
-            "12.14.4.1.3b of IEEE Std 802.1Q-2018";
-        }
-      } // config-error
-    } // config-errors
     
     container maintenance-domains {
       description
@@ -1767,7 +216,7 @@ module ieee802-dot1q-cfm {
         can be accessed, and thus controlled.";
 
       list maintenance-domain {
-        key "md-index";
+        key "md-id";
         description
           "Contains the Maintenance Domain configuration and 
           operational data. A Maintenance Domain is the network or the
@@ -1776,14 +225,14 @@ module ieee802-dot1q-cfm {
           a set of Domain Service Access Points (DoSAPs), each of 
           which can become a point of connectivity to a service 
           instance.";
-        leaf md-index {
-          type uint32;
+        leaf md-id {
+          type cfm-types:name-key-type;
           description
             "The index to the Maintenance Domain list.";
         }
         uses md-name-choice;
         leaf md-level {
-          type md-level-type;
+          type cfm-types:md-level-type;
           default 0;
           description
             "The Maintenance Domain level.";
@@ -1791,7 +240,7 @@ module ieee802-dot1q-cfm {
             "3.122, 12.14.5.1.3b of IEEE Std 802.1Q-2018";
         }
         leaf mhf-creation {
-          type mhf-creation-type;
+          type cfm-types:mhf-creation-type;
           default mhf-none;
           description
             "Value indicating whether the management entity can
@@ -1802,7 +251,7 @@ module ieee802-dot1q-cfm {
             "3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
         }
         leaf id-permission {
-          type sender-id-permission-type;
+          type cfm-types:sender-id-permission-type;
           default send-id-none;
           description
             "Value indicating what, if anything, is to be included in
@@ -1814,7 +263,7 @@ module ieee802-dot1q-cfm {
             "3.122, 12.14.5.1.3d of IEEE Std 802.1Q-2018";
         }
         leaf fault-alarm-address {
-          type fault-alarm-address-type;
+          type cfm-types:fault-alarm-address-type;
           default "not-transmitted";
           description
             "A value indicating whether Fault Alarms are to be 
@@ -1824,7 +273,7 @@ module ieee802-dot1q-cfm {
         }
         
         list maintenance-association {
-          key "ma-index";
+          key "ma-id";
           description
             "Provides configuration and operational data for the
             Maintenance Associations. A Maintenance Association is a 
@@ -1833,22 +282,14 @@ module ieee802-dot1q-cfm {
             service instance. A Maintenance Association can be thought
             of as a full mesh of Maintenance Entities among a set of
             MEPs so configured.";
-          leaf ma-index {
-            type uint32;
+          leaf ma-id {
+            type cfm-types:name-key-type;
             description 
               "Key of the Maintenance Association list of entries.";
           }
           uses ma-name-choice;
-          leaf md-index {
-            type uint32;
-            description
-              "An index reference to the Maintenance Domain that this
-              Maintenance Association belongs to.";
-            reference
-              "12.14.5.3.2a of IEEE Std 802.1Q-2018";
-          }
           leaf ccm-interval {
-            type cfm-interval-type;
+            type cfm-types:cfm-interval-type;
             default "1sec";
             description
               "The interval between CCM transmissions to be used by all
@@ -1857,7 +298,7 @@ module ieee802-dot1q-cfm {
               "12.14.6.1.3e of IEEE Std 802.1Q-2018";
           }
           leaf fault-alarm-address {
-            type fault-alarm-address-type;
+            type cfm-types:fault-alarm-address-type;
             default "not-specified";
             description
               "A value indicating whether Fault Alarms are to be 
@@ -1866,1323 +307,1316 @@ module ieee802-dot1q-cfm {
               used by the MD should be used.";
             reference
               "3.122, 12.14.5.1.3e of IEEE Std 802.1Q-2018";
-          }         
-          leaf maintenance-group {
-            type maintenance-group-type;
-            description
-              "The maintenance group provides a handle
-              for the MD and MA combination.";
           }
           
-          list maintenance-association-component {
-            key ma-component-id;
+          list maintenance-association-mep-list {
+            key mep-id;
             description
-              "This is the part of the complete MA table that is
-              variable across the Bridges in a Maintenance Domain, or
-              across the components of a single Bridge.";
-            leaf ma-component-id {
-              type component-identifier-type;
+              "The list of all MEPs that belong to this Maintenance
+              Association.";
+            leaf mep-id {
+              type cfm-types:mep-id-type;
               description
-                "The Bridge component within the system to which the
-                information applies. If the system is not a Bridge, or
-                if only one component is present in the Bridge, then
-                this variable (index) MUST be equal to 1";
+                "Integer that is unique among all the MEPs in the
+                same Maintenance Association.";
               reference
-                "12.3l of IEEE Std 802.1Q-2018";
+                "12.14.6.1.3g of IEEE Std 802.1Q-2018";
             }
-            container service-id {
-              description
-                "The list of VIDs, I-SID, or the TE-SID monitored by 
-                this MA, or 0, if the MA is not attached to a VID, or
-                I-SID, or TE-SID. In the case of a list of VIDs, the 
-                first VID in the list is the MAs Primary VID (default 
-                none). The specification of I-SID is allowed only in
-                the case of I- or B- components. The TE-SID is allowed
-                only in the case that PBB-TE is supported.";
-              uses service-id;
-              reference
-                "12.14.5.3.2c, 12.14.6.1.3b of IEEE Std 802.1Q-2018";
-            }
-            leaf mhf-creation {
-              type mhf-creation-type;
-              default mhf-defer;
-              description
-                "Value indicating whether the management entity can
-                create MHFs (MIP Half Function) for this Maintenance
-                Domain. Since there is no encompassing Maintenance
-                Domain, the value mhf-defer is not allowed.";
-              reference
-                "3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
-            }
-            leaf id-permission {
-              type sender-id-permission-type;
-              default "send-id-defer";
-              description
-                "Enumerated value indicating what, if anything, is to
-                be included in the Sender ID TLV (21.5.3) transmitted
-                by MPs configured in this MA.";
-              reference
-                "12.14.3.1.3d of IEEE Std 802.1Q-2018";
-            }
-            list mep {
-              key "mep-id maintenance-group";
-              description 
-                "A list of Maintenance association End Points (MEPs). A
-                MEP is an actively managed CFM entity, associated with
-                a specific DoSAP of a service instance, which can
-                generate and receive CFM PDUs and track any responses.
-                It is an end point of a single Maintenance Association
-                (MA) and is an end point of a separate Maintenance
-                Entity for each of the other MEPs in the same MA.";
-              leaf mep-id {
-                type mep-id-type;
-                description
-                  "Integer that is unique among all the MEPs in the
-                  same Maintenance Association.";
-                reference
-                  "3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
-              }
-              leaf maintenance-group {
-                type maintenance-group-type;
-                description
-                  "The maintenance group provides an identifier
-                  for the MD and MA combination.";
-              }
-              leaf ma-index {
-                type uint32;
-                description
-                  "An index reference to the particular Maintenance
-                  Association that this MEP belongs to.";
-                reference
-                  "12.14.6.3.2a of IEEE Std 802.1Q-2018";
-              }
-              leaf port {
-                type if:interface-ref;
-                description
-                  "The interface index of the interface (e.g., Bridge 
-                  Port) to which the MEP is attached.";
-                reference
-                  "12.14.7.1.3b of IEEE Std 802.1Q-2018";
-              }
-              leaf direction {
-                type mp-direction-type;
-                description
-                  "The direction in which the MEP faces on the Bridge
-                  Port. Example, up or down.";
-                reference
-                  "12.14.7.1.3c, 19.2 of IEEE Std 802.1Q-2018";
-              }
-              leaf primary-vid {
-                type uint32 {
-                  range "0..16777215";
-                }
-                default 0;
-                description
-                  "An integer indicating the Primary VID of the MEP. It
-                  is always one of the VIDs assigned to the MEPs MA. A
-                  value of 0 indicates that either the Primary VID is
-                  that of the MEPs MA, or that the MEPs MA is 
-                  associated with no VID.";
-                reference
-                  "12.14.7.1.3d of IEEE Std 802.1Q-2018"; 
-              }
-              leaf admin-state {
-                type boolean;
-                default "false";
-                description
-                  "The administrative state of the MEP. TRUE indicates
-                  that the MEP is to functional normally, and FALSE
-                  indicates that it is to cease functioning.";
-                reference
-                  "12.14.7.1.3e, 20.9.1 of IEEE Std 802.1Q-2018";
-              }
-              leaf fng-state {
-                type fng-state-type;
-                default "fng-reset";
-                config false;
-                description
-                  "The current state of the MEP Fault Notification 
-                  Generator state machine.";
-                reference
-                  "12.14.7.1.3f, 20.35 of IEEE Std 802.1Q-2018";
-              }
-              leaf ccm-ltm-priority {
-                type dot1q-types:priority-type;
-                description
-                  "The priority value for CCMs and LTMs transmitted by
-                  the MEP. The default value is the highest priority 
-                  allowed to pass through the Bridge Port for any of
-                  the MEPs VID(s).";
-                reference
-                  "12.14.7.1.3h of IEEE Std 802.1Q-2018";
-              }
-              leaf mac-address {
-                type ieee:mac-address;
-                config false;
-                description
-                  "The MAC address of the MEP.";
-                reference
-                  "12.14.7.1.3i, 19.4 of IEEE Std 802.1Q-2018";
-              }
-              leaf fault-alarm-address {
-                type fault-alarm-address-type;
-                default "not-specified";
-                description
-                  "A value indicating whether Fault Alarms are to be 
-                  transmitted or not. The default is not specified, 
-                  which implies that the disposition of the fault-alarm
-                  used by the MD should be used.";
-                reference
-                  "3.122, 12.14.7.1.3j of IEEE Std 802.1Q-2018";
-              }
-              leaf lowest-priority-defect {
-                type lowest-alarm-priority-type;
-                default "mac-remote-error-xcon";
-                description
-                  "The lowest priority defect that is allowed to
-                  generate fault alarms.";
-                reference
-                  "12.14.7.1.3k, 20.9.5 of IEEE Std 802.1Q-2018";
-              }
-              leaf fng-alarm-time {
-                type yang:zero-based-counter32 {
-                  range "250..1000";
-                }
-                units deciseconds;
-                default 250;
-                description
-                  "The time that defect must be present before a Fault
-                  Alarm is issued.";
-                reference
-                  "12.14.7.1.3l, 20.35.3 of IEEE Std 802.1Q-2018";
-              }
-              leaf fng-reset-time {
-                type yang:zero-based-counter32 {
-                  range "250..1000";            
-                }
-                units deciseconds;
-                default 1000;
-                description
-                  "The time that defects must be absent before 
-                  resetting a Fault Alarm.";
-                reference
-                  "12.14.7.1.3m, 20.35.4 of IEEE Std 802.1Q-2018";
-              }
-              leaf highest-priority-defect {
-                type highest-defect-priority-type;
-                config false;
-                description
-                  "The highest priority defect that has been present
-                  sicne the MEPs Fault Notification Generator state
-                  machine was last in the FNG_RESET state.";
-                reference
-                  "12.14.7.1.3n, 20.35.9 of IEEE Std 802.1Q-2018";
-              }
-              leaf defects {
-                type mep-defects-type;
-                config false;
-                description
-                  "Vector of boolean error conditions";
-                reference
-                  "12.14.7.1.3o-s, 20.21.3,
-                  20.23.3, 20.35.5, 20.35.6, 20.35.7 of IEEE Std 802.1Q-2018";
-              }
-              leaf error-ccm-last-failure {
-                type string {
-                  length "1..2000";
-                }
-                config false;
-                description
-                  "The last received CCM that triggered a def-error-ccm
-                  fault.";
-                reference
-                  "12.14.7.1.3t, 20.21.2 of IEEE Std 802.1Q-2018";
-              }
-              leaf xcon-ccm-last-failure {
-                type string {
-                  length "1..2000";
-                }
-                config false;
-                description
-                  "The last received CCM that triggered a def-xcon-ccm
-                  fault.";
-                reference
-                  "12.14.7.1.3u, 20.23.2 of IEEE Std 802.1Q-2018";
-              }
-              
-              list linktrace-reply {
-                key "ltr-seq-number ltr-receive-order";
-                description
-                  "This table extends the MEP table and contains a list
-                  of Linktrace replies received by a specific MEP in
-                  response to a linktrace message.";
-                leaf ltr-seq-number {
-                  type uint32 {
-                    range "0..4294967295";
-                  }
-                  description
-                    "Transaction identifier returned by a previous
-                    transmit linktrace message command, indicating
-                    which LTMs response is going to be returned.";
-                  reference
-                    "12.14.7.5.2b of IEEE Std 802.1Q-2018";
-                }
-                leaf ltr-receive-order {
-                  type uint32 {
-                    range "1..4294967295";
-                  }
-                  description
-                    "An index to distinguish among multiple LTRs with
-                    the same LTR Transaction Identifier field value. 
-                    Assigned sequentially from 1, in the order that the 
-                    Linktrace Initiator received the LTRs.";
-                }
-                leaf ltr-ttl {
-                  type uint32 {
-                    range "0..255";
-                  }
-                  config false;
-                  description
-                    "TTL field value for a returned LTR.";
-                  reference
-                    "12.14.7.5, 20.41.2.2 of IEEE Std 802.1Q-2018";
-                }
-                leaf ltr-forwarded {
-                  type boolean;
-                  config false;
-                  description
-                    "Indicates if a LTM was forwarded by the responding
-                    MP, as returned in the FwdYes flag of the flags 
-                    field.";
-                  reference
-                    "12.14.7.5.3c, 20.41.2.1 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-terminal-mep {
-                  type boolean;
-                  config false;
-                  description
-                    "A Boolean value stating whether the forwarded LTM
-                    reached a MEP enclosing its MA, as returned in the
-                    Terminal MEP flag of the Flags field";
-                  reference
-                    "12.14.7.5.3d, 20.41.2.1 of IEEE Std 802.1Q-2018";
-                }
-                leaf ltr-last-egress-identifier {
-                  type string {
-                    length "8";
-                  }
-                  config false;
-                  description
-                    "An octet field holding the Last Egress Identifier
-                    returned in the LTR Egress Identifier TLV of the
-                    LTR. The Last Egress Identifier identifies the MEP
-                    Linktrace Initiator that originated, or the 
-                    Linktrace Responder that forwarded, the LTM to
-                    which this LTR is the response. This is the same
-                    value as the Egress Identifier TLV of that LTM.";
-                  reference
-                    "12.14.7.5.3e, 20.41.2.3 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-next-egress-identifier {
-                  type string {
-                    length "8";
-                  }
-                  config false;
-                  description
-                    "An octet field holding the Next Egress Identifier
-                    returned in the LTR Egress Identifier TLV of the 
-                    LTR. The Next Egress Identifier Identifies the
-                    Linktrace Responder that transmitted this LTR, and
-                    can forward the LTM to the next hop. This is the
-                    same value as the Egress Identifier TLV of the
-                    forwarded LTM, if any. If the FwdYes bit of the
-                    Flags field is false, the contents of this field
-                    are undefined, i.e., any value can be transmitted,
-                    and the field is ignored by the receiver.";
-                  reference
-                    "12.14.7.5.3f, 20.41.2.4 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-relay {
-                  type relay-action-field-value;
-                  config false;
-                  description
-                    "Value returned in the Relay Action field.";
-                  reference
-                    "12.14.7.5.3g, 20.41.2.5 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-chassis-id-subtype {
-                  type lldp-chassis-id-subtype;
-                  config false;
-                  description
-                    "Specifies the format of the Chassis ID returned
-                    in the Sender ID TLV of the LTR, if any. This value
-                    is meaningless if the ltr-chassis-id has a length
-                    of 0.";
-                  reference
-                    "12.14.7.5.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-chassis-id {
-                  type lldp-chassis-id;
-                  config false;
-                  description
-                    "The Chassis ID returned in the Sender ID TLV of 
-                    the LTR, if any. The format of this object is
-                    determined by the value of the 
-                    ltr-chassis-id-subtype object.";
-                  reference
-                    "12.14.7.5.3i, 21.5.3.2 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-man-address-domain {
-                  type transport-service-domain;
-                  config false;
-                  description
-                    "The transport-service-domain that identifies the
-                    type and format of the related mep-db-man-address
-                    object, used to access the YANG agent of the system
-                    transmitting the LTR. Received in the LTR Sender ID
-                    TLV from that system.";
-                  reference
-                    "12.14.7.5.3j, 21.5.3.5,
-                    21.9.6 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-man-address {
-                  type transport-service-address;
-                  config false;
-                  description
-                    "The transport-service-address that can be used to
-                    access the YANG agent of the system transmitting
-                    the CCM, received in the CCM Sender ID TLV from
-                    that system.
-                    
-                    If the related object ltr-man-address-domain
-                    contains the value zeroDotZero, this object
-                    ltr-man-address MUST have a zero-length OCTET 
-                    STRING as a value.";
-                  reference
-                    "12.14.7.5.3j, 21.5.3.7,
-                    21.9.6 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-ingress {
-                  type ingress-action-field-value;
-                  config false;
-                  description
-                    "The value returned in the Ingress Action Field of
-                    the LTM. The value ingress-no-tlv indicates that no
-                    Reply Ingress TLV was returned in the LTM.";
-                  reference
-                    "12.14.7.5.3k, 20.41.2.6 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-ingress-mac {
-                  type ieee:mac-address;
-                  config false;
-                  description
-                    "MAC address returned in the ingress MAC address
-                    field. If the ltr-ingress object contains the value 
-                    ingress-no-tlv, then the contents of this object
-                    are meaningless.";
-                  reference
-                    "12.14.7.5.3l, 20.41.2.7 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-ingress-port-id-subtype {
-                  type lldp-port-id-subtype;
-                  config false;
-                  description
-                    "Ingress Port ID. The format of this object is 
-                    determined by the value of the 
-                    ltr-ingress-port-id-subtype object. If the
-                    ltr-ingress object contains the value 
-                    ingress-no-tlv, then the contents of this object
-                    are meaningless.";
-                  reference
-                    "12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-egress {
-                  type egress-action-field-value;
-                  config false;
-                  description
-                    "The value returned in the Egress Action Field of
-                    the LTM. The value egress-no-tlv indicates that 
-                    no Reply Egress TLV was returned in the LTM.";
-                  reference
-                    "12.14.7.5.3o, 20.41.2.10 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-egress-mac {
-                  type ieee:mac-address;
-                  config false;
-                  description
-                    "MAC address returned in the egress MAC address
-                    field. If the ltr-egress object contains the value
-                    egress-no-tlv, then the contents of this object are
-                    meaningless.";
-                  reference
-                    "12.14.7.5.3p, 20.41.2.11 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-egress-port-id-subtype {
-                  type lldp-port-id-subtype;
-                  config false;
-                  description
-                    "Format of the egress Port ID. If the ltr-egress
-                    object contains the value egress-no-tlv, then the
-                    contents of this object are meaningless.";
-                  reference
-                    "12.14.7.5.3q, 20.41.2.12 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-egress-port-id {
-                  type lldp-port-id;
-                  config false;
-                  description
-                    "Egress Port ID. The format of this object is
-                    determined by the value of the
-                    ltr-egress-port-id-subtype object. If the 
-                    ltr-egress object contains the value egress-no-tlv,
-                    then the contents of this object are meaningless.";
-                  reference
-                    "12.14.7.5.3r, 20.41.2.13 of IEEE Std 802.1Q-2018";
-                }           
-                leaf ltr-organization-specific-tlv {
-                  type string {
-                    length "0 | 4..1500";
-                  }
-                  config false;
-                  description
-                    "All Organization specific TLVs returned in the 
-                    LTR, if any. Includes all octets including and
-                    following the TLV Length field of each TLV, 
-                    concatenated together.";
-                  reference
-                    "12.14.7.5.3s, 21.5.2 of IEEE Std 802.1Q-2018";
-                }
-              } // linktrace-reply
-              
-              list mep-db {
-                key rmep-id;
-                description
-                  "The MEP CCM Database. A database, maintained by every 
-                  MEP, that maintains received information about other MEPs
-                  in the Maintenance Domain.";
-                leaf rmep-id {
-                  type mep-id-type;
-                  description
-                    "Maintenance association Endpoint Identifier of a
-                    remote MEP whose information from the MEP Database
-                    is to be returned.";
-                  reference
-                    "12.14.7.6.2b of IEEE Std 802.1Q-2018";             
-                }
-                leaf rmep-state {
-                  type remote-mep-state-type;
-                  config false;
-                  description 
-                    "The operational state of the remote MEP  state
-                    machine";
-                  reference
-                    "12.14.7.6.3b, 20.20 of IEEE Std 802.1Q-2018";
-                }
-                leaf rmep-failed-ok-time {
-                  type yang:zero-based-counter32;
-                  units seconds;
-                  config false;
-                  description
-                    "The time (SysUpTime) at which the Remote MEP state
-                    machine last entered either the RMEP_FAILED or
-                    RMEP_OK state";
-                  reference
-                    "12.14.7.6.3c of IEEE Std 802.1Q-2018";
-                }
-                leaf mac-address {
-                  type ieee:mac-address;
-                  config false;
-                  description
-                    "The MAC address of the remote MEP.";
-                  reference
-                    "12.14.7.6.3d, 20.19.7 of IEEE Std 802.1Q-2018";
-                }
-                leaf rdi {
-                  type boolean;
-                  config false;
-                  description
-                    "State of the RDI bit in the last received CCM
-                    (true for RDI=1), or false if none has been 
-                    received.";
-                  reference
-                    "12.14.7.6.3e, 20.19.2 of IEEE Std 802.1Q-2018";
-                }
-                leaf port-status-tlv {
-                  type port-status-tlv-value;
-                  default "no-port-state-tlv";
-                  config false;
-                  description
-                    "An enumerated value of the Port status TLV 
-                    received in the last CCM from the remote MEP or 
-                    the default value no-port-state-tlv indicating
-                    either no CCM has been received, or that no port
-                    status TLV was received in the last CCM.";
-                  reference
-                    "12.14.7.6.3f, 20.19.3 of IEEE Std 802.1Q-2018";
-                }
-                leaf interface-status-tlv {
-                  type interface-status-tlv-value;
-                  default "is-no-interface-status-tlv";
-                  config false;
-                  description
-                    "An enumerated value of the Interface status TLV
-                    received in the last CCM from the remote MEP or the
-                    default value is-no-interface-status-tlv indicating
-                    either no CCM has been received, or that no 
-                    interface status TLV was received in the last 
-                    CCM.";
-                  reference
-                    "12.14.7.6.3g, 20.19.4 of IEEE Std 802.1Q-2018";
-                }
-                leaf chassis-id-subtype {
-                  type lldp-chassis-id-subtype;
-                  config false;
-                  description
-                    "This object specifies the format of the Chassis ID
-                    received in the last CCM.";
-                  reference
-                    "12.14.7.6.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
-                }
-                leaf chassis-id {
-                  type lldp-chassis-id;
-                  config false;
-                  description
-                    "The Chassis ID. The format of this object is
-                    determined by the value of the 
-                    ltr-chassis-id-subtype object.";
-                  reference
-                    "12.14.7.6.3h, 21.5.3.3 of IEEE Std 802.1Q-2018";
-                }
-                leaf man-address-domain {
-                  type transport-service-domain;
-                  config false;
-                  description
-                    "The transport-service-domain that identifies the
-                    type and format of the related mep-db-man-address
-                    object, used to access the YANG agent of the system
-                    transmitting the CCM. Received in the CCM Sender ID
-                    TLV from that system.
-                    
-                    The value zeroDotZero (from RFC2578) indicates no
-                    management address was present in the LTR, in which
-                    case the related mep-db-man-address object MUST
-                    have a zero-length OCTET STRING as a value.";
-                  reference
-                    "12.14.7.6.3h, 21.5.3.5,
-                    21.6.7 of IEEE Std 802.1Q-2018";
-                }
-                leaf man-address {
-                  type transport-service-address;
-                  config false;
-                  description
-                    "The transport-service-address that can be used to 
-                    access the YANG agent of the system transmitting
-                    the CCM, received in the CCM Sender ID TLV from
-                    that system. If the related 
-                    mep-db-man-address-domain object contains the 
-                    value zeroDotZero, this object mep-db-man-address
-                    MUST have a zero-length OCTET STRING as a value.";
-                  reference
-                    "12.14.7.6.3h, 21.5.3.7,
-                    21.6.7 of IEEE Std 802.1Q-2018";
-                }
-                leaf rmep-is-active {
-                  type boolean;
-                  description
-                    "A Boolean value statign if the remote MEP is 
-                    active.";
-                  reference
-                    "12.14.7.1.3ae";
-                }
-              } // mep-db
-              
-              container continuity-check {
-                description
-                  "Continuity check protocol";
-                leaf ccm-enabled {
-                  type boolean;
-                  default "false";
-                  description
-                    "Indicates whether the MEP can generate CCMs. If 
-                    TRUE, the MEP will generate CCM PDUs.";
-                  reference
-                    "12.14.7.1.3g, 20.10.1 of IEEE Std 802.1Q-2018";
-                }
-                leaf priority {
-                  type dot1q-types:priority-type;
-                  description
-                    "The priority value for CCMs and LTMs transmitted by
-                    the MEP. The default value is the highest priority 
-                    allowed to pass through the Bridge Port for any of
-                    the MEPs VID(s).";
-                  reference
-                    "12.14.7.1.3h of IEEE Std 802.1Q-2018";
-                }
-                leaf ccm-interval {
-                  type cfm-interval-type;
-                  description
-                    "The interval between CCM transmissions to be used by all
-                    MEPs in the Maintenance Association.";
-                  reference
-                    "12.14.6.1.3e of IEEE Std 802.1Q-2018";
-                }
-              } // continuity-check
-              
-              container loopback {
-                description
-                  "Loopback protocol";
-                leaf status {
-                  type boolean;
-                  default "false";
-                  description
-                    "A Boolean flag set to TRUE by the MEP Loopback
-                    Initiator state machine or YANG network configuration
-                    manager to indicate that another LBM is being 
-                    transmitted. Reset to FALSE by the MEP Loopback
-                    initiator state machine.";
-                  reference
-                    "20.32, Figure 20-11 of IEEE Std 802.1Q-2018";
-                }
-                leaf interval {
-                  type cfm-interval-type;
-                  default 1sec;
-                  description
-                    "The interval between LBM transmissions to be used by all
-                    MEPs in the Maintenance Association.";
-                }
-                leaf dest-mac-address {
-                  type ieee:mac-address;
-                  description
-                    "The target MAC Address field to be transmitted.
-                    A unicast destination MAC address. This address
-                    is used if node mep-transmit-lbm-dest-is-mep-id
-                    is FALSE.";
-                  reference
-                    "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-                }
-                leaf dest-mep-id {
-                  type mep-id-or-zero-type;
-                  description
-                    "The identifier of a remote MEP in the same MA to
-                    which the LBM is to be sent. This address
-                    is used if node mep-transmit-lbm-dest-is-mep-id
-                    is TRUE.";
-                  reference
-                    "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-                }
-                leaf dest-is-mep-id {
-                  type boolean;
-                  default "false";
-                  description
-                    "TRUE indicates that MEP ID of the target MEP is used
-                    for Loopback transmissions. FALSE indicates that
-                    unicast destination MAC address of the target MEP is
-                    used for Loopback transmissions.";
-                  reference
-                    "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-                }
-                leaf message-count {
-                  type uint32 {
-                    range "1..1024";
-                  }
-                  default 1;
-                  description
-                    "The number of Loopback messages to be transmitted.";
-                  reference
-                    "12.14.7.3.2c of IEEE Std 802.1Q-2018";
-                }
-                leaf data-tlv {
-                  type string;
-                  description
-                    "An arbitrary amount of data to be included in the
-                    Data TLV, if the Data TLV is selected to be sent. The
-                    intent is to be able to fill the frame carrying the
-                    CFM PDU to its maximum length.";
-                  reference
-                    "12.14.7.3.2d of IEEE Std 802.1Q-2018";
-                }
-                leaf priority {
-                  type dot1q-types:priority-type;
-                  description
-                    "Priority. 3 bit value to be used in the VLAN tag, if
-                    present in the transmitted frame. The default value
-                    should be the CCM priority.";
-                  reference
-                    "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-                }
-                leaf vlan-drop-eligible {
-                  type boolean;
-                  default "false";
-                  description
-                    "Drop eligible bit value to be used in the VLAN tag,
-                    if present in the transmitted frame";
-                  reference
-                    "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-                }
-                leaf result-ok {
-                  type boolean;
-                  default "true";
-                  config false;
-                  description
-                    "Indicates the result of the operation:
-                       TRUE - The LBM will be (or has been) sent.
-                       FALSE - The LBM will not be sent.";
-                  reference
-                    "12.14.7.3.3a of IEEE Std 802.1Q-2018";
-                }
-                leaf seq-number {
-                  type uint32;
-                  description
-                    "The Loopback transaction identifier
-                    (mep-next-lbm-trans-id) of the first LBM (to be) 
-                    sent. The value returned is undefined if 
-                    mep-transmit-lbm-result-ok is FALSE.";
-                  reference
-                    "12.14.7.3.3b of IEEE Std 802.1Q-2018";
-                }
-                leaf next-lbm-trans-id {
-                  type uint32;
-                  config false;
-                  description
-                    "Next sequence number identifier to be sent in a
-                    Loopback message. This sequence number can be zero
-                    since it can wrap around.";
-                  reference
-                    "12.14.7.1.3x, 20.28.2 of IEEE Std 802.1Q-2018";
-                }
-              } // loopback
-              
-              container linktrace {
-                description
-                  "Linktrace protocol";
-                leaf status {
-                  type boolean;
-                  default "false";
-                  description
-                    "A Boolean flag set to TRUE by the Bridge Port to 
-                    indicate that another LTM may be transmitted. Reset
-                    to FALSE by the MEP Linktrace initiator state 
-                    machine.";
-                  reference
-                    "20.49, Figure 20-17 of IEEE Std 802.1Q-2018";
-                }
-                leaf interval {
-                  type cfm-interval-type;
-                  default 1sec;
-                  description
-                    "The interval between LTM transmissions to be used by all
-                    MEPs in the Maintenance Association.";
-                }
-                leaf priority {
-                  type dot1q-types:priority-type;
-                  description
-                    "The priority value for CCMs and LTMs transmitted by
-                    the MEP. The default value is the highest priority 
-                    allowed to pass through the Bridge Port for any of
-                    the MEPs VID(s).";
-                  reference
-                    "12.14.7.1.3h of IEEE Std 802.1Q-2018";
-                }
-                leaf flags {
-                  type mep-tx-ltm-flags-type;
-                  default use-fdb-only;
-                  description
-                    "The flags field for the LTMs transmitted by the 
-                    MEP.";
-                  reference
-                    "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
-                  
-                }
-                leaf target-mac-address {
-                  type ieee:mac-address;
-                  description
-                    "The target MAC address field to be transmitted. A
-                    unicast MAC address. This address will be used if the
-                    value of mep-transmit-ltm-target-is-mep-id is FALSE.";
-                  reference
-                    "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-                }
-                leaf target-mep-id {
-                  type mep-id-or-zero-type;
-                  description
-                    "The target MAC address field to be transmitted. The
-                    MEP identifier of another MEP in the same MA. This
-                    address will be used if the value of 
-                    mep-transmit-ltm-target-is-mep-id is TRUE.";
-                  reference
-                    "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-                }
-                leaf target-is-mep-id {
-                  type boolean;
-                  default "false";
-                  description
-                    "TRUE indicates that MEP id of the target MEP is used
-                    for Linktrace transmission. FALSE indicates that
-                    unicast destination MAC address of the target MEP is
-                    used for LinkTrace transmission.";
-                  reference
-                    "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-                }
-                leaf ttl {
-                  type uint32 {
-                    range "0..255";
-                  }
-                  default 64;
-                  description
-                    "The LTM TTL field. Indicates the number of hops 
-                    remaining to the LTM. Decremented by 1 by each
-                    Linktrace Responder that handles the LTM. The value
-                    returned in the LTR is one less than that received in
-                    the LTM. If the LTM TTL is 0 or 1, the LTM is not
-                    forwarded to the next hop, and if 0, no LTR is 
-                    generated.";
-                  reference
-                    "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
-                }
-                leaf result {
-                  type boolean;
-                  default "true";
-                  config false;
-                  description
-                    "Indicates the result of the operation:
-                       TRUE - The Linktrace message will be (or has been) 
-                              sent.
-                       FALSE - The Linktrace message will not be sent.";
-                  reference
-                    "12.14.7.4.3a of IEEE Std 802.1Q-2018";
-                }
-                leaf seq-number {
-                  type uint32;
-                  config false;
-                  description
-                    "The LTM transaction identifier 
-                    (mep-ltm-next-seq-number) of the LTM sent. The value
-                    returned is undefined if mep-transmit-ltm-result is 
-                    FALSE.";
-                  reference
-                    "12.14.7.4.3b of IEEE Std 802.1Q-2018";
-                }
-                leaf egress-identifier {
-                  type string {
-                    length "8";
-                  }
-                  config false;
-                  description
-                    "Identifies the MEP Linktrace Initiator that is 
-                    originating, or the Linktrace Responder that is
-                    forwarding, this LTM.
-                    
-                    The low-order six octets contain a 48-bit IEEE MAC
-                    address unique to the system in which the MEP 
-                    Linktrace Initiator or Linktrace Responder resides.
-                    The high-order two octets contain a value sufficient
-                    to uniquely identify the MEP Linktrace Initiator or 
-                    Linktrace Responder within that system.
-                    
-                    For most Bridges, the address of any MAC attached to
-                    the Bridge will suffice for the low-order six octets,
-                    and 0 for the high-order octets. In some situations,
-                    e.g., if multiple virtual Bridges utilizing emulated
-                    LANs are implemented in a single physical system, the
-                    high-order two octets can be used to differentiate
-                    among the transmitting entities.
-                    
-                    The value returned is undefined if 
-                    mep-transmit-ltm-result is FALSE.";
-                  reference
-                    "12.14.7.4.3c of IEEE Std 802.1Q-2018";           
-                }
-                leaf next-seq-number {
-                  type uint32;
-                  config false;
-                  description
-                    "Next transaction identifier to be sent in a 
-                    LinkTrace message.This sequence number can be zero
-                    since it can wrap around.";
-                  reference
-                    "12.14.7.1.3ab, 20.41.1 of IEEE Std 802.1Q-2018";
-                }
-              } // linktrace
-              
-              container stats {
-                config false;
-                description
-                  "Contains the counters associated with the MEP.";
-                leaf mep-ccm-sequence-errors {
-                  type yang:counter64;
-                  description
-                    "The total number of out-of-sequence CCMs received
-                    from all remote MEPs.";
-                  reference
-                    "12.14.7.1.3v, 20.16.12 of IEEE Std 802.1Q-2018";
-                }
-                leaf mep-ccms-sent {
-                  type yang:counter64;
-                  description
-                    "Total number of CCMs transmitted";
-                  reference
-                    "12.14.7.1.3w, 20.10.2 of IEEE Std 802.1Q-2018";
-                }
-                leaf mep-lbr-in {
-                  type yang:counter64;
-                  description
-                    "Total number of valid, in-order Loopback Replies
-                    received.";
-                  reference
-                    "12.14.7.1.3y, 20.31.1 of IEEE Std 802.1Q-2018";
-                }
-                leaf mep-lbr-in-out-of-order {
-                  type yang:counter64;
-                  description
-                    "The total number of valid, out-of-order
-                    Loopback Replies received";
-                  reference
-                    "12.14.7.1.3z, 20.31.1 of IEEE Std 802.1Q-2018";
-                }
-                leaf mep-lbr-bad-msdu {
-                  type yang:counter64;
-                  description
-                    "The total number of LBRs received whose
-                    mac_service_data_unit did not match (except for the
-                    OpCode) that of the corresponding LBM.";
-                  reference
-                    "12.14.7.1.3aa, 20.2.3 of IEEE Std 802.1Q-2018";
-                }
-                leaf mep-unexpected-ltr-in {
-                  type yang:counter64;
-                  description
-                    "The total number of unexpected LTRs received.";
-                  reference
-                    "12.14.7.1.3ac, 20.44.1 of IEEE Std 802.1Q-2018";
-                }
-                leaf mep-lbr-out {
-                  type yang:counter64;
-                  description
-                    "Total number of Loopback Replies transmitted.";
-                  reference
-                    "12.14.7.1.3ad, 20.28.2 of IEEE Std 802.1Q-2018";
-                }
-              } // stats
-            } // mep
-          } // maintenance-association-component
+          } // maintenance-association-mep-list
         } // maintenance-association
       } // maintenance-domain
     } // maintenance-domains
+    
+    list maintenance-group-list {
+      key "maintenance-group";
+      description
+        "The list of maintenance groups, which are uniquely associated
+        with a maintenance domain, maintenance association, and
+        maintenance association component, for which the MEPs belong.";
+      leaf maintenance-group {
+        type maintenance-group-type;
+        description
+          "The maintenance group provides a handle
+          for the MD and MA combination.";
+      }
+      leaf md-name {
+        type leafref {
+          path '/cfm/maintenance-domains/maintenance-domain/md-id';
+        }
+        mandatory true;
+        description
+          "A reference to the maintenance domain that this
+          maintenance group is associated with.";
+      }
+
+      leaf ma-name {
+        type leafref {
+          path '/cfm/maintenance-domains'
+             + '/maintenance-domain[md-id = current()/../md-name]'
+             + '/maintenance-association/ma-id';
+        }
+        mandatory true;
+        description
+          "A reference to the maintenance association in the specified
+          maintenance domain, that this maintanance group is 
+          associated with.";
+      }
+      
+      list mep {
+        key "mep-id";
+        description 
+          "A list of local Maintenance association End Points (MEPs).
+          A MEP is an actively managed CFM entity, associated with
+          a specific DoSAP of a service instance, which can
+          generate and receive CFM PDUs and track any responses.
+          It is an end point of a single Maintenance Association
+          (MA) and is an end point of a separate Maintenance
+          Entity for each of the other MEPs in the same MA.";
+        leaf mep-id {
+          type leafref {
+            path '/cfm/maintenance-domains'
+              + '/maintenance-domain'
+              + '[md-id = current()/../../md-name]'
+              + '/maintenance-association'
+              + '[ma-id = current()/../../ma-name]'
+              + '/maintenance-association-mep-list'
+              + '/mep-id';
+          }
+          description
+            "Integer that is unique among all the MEPs in the
+            same Maintenance Association.";
+          reference
+            "3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
+        }
+        leaf direction {
+          type cfm-types:mp-direction-type;
+          description
+            "The direction in which the MEP faces on the Bridge
+            Port. Example, up or down.";
+          reference
+            "12.14.7.1.3c, 19.2 of IEEE Std 802.1Q-2018";
+        }
+        leaf primary-vid {
+          type uint32 {
+            range "0..16777215";
+          }
+          default 0;
+          description
+            "An integer indicating the Primary VID of the MEP. It
+            is always one of the VIDs assigned to the MEPs MA. A
+            value of 0 indicates that either the Primary VID is
+            that of the MEPs MA, or that the MEPs MA is 
+            associated with no VID.";
+          reference
+            "12.14.7.1.3d of IEEE Std 802.1Q-2018"; 
+        }
+        leaf admin-state {
+          type boolean;
+          default "false";
+          description
+            "The administrative state of the MEP. TRUE indicates
+            that the MEP is to functional normally, and FALSE
+            indicates that it is to cease functioning.";
+          reference
+            "12.14.7.1.3e, 20.9.1 of IEEE Std 802.1Q-2018";
+        }
+        leaf fng-state {
+          type cfm-types:fng-state-type;
+          default "fng-reset";
+          config false;
+          description
+            "The current state of the MEP Fault Notification 
+            Generator state machine.";
+          reference
+            "12.14.7.1.3f, 20.35 of IEEE Std 802.1Q-2018";
+        }
+        leaf ccm-ltm-priority {
+          type dot1q-types:priority-type;
+          description
+            "The priority value for CCMs and LTMs transmitted by
+            the MEP. The default value is the highest priority 
+            allowed to pass through the Bridge Port for any of
+            the MEPs VID(s).";
+          reference
+            "12.14.7.1.3h of IEEE Std 802.1Q-2018";
+        }
+        leaf mac-address {
+          type ieee:mac-address;
+          config false;
+          description
+            "The MAC address of the MEP.";
+          reference
+            "12.14.7.1.3i, 19.4 of IEEE Std 802.1Q-2018";
+        }
+        leaf fault-alarm-address {
+          type cfm-types:fault-alarm-address-type;
+          default "not-specified";
+          description
+            "A value indicating whether Fault Alarms are to be 
+            transmitted or not. The default is not specified, 
+            which implies that the disposition of the fault-alarm
+            used by the MD should be used.";
+          reference
+            "3.122, 12.14.7.1.3j of IEEE Std 802.1Q-2018";
+        }
+        leaf lowest-priority-defect {
+          type cfm-types:lowest-alarm-priority-type;
+          default "mac-remote-error-xcon";
+          description
+            "The lowest priority defect that is allowed to
+            generate fault alarms.";
+          reference
+            "12.14.7.1.3k, 20.9.5 of IEEE Std 802.1Q-2018";
+        }
+        leaf fng-alarm-time {
+          type yang:zero-based-counter32 {
+            range "250..1000";
+          }
+          units deciseconds;
+          default 250;
+          description
+            "The time that defect must be present before a Fault
+            Alarm is issued.";
+          reference
+            "12.14.7.1.3l, 20.35.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf fng-reset-time {
+          type yang:zero-based-counter32 {
+            range "250..1000";
+          }
+          units deciseconds;
+          default 1000;
+          description
+            "The time that defects must be absent before 
+            resetting a Fault Alarm.";
+          reference
+            "12.14.7.1.3m, 20.35.4 of IEEE Std 802.1Q-2018";
+        }
+        leaf highest-priority-defect {
+          type cfm-types:highest-defect-priority-type;
+          config false;
+          description
+            "The highest priority defect that has been present
+            sicne the MEPs Fault Notification Generator state
+            machine was last in the FNG_RESET state.";
+          reference
+            "12.14.7.1.3n, 20.35.9 of IEEE Std 802.1Q-2018";
+        }
+        leaf defects {
+          type cfm-types:mep-defects-type;
+          config false;
+          description
+            "Vector of boolean error conditions";
+          reference
+            "12.14.7.1.3o-s, 20.21.3,
+            20.23.3, 20.35.5, 20.35.6, 20.35.7 of IEEE Std 802.1Q-2018";
+        }
+        leaf error-ccm-last-failure {
+          type string {
+            length "1..2000";
+          }
+          config false;
+          description
+            "The last received CCM that triggered a def-error-ccm
+            fault.";
+          reference
+            "12.14.7.1.3t, 20.21.2 of IEEE Std 802.1Q-2018";
+        }
+        leaf xcon-ccm-last-failure {
+          type string {
+            length "1..2000";
+          }
+          config false;
+          description
+            "The last received CCM that triggered a def-xcon-ccm
+            fault.";
+          reference
+            "12.14.7.1.3u, 20.23.2 of IEEE Std 802.1Q-2018";
+        }
+        
+        list mep-db {
+          key rmep-id;
+          description
+            "The MEP CCM Database. A database, maintained by every 
+            MEP, that maintains received information about other MEPs
+            in the Maintenance Domain.";
+          leaf rmep-id {
+            type leafref {
+              path '/cfm/maintenance-domains'
+                + '/maintenance-domain'
+                + '[md-id = current()/../../../md-name]'
+                + '/maintenance-association'
+                + '[ma-id = current()/../../../ma-name]'
+                + '/maintenance-association-mep-list'
+                + '/mep-id';
+            }
+            description
+              "Maintenance association Endpoint Identifier of a
+              remote MEP whose information from the MEP Database
+              is to be returned.";
+            reference
+              "12.14.7.6.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf rmep-state {
+            type cfm-types:remote-mep-state-type;
+            config false;
+            description 
+              "The operational state of the remote MEP  state
+              machine";
+            reference
+              "12.14.7.6.3b, 20.20 of IEEE Std 802.1Q-2018";
+          }
+          leaf rmep-failed-ok-time {
+            type yang:zero-based-counter32;
+            units seconds;
+            config false;
+            description
+              "The time (SysUpTime) at which the Remote MEP state
+              machine last entered either the RMEP_FAILED or
+              RMEP_OK state";
+            reference
+              "12.14.7.6.3c of IEEE Std 802.1Q-2018";
+          }
+          leaf mac-address {
+            type ieee:mac-address;
+            config false;
+            description
+              "The MAC address of the remote MEP.";
+            reference
+              "12.14.7.6.3d, 20.19.7 of IEEE Std 802.1Q-2018";
+          }
+          leaf rdi {
+            type boolean;
+            config false;
+            description
+              "State of the RDI bit in the last received CCM
+              (true for RDI=1), or false if none has been 
+              received.";
+            reference
+              "12.14.7.6.3e, 20.19.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf port-status-tlv {
+            type cfm-types:port-status-tlv-value;
+            default "no-port-state-tlv";
+            config false;
+            description
+              "An enumerated value of the Port status TLV 
+              received in the last CCM from the remote MEP or 
+              the default value no-port-state-tlv indicating
+              either no CCM has been received, or that no port
+              status TLV was received in the last CCM.";
+            reference
+              "12.14.7.6.3f, 20.19.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf interface-status-tlv {
+            type cfm-types:interface-status-tlv-value;
+            default "is-no-interface-status-tlv";
+            config false;
+            description
+              "An enumerated value of the Interface status TLV
+              received in the last CCM from the remote MEP or the
+              default value is-no-interface-status-tlv indicating
+              either no CCM has been received, or that no 
+              interface status TLV was received in the last 
+              CCM.";
+            reference
+              "12.14.7.6.3g, 20.19.4 of IEEE Std 802.1Q-2018";
+          }
+          leaf chassis-id-subtype {
+            type cfm-types:lldp-chassis-id-subtype;
+            config false;
+            description
+              "This object specifies the format of the Chassis ID
+              received in the last CCM.";
+            reference
+              "12.14.7.6.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf chassis-id {
+            type cfm-types:lldp-chassis-id;
+            config false;
+            description
+              "The Chassis ID. The format of this object is
+              determined by the value of the 
+              ltr-chassis-id-subtype object.";
+            reference
+              "12.14.7.6.3h, 21.5.3.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf man-address-domain {
+            type cfm-types:transport-service-domain;
+            config false;
+            description
+              "The transport-service-domain that identifies the
+              type and format of the related mep-db-man-address
+              object, used to access the YANG agent of the system
+              transmitting the CCM. Received in the CCM Sender ID
+              TLV from that system.
+              
+              The value zeroDotZero (from RFC2578) indicates no
+              management address was present in the LTR, in which
+              case the related mep-db-man-address object MUST
+              have a zero-length OCTET STRING as a value.";
+            reference
+              "12.14.7.6.3h, 21.5.3.5,
+              21.6.7 of IEEE Std 802.1Q-2018";
+          }
+          leaf man-address {
+            type cfm-types:transport-service-address;
+            config false;
+            description
+              "The transport-service-address that can be used to 
+              access the YANG agent of the system transmitting
+              the CCM, received in the CCM Sender ID TLV from
+              that system. If the related 
+              mep-db-man-address-domain object contains the 
+              value zeroDotZero, this object mep-db-man-address
+              MUST have a zero-length OCTET STRING as a value.";
+            reference
+              "12.14.7.6.3h, 21.5.3.7,
+              21.6.7 of IEEE Std 802.1Q-2018";
+          }
+          leaf rmep-is-active {
+            type boolean;
+            description
+              "A Boolean value statign if the remote MEP is 
+              active.";
+            reference
+              "12.14.7.1.3ae";
+          }
+        } // mep-db
+        
+        container continuity-check {
+          description
+            "Continuity check protocol";
+          leaf ccm-enabled {
+            type boolean;
+            default "false";
+            description
+              "Indicates whether the MEP can generate CCMs. If 
+              TRUE, the MEP will generate CCM PDUs.";
+            reference
+              "12.14.7.1.3g, 20.10.1 of IEEE Std 802.1Q-2018";
+          }
+          leaf priority {
+            type dot1q-types:priority-type;
+            description
+              "The priority value for CCMs and LTMs transmitted by
+              the MEP. The default value is the highest priority 
+              allowed to pass through the Bridge Port for any of
+              the MEPs VID(s).";
+            reference
+              "12.14.7.1.3h of IEEE Std 802.1Q-2018";
+          }
+          leaf ccm-interval {
+            type cfm-types:cfm-interval-type;
+            description
+              "The interval between CCM transmissions to be used by all
+              MEPs in the Maintenance Association.";
+            reference
+              "12.14.6.1.3e of IEEE Std 802.1Q-2018";
+          }
+        } // continuity-check
+        
+        container loopback {
+          description
+            "Loopback protocol";
+          leaf status {
+            type boolean;
+            default "false";
+            description
+              "A Boolean flag set to TRUE by the MEP Loopback
+              Initiator state machine or YANG network configuration
+              manager to indicate that another LBM is being 
+              transmitted. Reset to FALSE by the MEP Loopback
+              initiator state machine.";
+            reference
+              "20.32, Figure 20-11 of IEEE Std 802.1Q-2018";
+          }
+          leaf interval {
+            type cfm-types:cfm-interval-type;
+            default 1sec;
+            description
+              "The interval between LBM transmissions to be used by all
+              MEPs in the Maintenance Association.";
+          }
+          leaf dest-mac-address {
+            type ieee:mac-address;
+            description
+              "The target MAC Address field to be transmitted.
+              A unicast destination MAC address. This address
+              is used if node mep-transmit-lbm-dest-is-mep-id
+              is FALSE.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf dest-mep-id {
+            type cfm-types:mep-id-or-zero-type;
+            description
+              "The identifier of a remote MEP in the same MA to
+              which the LBM is to be sent. This address
+              is used if node mep-transmit-lbm-dest-is-mep-id
+              is TRUE.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf dest-is-mep-id {
+            type boolean;
+            default "false";
+            description
+              "TRUE indicates that MEP ID of the target MEP is used
+              for Loopback transmissions. FALSE indicates that
+              unicast destination MAC address of the target MEP is
+              used for Loopback transmissions.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf message-count {
+            type uint32 {
+              range "1..1024";
+            }
+            default 1;
+            description
+              "The number of Loopback messages to be transmitted.";
+            reference
+              "12.14.7.3.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf data-tlv {
+            type cfm-types:lbm-data-tlv-type;
+            description
+              "An arbitrary amount of data to be included in the
+              Data TLV, if the Data TLV is selected to be sent. The
+              intent is to be able to fill the frame carrying the
+              CFM PDU to its maximum length.";
+            reference
+              "12.14.7.3.2d of IEEE Std 802.1Q-2018";
+          }
+          leaf priority {
+            type dot1q-types:priority-type;
+            description
+              "Priority. 3 bit value to be used in the VLAN tag, if
+              present in the transmitted frame. The default value
+              should be the CCM priority.";
+            reference
+              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+          }
+          leaf vlan-drop-eligible {
+            type boolean;
+            default "false";
+            description
+              "Drop eligible bit value to be used in the VLAN tag,
+              if present in the transmitted frame";
+            reference
+              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+          }
+          leaf result-ok {
+            type boolean;
+            default "true";
+            config false;
+            description
+              "Indicates the result of the operation:
+                 TRUE - The LBM will be (or has been) sent.
+                 FALSE - The LBM will not be sent.";
+            reference
+              "12.14.7.3.3a of IEEE Std 802.1Q-2018";
+          }
+          leaf seq-number {
+            type cfm-types:seq-number-type;
+            config false;
+            description
+              "The Loopback transaction identifier
+              (mep-next-lbm-trans-id) of the first LBM (to be) 
+              sent. The value returned is undefined if 
+              mep-transmit-lbm-result-ok is FALSE.";
+            reference
+              "12.14.7.3.3b of IEEE Std 802.1Q-2018";
+          }
+          leaf next-lbm-trans-id {
+            type cfm-types:seq-number-type;
+            config false;
+            description
+              "Next sequence number identifier to be sent in a
+              Loopback message. This sequence number can be zero
+              since it can wrap around.";
+            reference
+              "12.14.7.1.3x, 20.28.2 of IEEE Std 802.1Q-2018";
+          }
+        } // loopback
+        
+        container linktrace {
+          description
+            "Linktrace protocol";
+          leaf status {
+            type boolean;
+            default "false";
+            description
+              "A Boolean flag set to TRUE by the Bridge Port to 
+              indicate that another LTM may be transmitted. Reset
+              to FALSE by the MEP Linktrace initiator state 
+              machine.";
+            reference
+              "20.49, Figure 20-17 of IEEE Std 802.1Q-2018";
+          }
+          leaf interval {
+            type cfm-types:cfm-interval-type;
+            default 1sec;
+            description
+              "The interval between LTM transmissions to be used by all
+              MEPs in the Maintenance Association.";
+          }
+          leaf priority {
+            type dot1q-types:priority-type;
+            description
+              "The priority value for CCMs and LTMs transmitted by
+              the MEP. The default value is the highest priority 
+              allowed to pass through the Bridge Port for any of
+              the MEPs VID(s).";
+            reference
+              "12.14.7.1.3h of IEEE Std 802.1Q-2018";
+          }
+          leaf flags {
+            type cfm-types:mep-tx-ltm-flags-type;
+            default use-fdb-only;
+            description
+              "The flags field for the LTMs transmitted by the 
+              MEP.";
+            reference
+              "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
+            
+          }
+          leaf target-mac-address {
+            type ieee:mac-address;
+            description
+              "The target MAC address field to be transmitted. A
+              unicast MAC address. This address will be used if the
+              value of mep-transmit-ltm-target-is-mep-id is FALSE.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf target-mep-id {
+            type cfm-types:mep-id-or-zero-type;
+            description
+              "The target MAC address field to be transmitted. The
+              MEP identifier of another MEP in the same MA. This
+              address will be used if the value of 
+              mep-transmit-ltm-target-is-mep-id is TRUE.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf target-is-mep-id {
+            type boolean;
+            default "false";
+            description
+              "TRUE indicates that MEP id of the target MEP is used
+              for Linktrace transmission. FALSE indicates that
+              unicast destination MAC address of the target MEP is
+              used for LinkTrace transmission.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf ttl {
+            type uint32 {
+              range "0..255";
+            }
+            default 64;
+            description
+              "The LTM TTL field. Indicates the number of hops 
+              remaining to the LTM. Decremented by 1 by each
+              Linktrace Responder that handles the LTM. The value
+              returned in the LTR is one less than that received in
+              the LTM. If the LTM TTL is 0 or 1, the LTM is not
+              forwarded to the next hop, and if 0, no LTR is 
+              generated.";
+            reference
+              "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
+          }
+          leaf result {
+            type boolean;
+            default "true";
+            config false;
+            description
+              "Indicates the result of the operation:
+                 TRUE - The Linktrace message will be (or has been) 
+                        sent.
+                 FALSE - The Linktrace message will not be sent.";
+            reference
+              "12.14.7.4.3a of IEEE Std 802.1Q-2018";
+          }
+          leaf seq-number {
+            type cfm-types:seq-number-type;
+            config false;
+            description
+              "The LTM transaction identifier 
+              (mep-ltm-next-seq-number) of the LTM sent. The value
+              returned is undefined if mep-transmit-ltm-result is 
+              FALSE.";
+            reference
+              "12.14.7.4.3b of IEEE Std 802.1Q-2018";
+          }
+          leaf egress-identifier {
+            type string {
+              length "8";
+            }
+            config false;
+            description
+              "Identifies the MEP Linktrace Initiator that is 
+              originating, or the Linktrace Responder that is
+              forwarding, this LTM.
+              
+              The low-order six octets contain a 48-bit IEEE MAC
+              address unique to the system in which the MEP 
+              Linktrace Initiator or Linktrace Responder resides.
+              The high-order two octets contain a value sufficient
+              to uniquely identify the MEP Linktrace Initiator or 
+              Linktrace Responder within that system.
+              
+              For most Bridges, the address of any MAC attached to
+              the Bridge will suffice for the low-order six octets,
+              and 0 for the high-order octets. In some situations,
+              e.g., if multiple virtual Bridges utilizing emulated
+              LANs are implemented in a single physical system, the
+              high-order two octets can be used to differentiate
+              among the transmitting entities.
+              
+              The value returned is undefined if 
+              mep-transmit-ltm-result is FALSE.";
+            reference
+              "12.14.7.4.3c of IEEE Std 802.1Q-2018";
+          }
+          leaf next-seq-number {
+            type cfm-types:seq-number-type;
+            config false;
+            description
+              "Next transaction identifier to be sent in a 
+              LinkTrace message.This sequence number can be zero
+              since it can wrap around.";
+            reference
+              "12.14.7.1.3ab, 20.41.1 of IEEE Std 802.1Q-2018";
+          }
+        } // linktrace
+        
+        container stats {
+          config false;
+          description
+            "Contains the counters associated with the MEP.";
+          leaf mep-ccm-sequence-errors {
+            type yang:counter64;
+            description
+              "The total number of out-of-sequence CCMs received
+              from all remote MEPs.";
+            reference
+              "12.14.7.1.3v, 20.16.12 of IEEE Std 802.1Q-2018";
+          }
+          leaf mep-ccms-sent {
+            type yang:counter64;
+            description
+              "Total number of CCMs transmitted";
+            reference
+              "12.14.7.1.3w, 20.10.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf mep-lbr-in {
+            type yang:counter64;
+            description
+              "Total number of valid, in-order Loopback Replies
+              received.";
+            reference
+              "12.14.7.1.3y, 20.31.1 of IEEE Std 802.1Q-2018";
+          }
+          leaf mep-lbr-in-out-of-order {
+            type yang:counter64;
+            description
+              "The total number of valid, out-of-order
+              Loopback Replies received";
+            reference
+              "12.14.7.1.3z, 20.31.1 of IEEE Std 802.1Q-2018";
+          }
+          leaf mep-lbr-bad-msdu {
+            type yang:counter64;
+            description
+              "The total number of LBRs received whose
+              mac_service_data_unit did not match (except for the
+              OpCode) that of the corresponding LBM.";
+            reference
+              "12.14.7.1.3aa, 20.2.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf mep-unexpected-ltr-in {
+            type yang:counter64;
+            description
+              "The total number of unexpected LTRs received.";
+            reference
+              "12.14.7.1.3ac, 20.44.1 of IEEE Std 802.1Q-2018";
+          }
+          leaf mep-lbr-out {
+            type yang:counter64;
+            description
+              "Total number of Loopback Replies transmitted.";
+            reference
+              "12.14.7.1.3ad, 20.28.2 of IEEE Std 802.1Q-2018";
+          }
+        } // stats
+        
+        notification mep-fault-alarm {
+          description
+            "To alert the Manager to the existence of a fault in a
+            monitored MA by issuing a Fault Alarm.";
+          leaf mep-priority-defect {
+            type leafref {
+              path "../../highest-priority-defect";
+            }
+            description
+              "The highest priority defect that has been present
+              since the MEPs Fault Notification Generator state
+              machine was last in the FNG_RESET state.";
+          }
+        } // mep-fault-alarm
+      } // mep
+    } // maintenance-group-list
+    
+    list cfm-operation {
+      key "maintenance-group mep-id";
+      description 
+        "A list of CFM commands that can be performed.";
+      leaf maintenance-group {
+        type leafref {
+          path '/cfm/maintenance-group-list/maintenance-group';
+        }
+        description
+          "A reference to the maintenance group.";
+      }
+      leaf mep-id {
+        type leafref {
+          path '/cfm'
+            + '/maintenance-group-list'
+            + '[maintenance-group = current()/../maintenance-group]'
+            + '/mep/mep-id';
+        }
+        description
+          "A reference to a MEP associated with the maintenance
+          group.";
+      }
+      
+      action transmit-loopback {
+        description
+          "To signal to the MEP to transmit some number of LBMs.";
+        input {
+          leaf lbm-dest-is-mep-id {
+            type boolean;
+            default "false";
+            description
+              "TRUE indicates that MEP ID of the target MEP is used
+              for Loopback transmissions. FALSE indicates that
+              unicast destination MAC address of the target MEP is
+              used for Loopback transmissions.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-dest-mac-address {
+            type ieee:mac-address;
+            description
+              "The target MAC Address field to be transmitted.
+              A unicast destination MAC address. This address
+              is used if node lbm-dest-is-mep-id is FALSE.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-dest-mep-id {
+            type cfm-types:mep-id-or-zero-type;
+            default 0;
+            description
+              "The identifier of a remote MEP in the same MA to
+              which the LBM is to be sent. This address
+              is used if node mep-transmit-lbm-dest-is-mep-id
+              is TRUE.";
+            reference
+              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+          }
+          leaf interval {
+            type cfm-types:cfm-interval-type;
+            default 1sec;
+            description
+              "The interval between LBM transmissions to be used by all
+              MEPs in the Maintenance Association.";
+          }
+          leaf lbm-messages {
+            type uint32 {
+              range "1..1024";
+            }
+            default 1;
+            description
+              "The number of Loopback messages to be transmitted.";
+            reference
+              "12.14.7.3.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-priority {
+            type dot1q-types:priority-type;
+            description
+              "Priority. 3 bit value to be used in the VLAN tag, if
+              present in the transmitted frame. The default value
+              should be the CCM priority.";
+            reference
+              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-drop-eligible {
+            type boolean;
+            default "false";
+            description
+              "Drop eligible bit value to be used in the VLAN tag, if
+              present in the transmitted frame";
+            reference
+              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-data-tlv {
+            type cfm-types:lbm-data-tlv-type;
+            description
+              "An arbitrary amount of data to be included in the
+              Data TLV, if the Data TLV is selected to be sent. The
+              intent is to be able to fill the frame carrying the
+              CFM PDU to its maximum length.";
+            reference
+              "12.14.7.3.2d of IEEE Std 802.1Q-2018";
+          }
+        } // input
+        output {
+          leaf lbm-result-ok {
+            type boolean;
+            default "true";
+            description
+              "Indicates the result of the operation:
+                 TRUE - The LBM will be (or has been) sent.
+                 FALSE - The LBM will not be sent.";
+            reference
+              "12.14.7.3.3a of IEEE Std 802.1Q-2018";
+          }
+          leaf lbm-seq-number {
+            type cfm-types:seq-number-type;
+            description
+              "The Loopback transaction identifier
+              (mep-next-lbm-trans-id) of the first LBM (to be) sent.
+              The value returned is undefined if 
+              mep-transmit-lbm-result-ok is FALSE.";
+            reference
+              "12.14.7.3.3b of IEEE Std 802.1Q-2018";
+          }     
+        } // output        
+      } // transmit-loopback
+      
+      action transmit-linktrace {
+        description
+          "To signal to the MEP to transmit an LTM and to create an LTM
+          entry in the MEPs Linktrace Database.";
+        input {
+          leaf interval {
+            type cfm-types:cfm-interval-type;
+            default 1sec;
+            description
+              "The interval between LTM transmissions to be used by all
+              MEPs in the Maintenance Association.";
+          }
+          leaf ltm-target-is-mep-id {
+            type boolean;
+            default "false";
+            description
+              "TRUE indicates that MEP id of the target MEP is used
+              for Linktrace transmission. FALSE indicates that
+              unicast destination MAC address of the target MEP is
+              used for LinkTrace transmission.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-target-mac-address {
+            type ieee:mac-address;
+            description
+              "The target MAC address field to be transmitted. A
+              unicast MAC address. This address will be used if the
+              value of mep-transmit-ltm-target-is-mep-id is FALSE.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-target-mep-id {
+            type cfm-types:mep-id-or-zero-type;
+            default 0;
+            description
+              "The target MAC address field to be transmitted. The
+              MEP identifier of another MEP in the same MA. This
+              address will be used if the value of 
+              mep-transmit-ltm-target-is-mep-id is TRUE.";
+            reference
+              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-priority {
+            type dot1q-types:priority-type;
+            description
+              "Priority. 3 bit value to be used in the VLAN tag, if
+              present in the transmitted frame. The default value
+              should be the CCM priority.";
+          }
+          leaf ltm-drop-eligible {
+            type boolean;
+            default "false";
+            description
+              "Drop eligible bit value to be used in the VLAN tag, if
+              present in the transmitted frame";
+          }
+          leaf ltm-ttl {
+            type uint32 {
+              range "0..255";
+            }
+            default 64;
+            description
+              "The LTM TTL field. Indicates the number of hops 
+              remaining to the LTM. Decremented by 1 by each
+              Linktrace Responder that handles the LTM. The value
+              returned in the LTR is one less than that received in
+              the LTM. If the LTM TTL is 0 or 1, the LTM is not
+              forwarded to the next hop, and if 0, no LTR is 
+              generated.";
+            reference
+              "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-flags {
+            type cfm-types:mep-tx-ltm-flags-type;
+            default use-fdb-only;
+            description
+              "The flags field for the LTMs transmitted by the MEP.";
+            reference
+              "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
+            
+          }
+        } // input
+        output {
+          leaf ltm-result-ok {
+            type boolean;
+            default "true";
+            description
+              "Indicates the result of the operation:
+                 TRUE - The Linktrace message will be (or has been) 
+                        sent.
+                 FALS - The Linktrace message will not be sent.";
+            reference
+              "12.14.7.4.3a of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-seq-number {
+            type cfm-types:seq-number-type;
+            description
+              "The LTM transaction identifier 
+              (mep-ltm-next-seq-number) of the LTM sent. The value
+              returned is undefined if mep-transmit-ltm-result is 
+              FALSE.";
+            reference
+              "12.14.7.4.3b of IEEE Std 802.1Q-2018";
+          }
+          leaf ltm-egress-identifier {
+            type string {
+              length "8";
+            }
+            description
+              "Identifies the MEP Linktrace Initiator that is 
+              originating, or the Linktrace Responder that is
+              forwarding, this LTM.
+              
+              The low-order six octets contain a 48-bit IEEE MAC
+              address unique to the system in which the MEP Linktrace
+              Initiator or Linktrace Responder resides. The 
+              high-order two octets contain a value sufficient to 
+              uniquely identify the MEP Linktrace Initiator or 
+              Linktrace Responder within that system.
+              
+              For most Bridges, the address of any MAC attached to
+              the Bridge will suffice for the low-order six octets,
+              and 0 for the high-order octets. In some situations,
+              e.g., if multiple virtual Bridges utilizing emulated
+              LANs are implemented in a single physical system, the
+              high-order two octets can be used to differentiate
+              among the transmitting entities.
+              
+              The value returned is undefined if 
+              mep-transmit-ltm-result is FALSE.";
+            reference
+              "12.14.7.4.3c of IEEE Std 802.1Q-2018";
+          }
+        } // output
+      } // transmit-linktrace
+      
+      list loopback-reply {
+        key "lbr-seq-number lbr-receive-order";
+        description 
+          "This table extends the MEP table and contains a list
+          of Loopback replies received by a specific MEP in
+          response to a loopback message.";
+        leaf lbr-seq-number {
+          type cfm-types:seq-number-type;
+          description
+            "The Loopback transaction identifier
+            (mep-next-lbm-trans-id) of the first LBM (to be) 
+            sent. The value returned is undefined if 
+            mep-transmit-lbm-result-ok is FALSE.";
+          reference
+            "12.14.7.3.3b of IEEE Std 802.1Q-2018";
+        }
+        leaf lbr-receive-order {
+          type uint32 {
+            range "1..4294967295";
+          }
+          description
+            "An index to distinguish among multiple LBRs with
+            the same LBR Transaction Identifier field value. 
+            Assigned sequentially from 1, in the order that the 
+            Loopback Initiator received the LBRs.";
+        }
+        leaf result-ok {
+          type boolean;
+          default "true";
+          config false;
+          description
+            "Indicates the result of the operation:
+               TRUE - The LBM will be (or has been) sent.
+               FALSE - The LBM will not be sent.";
+          reference
+            "12.14.7.3.3a of IEEE Std 802.1Q-2018";
+        }
+      } // loopback-reply
+      
+      list linktrace-reply {
+        key "ltr-seq-number ltr-receive-order";
+        description
+          "This table extends the MEP table and contains a list
+          of Linktrace replies received by a specific MEP in
+          response to a linktrace message.";
+        leaf ltr-seq-number {
+          type cfm-types:seq-number-type;
+          description
+            "Transaction identifier returned by a previous
+            transmit linktrace message command, indicating
+            which LTMs response is going to be returned.";
+          reference
+            "12.14.7.5.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-receive-order {
+          type uint32 {
+            range "1..4294967295";
+          }
+          description
+            "An index to distinguish among multiple LTRs with
+            the same LTR Transaction Identifier field value. 
+            Assigned sequentially from 1, in the order that the 
+            Linktrace Initiator received the LTRs.";
+        }
+        leaf ltr-ttl {
+          type uint32 {
+            range "0..255";
+          }
+          config false;
+          description
+            "TTL field value for a returned LTR.";
+          reference
+            "12.14.7.5, 20.41.2.2 of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-forwarded {
+          type boolean;
+          config false;
+          description
+            "Indicates if a LTM was forwarded by the responding
+            MP, as returned in the FwdYes flag of the flags 
+            field.";
+          reference
+            "12.14.7.5.3c, 20.41.2.1 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-terminal-mep {
+          type boolean;
+          config false;
+          description
+            "A Boolean value stating whether the forwarded LTM
+            reached a MEP enclosing its MA, as returned in the
+            Terminal MEP flag of the Flags field";
+          reference
+            "12.14.7.5.3d, 20.41.2.1 of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-last-egress-identifier {
+          type string {
+            length "8";
+          }
+          config false;
+          description
+            "An octet field holding the Last Egress Identifier
+            returned in the LTR Egress Identifier TLV of the
+            LTR. The Last Egress Identifier identifies the MEP
+            Linktrace Initiator that originated, or the 
+            Linktrace Responder that forwarded, the LTM to
+            which this LTR is the response. This is the same
+            value as the Egress Identifier TLV of that LTM.";
+          reference
+            "12.14.7.5.3e, 20.41.2.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-next-egress-identifier {
+          type string {
+            length "8";
+          }
+          config false;
+          description
+            "An octet field holding the Next Egress Identifier
+            returned in the LTR Egress Identifier TLV of the 
+            LTR. The Next Egress Identifier Identifies the
+            Linktrace Responder that transmitted this LTR, and
+            can forward the LTM to the next hop. This is the
+            same value as the Egress Identifier TLV of the
+            forwarded LTM, if any. If the FwdYes bit of the
+            Flags field is false, the contents of this field
+            are undefined, i.e., any value can be transmitted,
+            and the field is ignored by the receiver.";
+          reference
+            "12.14.7.5.3f, 20.41.2.4 of IEEE Std 802.1Q-2018";
+        }
+        leaf ltr-relay {
+          type cfm-types:relay-action-field-value;
+          config false;
+          description
+            "Value returned in the Relay Action field.";
+          reference
+            "12.14.7.5.3g, 20.41.2.5 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-chassis-id-subtype {
+          type cfm-types:lldp-chassis-id-subtype;
+          config false;
+          description
+            "Specifies the format of the Chassis ID returned
+            in the Sender ID TLV of the LTR, if any. This value
+            is meaningless if the ltr-chassis-id has a length
+            of 0.";
+          reference
+            "12.14.7.5.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-chassis-id {
+          type cfm-types:lldp-chassis-id;
+          config false;
+          description
+            "The Chassis ID returned in the Sender ID TLV of 
+            the LTR, if any. The format of this object is
+            determined by the value of the 
+            ltr-chassis-id-subtype object.";
+          reference
+            "12.14.7.5.3i, 21.5.3.2 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-man-address-domain {
+          type cfm-types:transport-service-domain;
+          config false;
+          description
+            "The transport-service-domain that identifies the
+            type and format of the related mep-db-man-address
+            object, used to access the YANG agent of the system
+            transmitting the LTR. Received in the LTR Sender ID
+            TLV from that system.";
+          reference
+            "12.14.7.5.3j, 21.5.3.5,
+            21.9.6 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-man-address {
+          type cfm-types:transport-service-address;
+          config false;
+          description
+            "The transport-service-address that can be used to
+            access the YANG agent of the system transmitting
+            the CCM, received in the CCM Sender ID TLV from
+            that system.
+            
+            If the related object ltr-man-address-domain
+            contains the value zeroDotZero, this object
+            ltr-man-address MUST have a zero-length OCTET 
+            STRING as a value.";
+          reference
+            "12.14.7.5.3j, 21.5.3.7,
+            21.9.6 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-ingress {
+          type cfm-types:ingress-action-field-value;
+          config false;
+          description
+            "The value returned in the Ingress Action Field of
+            the LTM. The value ingress-no-tlv indicates that no
+            Reply Ingress TLV was returned in the LTM.";
+          reference
+            "12.14.7.5.3k, 20.41.2.6 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-ingress-mac {
+          type ieee:mac-address;
+          config false;
+          description
+            "MAC address returned in the ingress MAC address
+            field. If the ltr-ingress object contains the value 
+            ingress-no-tlv, then the contents of this object
+            are meaningless.";
+          reference
+            "12.14.7.5.3l, 20.41.2.7 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-ingress-port-id-subtype {
+          type cfm-types:lldp-port-id-subtype;
+          config false;
+          description
+            "Ingress Port ID. The format of this object is 
+            determined by the value of the 
+            ltr-ingress-port-id-subtype object. If the
+            ltr-ingress object contains the value 
+            ingress-no-tlv, then the contents of this object
+            are meaningless.";
+          reference
+            "12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-egress {
+          type cfm-types:egress-action-field-value;
+          config false;
+          description
+            "The value returned in the Egress Action Field of
+            the LTM. The value egress-no-tlv indicates that 
+            no Reply Egress TLV was returned in the LTM.";
+          reference
+            "12.14.7.5.3o, 20.41.2.10 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-egress-mac {
+          type ieee:mac-address;
+          config false;
+          description
+            "MAC address returned in the egress MAC address
+            field. If the ltr-egress object contains the value
+            egress-no-tlv, then the contents of this object are
+            meaningless.";
+          reference
+            "12.14.7.5.3p, 20.41.2.11 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-egress-port-id-subtype {
+          type cfm-types:lldp-port-id-subtype;
+          config false;
+          description
+            "Format of the egress Port ID. If the ltr-egress
+            object contains the value egress-no-tlv, then the
+            contents of this object are meaningless.";
+          reference
+            "12.14.7.5.3q, 20.41.2.12 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-egress-port-id {
+          type cfm-types:lldp-port-id;
+          config false;
+          description
+            "Egress Port ID. The format of this object is
+            determined by the value of the
+            ltr-egress-port-id-subtype object. If the 
+            ltr-egress object contains the value egress-no-tlv,
+            then the contents of this object are meaningless.";
+          reference
+            "12.14.7.5.3r, 20.41.2.13 of IEEE Std 802.1Q-2018";
+        }           
+        leaf ltr-organization-specific-tlv {
+          type string {
+            length "0 | 4..1500";
+          }
+          config false;
+          description
+            "All Organization specific TLVs returned in the 
+            LTR, if any. Includes all octets including and
+            following the TLV Length field of each TLV, 
+            concatenated together.";
+          reference
+            "12.14.7.5.3s, 21.5.2 of IEEE Std 802.1Q-2018";
+        }
+      } // linktrace-reply
+    } // cfm-operation
+    
   } // cfm
   
-  
-  /* ------------------------
-   *  Remote Procedure Calls
-   * ------------------------
-   */
-  rpc transmit-loopback {
-    description
-      "To signal to the MEP to transmit some number of LBMs.";
-    input {
-      leaf maintenance-group {
-        type maintenance-group-type;
-        description
-          "The maintenance group to which the Maintenance Points
-          is associated with.";
-      }
-      leaf mep-id {
-        type mep-id-type;
-        description
-          "Integer that is unique among all the MEPs in the same
-          Maintenance Association.";
-        reference
-          "12.14.7.3.2a of IEEE Std 802.1Q-2018";
-      }
-      leaf interval {
-        type cfm-interval-type;
-        default 1sec;
-        description
-          "The interval between LBM transmissions to be used by all
-          MEPs in the Maintenance Association.";
-      }
-      leaf lbm-dest-is-mep-id {
-        type boolean;
-        default "false";
-        description
-          "TRUE indicates that MEP ID of the target MEP is used
-          for Loopback transmissions. FALSE indicates that
-          unicast destination MAC address of the target MEP is
-          used for Loopback transmissions.";
-        reference
-          "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-      }
-      leaf lbm-dest-mac-address {
-        type ieee:mac-address;
-        description
-          "The target MAC Address field to be transmitted.
-          A unicast destination MAC address. This address
-          is used if node lbm-dest-is-mep-id is FALSE.";
-        reference
-          "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-      }
-      leaf lbm-dest-mep-id {
-        type mep-id-or-zero-type;
-        default 0;
-        description
-          "The identifier of a remote MEP in the same MA to
-          which the LBM is to be sent. This address
-          is used if node mep-transmit-lbm-dest-is-mep-id
-          is TRUE.";
-        reference
-          "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-      }
-      leaf lbm-messages {
-        type uint32 {
-          range "1..1024";
-        }
-        default 1;
-        description
-          "The number of Loopback messages to be transmitted.";
-        reference
-          "12.14.7.3.2c of IEEE Std 802.1Q-2018";
-      }
-      leaf lbm-priority {
-        type dot1q-types:priority-type;
-        description
-          "Priority. 3 bit value to be used in the VLAN tag, if
-          present in the transmitted frame. The default value
-          should be the CCM priority.";
-        reference
-          "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-      }
-      leaf lbm-drop-eligible {
-        type boolean;
-        default "false";
-        description
-          "Drop eligible bit value to be used in the VLAN tag, if
-          present in the transmitted frame";
-        reference
-          "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-      }
-      leaf lbm-data-tlv {
-        type string;
-        description
-          "An arbitrary amount of data to be included in the
-          Data TLV, if the Data TLV is selected to be sent. The
-          intent is to be able to fill the frame carrying the
-          CFM PDU to its maximum length.";
-        reference
-          "12.14.7.3.2d of IEEE Std 802.1Q-2018";
-      }
-    } // input
-    output {
-      leaf lbm-result-ok {
-        type boolean;
-        default "true";
-        description
-          "Indicates the result of the operation:
-             TRUE - The LBM will be (or has been) sent.
-             FALSE - The LBM will not be sent.";
-        reference
-          "12.14.7.3.3a of IEEE Std 802.1Q-2018";
-      }
-      leaf lbm-seq-number {
-        type uint32;
-        description
-          "The Loopback transaction identifier
-          (mep-next-lbm-trans-id) of the first LBM (to be) sent.
-          The value returned is undefined if 
-          mep-transmit-lbm-result-ok is FALSE.";
-        reference
-          "12.14.7.3.3b of IEEE Std 802.1Q-2018";
-      }     
-    } // output
-  } // transmit-loopback
-    
-  rpc transmit-linktrace {
-    description
-      "To signal to the MEP to transmit an LTM and to create an LTM
-      entry in the MEPs Linktrace Database.";
-    input {
-      leaf maintenance-group {
-        type maintenance-group-type;
-        description
-          "The maintenance group to which the Maintenance Points
-          is associated with.";
-      }
-      leaf mep-id {
-        type mep-id-type;
-        description
-          "Integer that is unique among all the MEPs in the same
-          Maintenance Association.";
-        reference
-          "12.14.7.4.2a of IEEE Std 802.1Q-2018";
-      }
-      leaf interval {
-        type cfm-interval-type;
-        default 1sec;
-        description
-          "The interval between LTM transmissions to be used by all
-          MEPs in the Maintenance Association.";
-      }
-      leaf ltm-target-is-mep-id {
-        type boolean;
-        default "false";
-        description
-          "TRUE indicates that MEP id of the target MEP is used
-          for Linktrace transmission. FALSE indicates that
-          unicast destination MAC address of the target MEP is
-          used for LinkTrace transmission.";
-        reference
-          "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-      }
-      leaf ltm-target-mac-address {
-        type ieee:mac-address;
-        description
-          "The target MAC address field to be transmitted. A
-          unicast MAC address. This address will be used if the
-          value of mep-transmit-ltm-target-is-mep-id is FALSE.";
-        reference
-          "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-      }
-      leaf ltm-target-mep-id {
-        type mep-id-or-zero-type;
-        default 0;
-        description
-          "The target MAC address field to be transmitted. The
-          MEP identifier of another MEP in the same MA. This
-          address will be used if the value of 
-          mep-transmit-ltm-target-is-mep-id is TRUE.";
-        reference
-          "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-      }
-      leaf ltm-priority {
-        type dot1q-types:priority-type;
-        description
-          "Priority. 3 bit value to be used in the VLAN tag, if
-          present in the transmitted frame. The default value
-          should be the CCM priority.";
-      }
-      leaf ltm-drop-eligible {
-        type boolean;
-        default "false";
-        description
-          "Drop eligible bit value to be used in the VLAN tag, if
-          present in the transmitted frame";
-      }
-      leaf ltm-ttl {
-        type uint32 {
-          range "0..255";
-        }
-        default 64;
-        description
-          "The LTM TTL field. Indicates the number of hops 
-          remaining to the LTM. Decremented by 1 by each
-          Linktrace Responder that handles the LTM. The value
-          returned in the LTR is one less than that received in
-          the LTM. If the LTM TTL is 0 or 1, the LTM is not
-          forwarded to the next hop, and if 0, no LTR is 
-          generated.";
-        reference
-          "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
-      }
-      leaf ltm-flags {
-        type mep-tx-ltm-flags-type;
-        default use-fdb-only;
-        description
-          "The flags field for the LTMs transmitted by the MEP.";
-        reference
-          "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
-        
-      }
-    } // input
-    output {
-      leaf ltm-result {
-        type boolean;
-        default "true";
-        description
-          "Indicates the result of the operation:
-             TRUE - The Linktrace message will be (or has been) 
-                    sent.
-             FALS - The Linktrace message will not be sent.";
-        reference
-          "12.14.7.4.3a of IEEE Std 802.1Q-2018";
-      }
-      leaf ltm-seq-number {
-        type uint32;
-        description
-          "The LTM transaction identifier 
-          (mep-ltm-next-seq-number) of the LTM sent. The value
-          returned is undefined if mep-transmit-ltm-result is 
-          FALSE.";
-        reference
-          "12.14.7.4.3b of IEEE Std 802.1Q-2018";
-      }
-      leaf ltm-egress-identifier {
-        type string {
-          length "8";
-        }
-        description
-          "Identifies the MEP Linktrace Initiator that is 
-          originating, or the Linktrace Responder that is
-          forwarding, this LTM.
-          
-          The low-order six octets contain a 48-bit IEEE MAC
-          address unique to the system in which the MEP Linktrace
-          Initiator or Linktrace Responder resides. The 
-          high-order two octets contain a value sufficient to 
-          uniquely identify the MEP Linktrace Initiator or 
-          Linktrace Responder within that system.
-          
-          For most Bridges, the address of any MAC attached to
-          the Bridge will suffice for the low-order six octets,
-          and 0 for the high-order octets. In some situations,
-          e.g., if multiple virtual Bridges utilizing emulated
-          LANs are implemented in a single physical system, the
-          high-order two octets can be used to differentiate
-          among the transmitting entities.
-          
-          The value returned is undefined if 
-          mep-transmit-ltm-result is FALSE.";
-        reference
-          "12.14.7.4.3c of IEEE Std 802.1Q-2018";           
-      }
-    } // output
-  } // transmit- linktrace
-  
-  /* ---------------
-   *  Notifications
-   * ---------------
-   */
-  
-  notification mep-fault-alarm {
-    description
-      "To alert the Manager to the existence of a fault in a monitored
-      MA by issuing a Fault Alarm.";
-    leaf maintenance-group {
-      type maintenance-group-type;
-      description
-        "The maintenance group to which the Maintenance Points
-        is associated with.";
-    }   
-    leaf mep-id {
-      type leafref {
-        path "/cfm/maintenance-domains/maintenance-domain"+
-         "/maintenance-association/maintenance-association-component"+
-         "/mep/mep-id";
-      }
-      description
-        "Integer that is unique among all the MEPs in the same
-        Maintenance Association.";
-      reference
-        "3.114, 12.14.7, 19.2 of IEEE Std 802.1Q-2018";
-    }
-    leaf mep-priority-defect {
-      type leafref {
-        path "/cfm/maintenance-domains/maintenance-domain"+
-         "/maintenance-association/maintenance-association-component"+
-         "/mep/highest-priority-defect";
-      }
-      description
-        "The highest priority defect that has been present
-        since the MEPs Fault Notification Generator state
-        machine was last in the FNG_RESET state.";
-    }
-  } // mep-fault-alarm
-    
 } // ieee802-dot1q-cfm


### PR DESCRIPTION
Clean compile

**ieee802-dot1q-types.yang**
Pyang Validation
ieee802-dot1q-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm.yang**
Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw maintenance-domains
       |  +--rw maintenance-domain* [md-id]
       |     +--rw md-id                        cfm-types:name-key-type
       |     +--rw (md-name)?
       |     |  +--:(ieee-reserved-0)
       |     |  |  +--rw name?                        string
       |     |  +--:(none)
       |     |  |  +--rw none?                        empty
       |     |  +--:(dns-like-name)
       |     |  |  +--rw dns-like-name?               string
       |     |  +--:(mac-address-and-uint)
       |     |  |  +--rw mac-address-and-uint-type
       |     |  |     +--rw address?   ieee:mac-address
       |     |  |     +--rw int?       uint16
       |     |  +--:(char-string)
       |     |     +--rw char-string?                 string
       |     +--rw md-level?                    cfm-types:md-level-type
       |     +--rw mhf-creation?                cfm-types:mhf-creation-type
       |     +--rw id-permission?               cfm-types:sender-id-permission-type
       |     +--rw fault-alarm-address?         cfm-types:fault-alarm-address-type
       |     +--rw maintenance-association* [ma-id]
       |        +--rw ma-id                               cfm-types:name-key-type
       |        +--rw (ma-name)?
       |        |  +--:(ieee-reserved-0)
       |        |  |  +--rw name?                               string
       |        |  +--:(primary-vid)
       |        |  |  +--rw primary-vid?                        dot1q-types:vlanid
       |        |  +--:(char-string)
       |        |  |  +--rw char-string?                        string
       |        |  +--:(unsigned-int16)
       |        |  |  +--rw unsigned-int16?                     uint16
       |        |  +--:(rfc2865-vpn-id)
       |        |  |  +--rw rfc2865-vpn-id?                     string
       |        |  +--:(icc-format)
       |        |     +--rw icc-format?                         string
       |        +--rw ccm-interval?                       cfm-types:cfm-interval-type
       |        +--rw fault-alarm-address?                cfm-types:fault-alarm-address-type
       |        +--rw maintenance-association-mep-list* [mep-id]
       |           +--rw mep-id    cfm-types:mep-id-type
       +--rw maintenance-group-list* [maintenance-group]
       |  +--rw maintenance-group    maintenance-group-type
       |  +--rw md-name              -> /cfm/maintenance-domains/maintenance-domain/md-id
       |  +--rw ma-name              -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../md-name]/maintenance-association/ma-id
       |  +--rw mep* [mep-id]
       |     +--rw mep-id                     -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../../md-name]/maintenance-association[ma-id = current()/../../ma-name]/maintenance-association-mep-list/mep-id
       |     +--rw direction?                 cfm-types:mp-direction-type
       |     +--rw primary-vid?               uint32
       |     +--rw admin-state?               boolean
       |     +--ro fng-state?                 cfm-types:fng-state-type
       |     +--rw ccm-ltm-priority?          dot1q-types:priority-type
       |     +--ro mac-address?               ieee:mac-address
       |     +--rw fault-alarm-address?       cfm-types:fault-alarm-address-type
       |     +--rw lowest-priority-defect?    cfm-types:lowest-alarm-priority-type
       |     +--rw fng-alarm-time?            yang:zero-based-counter32
       |     +--rw fng-reset-time?            yang:zero-based-counter32
       |     +--ro highest-priority-defect?   cfm-types:highest-defect-priority-type
       |     +--ro defects?                   cfm-types:mep-defects-type
       |     +--ro error-ccm-last-failure?    string
       |     +--ro xcon-ccm-last-failure?     string
       |     +--rw mep-db* [rmep-id]
       |     |  +--rw rmep-id                 -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../../../md-name]/maintenance-association[ma-id = current()/../../../ma-name]/maintenance-association-mep-list/mep-id
       |     |  +--ro rmep-state?             cfm-types:remote-mep-state-type
       |     |  +--ro rmep-failed-ok-time?    yang:zero-based-counter32
       |     |  +--ro mac-address?            ieee:mac-address
       |     |  +--ro rdi?                    boolean
       |     |  +--ro port-status-tlv?        cfm-types:port-status-tlv-value
       |     |  +--ro interface-status-tlv?   cfm-types:interface-status-tlv-value
       |     |  +--ro chassis-id-subtype?     cfm-types:lldp-chassis-id-subtype
       |     |  +--ro chassis-id?             cfm-types:lldp-chassis-id
       |     |  +--ro man-address-domain?     cfm-types:transport-service-domain
       |     |  +--ro man-address?            cfm-types:transport-service-address
       |     |  +--rw rmep-is-active?         boolean
       |     +--rw continuity-check
       |     |  +--rw ccm-enabled?    boolean
       |     |  +--rw priority?       dot1q-types:priority-type
       |     |  +--rw ccm-interval?   cfm-types:cfm-interval-type
       |     +--rw loopback
       |     |  +--rw status?               boolean
       |     |  +--rw interval?             cfm-types:cfm-interval-type
       |     |  +--rw dest-mac-address?     ieee:mac-address
       |     |  +--rw dest-mep-id?          cfm-types:mep-id-or-zero-type
       |     |  +--rw dest-is-mep-id?       boolean
       |     |  +--rw message-count?        uint32
       |     |  +--rw data-tlv?             cfm-types:lbm-data-tlv-type
       |     |  +--rw priority?             dot1q-types:priority-type
       |     |  +--rw vlan-drop-eligible?   boolean
       |     |  +--ro result-ok?            boolean
       |     |  +--ro seq-number?           cfm-types:seq-number-type
       |     |  +--ro next-lbm-trans-id?    cfm-types:seq-number-type
       |     +--rw linktrace
       |     |  +--rw status?               boolean
       |     |  +--rw interval?             cfm-types:cfm-interval-type
       |     |  +--rw priority?             dot1q-types:priority-type
       |     |  +--rw flags?                cfm-types:mep-tx-ltm-flags-type
       |     |  +--rw target-mac-address?   ieee:mac-address
       |     |  +--rw target-mep-id?        cfm-types:mep-id-or-zero-type
       |     |  +--rw target-is-mep-id?     boolean
       |     |  +--rw ttl?                  uint32
       |     |  +--ro result?               boolean
       |     |  +--ro seq-number?           cfm-types:seq-number-type
       |     |  +--ro egress-identifier?    string
       |     |  +--ro next-seq-number?      cfm-types:seq-number-type
       |     +--ro stats
       |     |  +--ro mep-ccm-sequence-errors?   yang:counter64
       |     |  +--ro mep-ccms-sent?             yang:counter64
       |     |  +--ro mep-lbr-in?                yang:counter64
       |     |  +--ro mep-lbr-in-out-of-order?   yang:counter64
       |     |  +--ro mep-lbr-bad-msdu?          yang:counter64
       |     |  +--ro mep-unexpected-ltr-in?     yang:counter64
       |     |  +--ro mep-lbr-out?               yang:counter64
       |     +---n mep-fault-alarm
       |        +---- mep-priority-defect?   -> ../../highest-priority-defect
       +--rw cfm-operation* [maintenance-group mep-id]
          +--rw maintenance-group     -> /cfm/maintenance-group-list/maintenance-group
          +--rw mep-id                -> /cfm/maintenance-group-list[maintenance-group = current()/../maintenance-group]/mep/mep-id
          +---x transmit-loopback
          |  +---w input
          |  |  +---w lbm-dest-is-mep-id?     boolean
          |  |  +---w lbm-dest-mac-address?   ieee:mac-address
          |  |  +---w lbm-dest-mep-id?        cfm-types:mep-id-or-zero-type
          |  |  +---w interval?               cfm-types:cfm-interval-type
          |  |  +---w lbm-messages?           uint32
          |  |  +---w lbm-priority?           dot1q-types:priority-type
          |  |  +---w lbm-drop-eligible?      boolean
          |  |  +---w lbm-data-tlv?           cfm-types:lbm-data-tlv-type
          |  +--ro output
          |     +--ro lbm-result-ok?    boolean
          |     +--ro lbm-seq-number?   cfm-types:seq-number-type
          +---x transmit-linktrace
          |  +---w input
          |  |  +---w interval?                 cfm-types:cfm-interval-type
          |  |  +---w ltm-target-is-mep-id?     boolean
          |  |  +---w ltm-target-mac-address?   ieee:mac-address
          |  |  +---w ltm-target-mep-id?        cfm-types:mep-id-or-zero-type
          |  |  +---w ltm-priority?             dot1q-types:priority-type
          |  |  +---w ltm-drop-eligible?        boolean
          |  |  +---w ltm-ttl?                  uint32
          |  |  +---w ltm-flags?                cfm-types:mep-tx-ltm-flags-type
          |  +--ro output
          |     +--ro ltm-result-ok?           boolean
          |     +--ro ltm-seq-number?          cfm-types:seq-number-type
          |     +--ro ltm-egress-identifier?   string
          +--rw loopback-reply* [lbr-seq-number lbr-receive-order]
          |  +--rw lbr-seq-number       cfm-types:seq-number-type
          |  +--rw lbr-receive-order    uint32
          |  +--ro result-ok?           boolean
          +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
             +--rw ltr-seq-number                   cfm-types:seq-number-type
             +--rw ltr-receive-order                uint32
             +--ro ltr-ttl?                         uint32
             +--ro ltr-forwarded?                   boolean
             +--ro ltr-terminal-mep?                boolean
             +--ro ltr-last-egress-identifier?      string
             +--ro ltr-next-egress-identifier?      string
             +--ro ltr-relay?                       cfm-types:relay-action-field-value
             +--ro ltr-chassis-id-subtype?          cfm-types:lldp-chassis-id-subtype
             +--ro ltr-chassis-id?                  cfm-types:lldp-chassis-id
             +--ro ltr-man-address-domain?          cfm-types:transport-service-domain
             +--ro ltr-man-address?                 cfm-types:transport-service-address
             +--ro ltr-ingress?                     cfm-types:ingress-action-field-value
             +--ro ltr-ingress-mac?                 ieee:mac-address
             +--ro ltr-ingress-port-id-subtype?     cfm-types:lldp-port-id-subtype
             +--ro ltr-egress?                      cfm-types:egress-action-field-value
             +--ro ltr-egress-mac?                  ieee:mac-address
             +--ro ltr-egress-port-id-subtype?      cfm-types:lldp-port-id-subtype
             +--ro ltr-egress-port-id?              cfm-types:lldp-port-id
             +--ro ltr-organization-specific-tlv?   string
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm-mip.yang**
Pyang Validation
ieee802-dot1q-cfm-mip.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-mip
  augment /dot1q-cfm:cfm:
    +--rw mips
       +--rw mip* [mip-id]
          +--rw mip-id           cfm-types:name-key-type
          +--rw md-level?        cfm-types:md-level-type
          +--rw id-permission?   cfm-types:sender-id-permission-type
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm-types.yang**
Pyang Validation
ieee802-dot1q-cfm-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

ieee802-dot1q-cfm-bridge.yang
Pyang Validation
ieee802-dot1q-cfm-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-bridge
  augment /dot1q-cfm:cfm:
    +--rw cfm-stacks
    |  +--rw cfm-stack* [port md-level direction]
    |     +--rw port                 port-ref
    |     +--rw md-level             cfm-types:md-level-type
    |     +--rw direction            cfm-types:mp-direction-type
    |     +--ro service-id
    |     |  +--ro (service-id)?
    |     |     +--:(none)
    |     |     |  +--ro zero?         uint32
    |     |     +--:(vid)
    |     |     |  +--ro vid*          dot1q-types:vlanid
    |     |     +--:(isid)
    |     |     |  +--ro isid?         uint32
    |     |     +--:(tesid)
    |     |     |  +--ro tesid?        uint32
    |     |     +--:(segid)
    |     |     |  +--ro segid?        uint32
    |     |     +--:(path-tesid)
    |     |     |  +--ro path-tesid?   uint32
    |     |     +--:(group-isid)
    |     |        +--ro group-isid?   uint32
    |     +--ro maintenance-group?   -> /dot1q-cfm:cfm/maintenance-group-list/maintenance-group
    |     +--ro md-id?               cfm-types:name-key-type
    |     +--ro ma-id?               -> /dot1q-cfm:cfm/maintenance-domains/maintenance-domain[dot1q-cfm:md-id = current()/../md-id]/maintenance-association/ma-id
    |     +--ro mep-id?              -> /dot1q-cfm:cfm/maintenance-group-list[dot1q-cfm:maintenance-group = current()/../maintenance-group]/mep/mep-id
    |     +--ro mac-address?         ieee:mac-address
    +--rw default-md-levels
    |  +--rw default-md-level* [bridge-id component-id]
    |     +--rw bridge-id                 bridge-ref
    |     +--rw component-id              -> /dot1q:bridges/bridge[dot1q:name = current()/../bridge-id]/component/name
    |     +--rw primary-service-id
    |     |  +--rw (service-id)?
    |     |     +--:(none)
    |     |     |  +--rw zero?         uint32
    |     |     +--:(vid)
    |     |     |  +--rw vid*          dot1q-types:vlanid
    |     |     +--:(isid)
    |     |     |  +--rw isid?         uint32
    |     |     +--:(tesid)
    |     |     |  +--rw tesid?        uint32
    |     |     +--:(segid)
    |     |     |  +--rw segid?        uint32
    |     |     +--:(path-tesid)
    |     |     |  +--rw path-tesid?   uint32
    |     |     +--:(group-isid)
    |     |        +--rw group-isid?   uint32
    |     +--rw associated-service-ids
    |     |  +--rw (service-id)?
    |     |     +--:(none)
    |     |     |  +--rw zero?         uint32
    |     |     +--:(vid)
    |     |     |  +--rw vid*          dot1q-types:vlanid
    |     |     +--:(isid)
    |     |     |  +--rw isid?         uint32
    |     |     +--:(tesid)
    |     |     |  +--rw tesid?        uint32
    |     |     +--:(segid)
    |     |     |  +--rw segid?        uint32
    |     |     +--:(path-tesid)
    |     |     |  +--rw path-tesid?   uint32
    |     |     +--:(group-isid)
    |     |        +--rw group-isid?   uint32
    |     +--ro md-status?                boolean
    |     +--rw md-level?                 cfm-types:md-level-or-none-type
    |     +--rw mhf-creation?             cfm-types:mhf-creation-type
    |     +--rw id-permission?            cfm-types:sender-id-permission-type
    +--rw config-errors
       +--rw config-error* [port]
          +--rw port          port-ref
          +--ro service-id
          |  +--ro (service-id)?
          |     +--:(none)
          |     |  +--ro zero?         uint32
          |     +--:(vid)
          |     |  +--ro vid*          dot1q-types:vlanid
          |     +--:(isid)
          |     |  +--ro isid?         uint32
          |     +--:(tesid)
          |     |  +--ro tesid?        uint32
          |     +--:(segid)
          |     |  +--ro segid?        uint32
          |     +--:(path-tesid)
          |     |  +--ro path-tesid?   uint32
          |     +--:(group-isid)
          |        +--ro group-isid?   uint32
          +--ro error-type?   cfm-types:config-error-type
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-domains/dot1q-cfm:maintenance-domain/dot1q-cfm:maintenance-association:
    +--rw maintenance-association-component* [ma-component-id]
       +--rw ma-component-id      -> /dot1q-cfm:cfm/maintenance-group-list[dot1q-cfm:maintenance-group = current()/../maintenance-group]/component-name
       +--ro maintenance-group?   -> /dot1q-cfm:cfm/maintenance-group-list/maintenance-group
       +--rw (service-id)?
       |  +--:(none)
       |  |  +--rw zero?                uint32
       |  +--:(vid)
       |  |  +--rw vid*                 dot1q-types:vlanid
       |  +--:(isid)
       |  |  +--rw isid?                uint32
       |  +--:(tesid)
       |  |  +--rw tesid?               uint32
       |  +--:(segid)
       |  |  +--rw segid?               uint32
       |  +--:(path-tesid)
       |  |  +--rw path-tesid?          uint32
       |  +--:(group-isid)
       |     +--rw group-isid?          uint32
       +--rw mhf-creation?        cfm-types:mhf-creation-type
       +--rw id-permission?       cfm-types:sender-id-permission-type
  augment /dot1q-cfm:cfm/cfm-mip:mips/cfm-mip:mip:
    +--rw port?         port-ref
    +--rw (service-id)?
       +--:(none)
       |  +--rw zero?         uint32
       +--:(vid)
       |  +--rw vid*          dot1q-types:vlanid
       +--:(isid)
       |  +--rw isid?         uint32
       +--:(tesid)
       |  +--rw tesid?        uint32
       +--:(segid)
       |  +--rw segid?        uint32
       +--:(path-tesid)
       |  +--rw path-tesid?   uint32
       +--:(group-isid)
          +--rw group-isid?   uint32
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list:
    +--rw bridge-id?        bridge-ref
    +--rw component-name?   -> /dot1q:bridges/bridge[dot1q:name = current()/../cfm-bridge:bridge-id]/dot1q:component/name
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list/dot1q-cfm:mep:
    +--rw port?   port-ref
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors