### PR TITLE
Fix TDomain and TAddress YANG for CFM

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-bridge.yang
@@ -158,6 +158,7 @@ module ieee802-dot1q-cfm-bridge {
       Bridge configuration specific attributes.";
     
     container cfm-stacks {
+      config false;
       description 
         "The CFM Stack contains information about the Maintenance
         Points configured on a particular Bridge Port (or
@@ -205,7 +206,6 @@ module ieee802-dot1q-cfm-bridge {
             "12.14.2.1.2c of IEEE Std 802.1Q-2018";     
         }
         container service-id {
-          config false;
           description 
             "A specific VID, I-SID, Traffic Engineering service 
             instance Identifier (TE-SID), or Segment Identifier
@@ -218,14 +218,12 @@ module ieee802-dot1q-cfm-bridge {
             path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list'
               + '/dot1q-cfm:maintenance-group';
           }
-          config false;
           description
             "The maintenance group to which the Maintenance Points
             is associated with.";
         }
         leaf md-id {
           type cfm-types:name-key-type;
-          config false;
           description
             "The Maintenance Domain reference to which the Maintenance
             Points Maintenance Association is associated. If none,
@@ -242,7 +240,6 @@ module ieee802-dot1q-cfm-bridge {
               + '/dot1q-cfm:maintenance-association'
               + '/dot1q-cfm:ma-id';
           }
-          config false;
           description
             "The Maintenance Association reference to which the 
             Maintenance Point is associated. If none, then 0.";
@@ -257,7 +254,6 @@ module ieee802-dot1q-cfm-bridge {
               + '/../maintenance-group]'
               + '/dot1q-cfm:mep/dot1q-cfm:mep-id';
           }
-          config false;
           description
             "The MEP identifier if a MEP is configured. Otherwise is 0.";
           reference
@@ -265,7 +261,6 @@ module ieee802-dot1q-cfm-bridge {
         }
         leaf mac-address {
           type ieee:mac-address;
-          config false;
           description
             "The MAC address of the maintenance point.";
           reference
@@ -399,6 +394,7 @@ module ieee802-dot1q-cfm-bridge {
     } // default-md-levels
     
     container config-errors {
+      config false;
       description
         "The Configuration Error List managed object is a list of
         {identifier, port} pairs configured in error together with
@@ -426,7 +422,6 @@ module ieee802-dot1q-cfm-bridge {
             "12.14.4.1.2b of IEEE Std 802.1Q-2018";
         }
         container service-id {
-          config false;
           description 
             "The Service Selector Identifier of the Service with 
             interfaces in error.";
@@ -436,7 +431,6 @@ module ieee802-dot1q-cfm-bridge {
         }
         leaf error-type {
           type cfm-types:config-error-type;
-          config false;
           description
             "vector of Boolean error conditions from 22.2.4.";
           reference

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-mip.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-mip.yang
@@ -43,7 +43,7 @@ module ieee802-dot1q-cfm-mip {
     
     container mips {
       description
-        "Maintenance Association Intermediate Points";
+        "Maintenance Domain Intermediate Points";
       list mip {
         key "mip-id";
         description
@@ -63,6 +63,19 @@ module ieee802-dot1q-cfm-mip {
             apply.";
           reference
             "12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
+        }
+        leaf mhf-creation {
+          type cfm-types:mhf-creation-type;
+          default "mhf-default";
+          description
+            "A value indicating if the Management entity can create MHFs
+            (MIP Half Function) for this VID at this MD Level. If this
+            object has the value mhf-defer, MHF creation for this VLAN
+            is controlled by md-mhf-creation. The value of this variable
+            is meaningless if the values of md-status is false.";
+          reference
+            "12.14.3.1.3d of IEEE Std 802.1Q-2018";
+          
         }
         leaf id-permission {
           type cfm-types:sender-id-permission-type;

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-types.yang
@@ -5,6 +5,7 @@ module ieee802-dot1q-cfm-types {
   prefix "cfm-types";
   
   import ietf-yang-types { prefix "yang"; }
+  import ietf-inet-types { prefix "inet"; }
 
   organization
     "IEEE 802.1 Working Group";
@@ -274,21 +275,417 @@ module ieee802-dot1q-cfm-types {
    *         ieee802-types.
    * -------------------------------------------------------
    */
- 
-  typedef transport-service-domain {
-    type yang:object-identifier;
-    description
-      "Denotes a kind of transport service";
-    reference
-      "RFC2579 - Textual Conventions for SMIv2";
-  }
   
-  typedef transport-service-address {
-    type string {
-      length "1..255";
-    }
+  grouping management-address-grouping {
     description
-      "Denotes a transport service address";
+      "Defines the Management Address.";
+    reference
+      "21.5.3.5 of IEEE Std 802.1Q-2018";
+  
+    choice management-address-domain {
+      description
+        "Selects the domain of the management address";
+        
+      case udp-ipv4 {
+        description
+          "Represents an IPv4 UDP transport address consisting of an 
+           IPv4 address, and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv4";
+          
+        leaf domain-udp-ipv4 {
+          type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100..1";
+            }
+          default "1.3.6.1.2.1.100.1";
+          description
+            "The domain type transportDomainUdpIpv4 corresponding to
+            OID 1.3.6.1.2.1.100.1";
+        }
+        leaf udp-ipv4-address {
+          type inet:ipv4-address;
+          description
+            "UDP IPv4 address.";
+        }
+        leaf udp-ipv4-port {
+          type inet:port-number;
+            description
+              "UDP IPv4 port.";
+        }
+      }
+      
+      case udp-ipv6 {
+        description
+          "Represents an IPv6 UDP transport address consisting of an 
+           IPv6 address and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv6";
+          
+        leaf domain-udp-ipv6 {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainUdpIpv6";
+        }
+        leaf udp-ipv6-address {
+          type inet:ipv6-address;
+          description
+            "UDP IPv6 address.";
+        }        
+        leaf udp-ipv6-port {
+          type inet:port-number;
+          description
+            "UDP IPv6 port.";
+        }
+      }
+      
+      case udp-ipv4z {
+        description
+          "Represents a UDP transport address consisting of an IPv4 
+           address, a zone index and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv4z";
+          
+        leaf domain-udp-ipv4z {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainUdpIpv4z";
+        }
+        leaf udp-ipv4z-address {
+          type inet:ipv4-address;
+          description
+            "UDP IPv4 address.";
+        }        
+        leaf udp-ipv4z-index {
+          type uint32;
+          description
+            "UDP IPv4 zone index.";
+        }
+        leaf udp-ipv4z-port {
+          type inet:port-number;
+          description
+            "UDP IPv4 port.";
+        }
+      }
+      
+      case udp-ipv6z {
+        description
+          "Represents a UDP transport address consisting of an IPv6 
+           address, a zone index and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv6z";
+          
+        leaf domain-udp-ipv6z {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainUdpIpv6z";
+        }
+        leaf udp-ipv6z-address {
+          type inet:ipv6-address;
+          description
+            "UDP IPv6 zone index.";
+        }        
+        leaf udp-ipv6z-index {
+          type uint32;
+          description
+            "UDP IPv6 zone index.";
+        }
+        leaf udp-ipv6z-port {
+          type inet:port-number;
+          description
+            "UDP IPv6 port.";
+        }
+      }
+      
+      case tcp-ipv4 {
+        description
+          "Represents an IPv4 TCP transport address consisting of an 
+           IPv4 address and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv4";
+          
+        leaf domain-tcp-ipv4 {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainTcpIpv4";
+        }
+        leaf tcp-ipv4-address {
+          type inet:ipv4-address;
+          description
+            "TCP IPv4 address.";
+        }        
+        leaf tcp-ipv4-port {
+          type inet:port-number;
+          description
+            "TCP IPv4 port.";
+        }
+      }
+      
+      case tcp-ipv6 {
+        description
+          "Represents an IPv6 TCP transport address consisting of an 
+           IPv6 address and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv6";
+
+        leaf domain-tcp-ipv6 {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainTcpIpv6";
+        }
+        leaf tcp-ipv6-address {
+          type inet:ipv6-address;
+          description
+            "TCP IPv6 address.";
+        }
+        leaf tcp-ipv6-port {
+          type inet:port-number;
+          description
+            "TCP IPv6 port.";
+        }
+      }
+      
+      case tcp-ipv4z {
+        description
+          "Represents a TCP IPv4 transport address consisting of an 
+           IPv4 address, a zone index and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv4z";
+          
+        leaf domain-tcp-ipv4z {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainTcpIpv4z";
+        }
+        leaf tcp-ipv4z-address {
+          type inet:ipv4-address;
+          description
+            "TCP IPv4 address.";
+        }        
+        leaf tcp-ipv4z-index {
+          type uint32;
+          description
+            "TCP IPv4 zone index.";
+        }
+        leaf tcp-ipv4z-port {
+          type inet:port-number;
+          description
+            "TCP IPv4 port.";
+        }
+      }
+      
+      case tcp-ipv6z {
+        description
+          "Represents a TCP IPv6 transport address consisting of an 
+           IPv6 address, a zone index and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv6z";
+          
+        leaf domain-tcp-ipv6z {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainTcpIpv6z";
+        }
+        leaf tcp-ipv6z-address {
+            type inet:ipv6-address;
+          description
+          "TCP IPv6 address.";
+        }          
+        leaf tcp-ipv6z-index {
+          type uint32;
+          description
+            "TCP IPv6 zone index.";
+        }        
+        leaf tcp-ipv6z-port {
+          type inet:port-number;
+          description
+            "TCP IPv6 port.";
+        }
+      }
+      
+      case sctp-ipv4 {
+        description
+          "Represents an IPv4 SCTP transport address consisting of 
+           an IPv4 address and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv4";
+          
+        leaf domain-sctp-ipv4 {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainSctpIpv4";
+        }
+        leaf sctp-ipv4-address {
+          type inet:ipv4-address;
+          description
+            "SCTP IPv4 address.";
+        }        
+        leaf sctp-ipv4-port {
+          type inet:port-number;
+          description
+            "SCTP IPv4 port.";
+        }
+      } 
+      
+      case sctp-ipv6 {
+        description
+          "Represents an IPv6 SCTP transport address consisting of 
+           an IPv6 address and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv6";
+          
+        leaf domain-sctp-ipv6 {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainSctpIpv6";
+        }
+        leaf sctp-ipv6-address {
+          type inet:ipv6-address;
+          description
+            "SCTP IPv6 address.";
+        }        
+        leaf sctp-ipv6-port {
+          type inet:port-number;
+          description
+            "SCTP IPv6 port.";
+        }
+      }
+      
+      case sctp-ipv4z {
+        description
+          "Represents an SCTP IPv4 transport address consisting of 
+           an IPv4 address, a zone index and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv4z";
+          
+        leaf domain-sctp-ipv4z {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainSctpIpv4z";
+        }
+        leaf sctp-iv4z-address {
+          type inet:ipv4-address;
+          description
+            "SCTP IPv4 address.";
+        }        
+        leaf sctp-ipv4z-index {
+          type uint32;
+          description
+            "SCTP IPv4 zone index.";
+        }        
+        leaf sctp-ipv4z-port {
+          type inet:port-number;
+          description
+            "SCTP IPv4 port.";
+        }
+      }
+      
+      case sctp-ipv6z {
+        description
+          "Represents an SCTP IPv6 transport address consisting of 
+           an IPv6 address, a zone index and a port number.";
+        reference
+          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv6z";
+          
+        leaf domain-sctp-ipv6z {
+          type yang:object-identifier-128;
+          description
+            "The domain type transportDomainSctpIpv6z";
+        }
+        leaf sctp-ipv6z-address {
+          type inet:ipv6-address;
+          description
+            "SCTP IPv6 address.";
+        }        
+        leaf sctp-ipv6z-index {
+          type uint32;
+          description
+            "SCTP IPv6 zone index.";
+        }        
+        leaf sctp-ipv6z-port {
+          type inet:port-number;
+          description
+            "SCTP IPv6 port.";
+        }
+      }
+      
+      case local {
+        leaf domain-local {
+          type yang:object-identifier-128;
+          description
+            "The domain type";
+        }
+        leaf local-address {
+          type string {
+            length '1..255';
+          }
+          description
+            "Represents a POSIX Local IPC transport address.";
+        }
+      }
+      
+      case udp-dns {
+        leaf domain-udp-dns {
+          type yang:object-identifier-128;
+          description
+            "The domain type";
+        }
+        leaf udp-dns-address {
+          type string {
+            length "1..255";
+          }
+          description
+            "The UDP transport domain using fully qualified domain 
+             names. Represents a DNS domain name followed by a colon 
+             ':' (ASCII character 0x3A) and a port number in ASCII. 
+             The name SHOULD be fully qualified whenever possible.";
+          reference
+            "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpDns";
+        }
+      }
+      
+      case tcp-dns {
+        leaf domain-tcp-dns {
+          type yang:object-identifier-128;
+          description
+            "The domain type";
+        }
+        leaf tcp-dns-address {
+          type string {
+            length "1..255";
+          }
+          description
+            "The TCP transport domain using fully qualified domain 
+             names. Represents a DNS domain name followed by a colon 
+             ':' (ASCII character 0x3A) and a port number in ASCII. 
+             The name SHOULD be fully qualified whenever possible.";
+          reference
+            "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpDns";
+        }
+      }
+      
+      case sctp-dns {
+        leaf domain-sctp-dns {
+          type yang:object-identifier-128;
+          description
+            "The domain type";
+        }
+        leaf sctp-dns-address {
+          type string {
+            length "1..255";
+          }
+          description
+            "The SCTP transport domain using fully qualified domain 
+             names. Represents a DNS domain name followed by a colon 
+             ':' (ASCII character 0x3A) and a port number in ASCII. 
+             The name SHOULD be fully qualified whenever possible.";
+          reference
+            "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpDns";
+        }
+      }
+    }
   }
 
   /* ------------------------------------------------------

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -641,37 +641,12 @@ module ieee802-dot1q-cfm {
             reference
               "12.14.7.6.3h, 21.5.3.3 of IEEE Std 802.1Q-2018";
           }
-          leaf man-address-domain {
-            type cfm-types:transport-service-domain;
-            config false;
+          container transport-service-domain {
             description
-              "The transport-service-domain that identifies the
-              type and format of the related mep-db-man-address
-              object, used to access the YANG agent of the system
-              transmitting the CCM. Received in the CCM Sender ID
-              TLV from that system.
-              
-              The value zeroDotZero (from RFC2578) indicates no
-              management address was present in the LTR, in which
-              case the related mep-db-man-address object MUST
-              have a zero-length OCTET STRING as a value.";
+              "The transport management domain and address.";
+            uses cfm-types:management-address-grouping;
             reference
-              "12.14.7.6.3h, 21.5.3.5,
-              21.6.7 of IEEE Std 802.1Q-2018";
-          }
-          leaf man-address {
-            type cfm-types:transport-service-address;
-            config false;
-            description
-              "The transport-service-address that can be used to 
-              access the YANG agent of the system transmitting
-              the CCM, received in the CCM Sender ID TLV from
-              that system. If the related 
-              mep-db-man-address-domain object contains the 
-              value zeroDotZero, this object mep-db-man-address
-              MUST have a zero-length OCTET STRING as a value.";
-            reference
-              "12.14.7.6.3h, 21.5.3.7,
+              "12.14.7.6.3h, 21.5.3.5, 21.5.3.7,
               21.6.7 of IEEE Std 802.1Q-2018";
           }
           leaf rmep-is-active {
@@ -1493,37 +1468,16 @@ module ieee802-dot1q-cfm {
             ltr-chassis-id-subtype object.";
           reference
             "12.14.7.5.3i, 21.5.3.2 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-man-address-domain {
-          type cfm-types:transport-service-domain;
+        }
+        container ltr-transport-service-domain {
           config false;
           description
-            "The transport-service-domain that identifies the
-            type and format of the related mep-db-man-address
-            object, used to access the YANG agent of the system
-            transmitting the LTR. Received in the LTR Sender ID
-            TLV from that system.";
+            "The transport management domain and address.";
+          uses cfm-types:management-address-grouping;
           reference
-            "12.14.7.5.3j, 21.5.3.5,
+            "12.14.7.5.3j, 21.5.3.5, 21.5.3.7,
             21.9.6 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-man-address {
-          type cfm-types:transport-service-address;
-          config false;
-          description
-            "The transport-service-address that can be used to
-            access the YANG agent of the system transmitting
-            the CCM, received in the CCM Sender ID TLV from
-            that system.
-            
-            If the related object ltr-man-address-domain
-            contains the value zeroDotZero, this object
-            ltr-man-address MUST have a zero-length OCTET 
-            STRING as a value.";
-          reference
-            "12.14.7.5.3j, 21.5.3.7,
-            21.9.6 of IEEE Std 802.1Q-2018";
-        }           
+        }
         leaf ltr-ingress {
           type cfm-types:ingress-action-field-value;
           config false;


### PR DESCRIPTION
Clean PYANG

**ieee802-dot1q-types.yang**
Pyang Validation
ieee802-dot1q-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm.yang**
Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw maintenance-domains
       |  +--rw maintenance-domain* [md-id]
       |     +--rw md-id                        cfm-types:name-key-type
       |     +--rw (md-name)?
       |     |  +--:(ieee-reserved-0)
       |     |  |  +--rw name?                        string
       |     |  +--:(none)
       |     |  |  +--rw none?                        empty
       |     |  +--:(dns-like-name)
       |     |  |  +--rw dns-like-name?               string
       |     |  +--:(mac-address-and-uint)
       |     |  |  +--rw mac-address-and-uint-type
       |     |  |     +--rw address?   ieee:mac-address
       |     |  |     +--rw int?       uint16
       |     |  +--:(char-string)
       |     |     +--rw char-string?                 string
       |     +--rw md-level?                    cfm-types:md-level-type
       |     +--rw mhf-creation?                cfm-types:mhf-creation-type
       |     +--rw id-permission?               cfm-types:sender-id-permission-type
       |     +--rw fault-alarm-address?         cfm-types:fault-alarm-address-type
       |     +--rw maintenance-association* [ma-id]
       |        +--rw ma-id                               cfm-types:name-key-type
       |        +--rw (ma-name)?
       |        |  +--:(ieee-reserved-0)
       |        |  |  +--rw name?                               string
       |        |  +--:(primary-vid)
       |        |  |  +--rw primary-vid?                        dot1q-types:vlanid
       |        |  +--:(char-string)
       |        |  |  +--rw char-string?                        string
       |        |  +--:(unsigned-int16)
       |        |  |  +--rw unsigned-int16?                     uint16
       |        |  +--:(rfc2865-vpn-id)
       |        |  |  +--rw rfc2865-vpn-id?                     string
       |        |  +--:(icc-format)
       |        |     +--rw icc-format?                         string
       |        +--rw ccm-interval?                       cfm-types:cfm-interval-type
       |        +--rw fault-alarm-address?                cfm-types:fault-alarm-address-type
       |        +--rw maintenance-association-mep-list* [mep-id]
       |           +--rw mep-id    cfm-types:mep-id-type
       +--rw maintenance-group-list* [maintenance-group]
       |  +--rw maintenance-group    maintenance-group-type
       |  +--rw md-name              -> /cfm/maintenance-domains/maintenance-domain/md-id
       |  +--rw ma-name              -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../md-name]/maintenance-association/ma-id
       |  +--rw mep* [mep-id]
       |     +--rw mep-id                     -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../../md-name]/maintenance-association[ma-id = current()/../../ma-name]/maintenance-association-mep-list/mep-id
       |     +--rw direction?                 cfm-types:mp-direction-type
       |     +--rw primary-vid?               uint32
       |     +--rw admin-state?               boolean
       |     +--ro fng-state?                 cfm-types:fng-state-type
       |     +--rw ccm-ltm-priority?          dot1q-types:priority-type
       |     +--ro mac-address?               ieee:mac-address
       |     +--rw fault-alarm-address?       cfm-types:fault-alarm-address-type
       |     +--rw lowest-priority-defect?    cfm-types:lowest-alarm-priority-type
       |     +--rw fng-alarm-time?            yang:zero-based-counter32
       |     +--rw fng-reset-time?            yang:zero-based-counter32
       |     +--ro highest-priority-defect?   cfm-types:highest-defect-priority-type
       |     +--ro defects?                   cfm-types:mep-defects-type
       |     +--ro error-ccm-last-failure?    string
       |     +--ro xcon-ccm-last-failure?     string
       |     +--rw mep-db* [rmep-id]
       |     |  +--rw rmep-id                     -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../../../md-name]/maintenance-association[ma-id = current()/../../../ma-name]/maintenance-association-mep-list/mep-id
       |     |  +--ro rmep-state?                 cfm-types:remote-mep-state-type
       |     |  +--ro rmep-failed-ok-time?        yang:zero-based-counter32
       |     |  +--ro mac-address?                ieee:mac-address
       |     |  +--ro rdi?                        boolean
       |     |  +--ro port-status-tlv?            cfm-types:port-status-tlv-value
       |     |  +--ro interface-status-tlv?       cfm-types:interface-status-tlv-value
       |     |  +--ro chassis-id-subtype?         cfm-types:lldp-chassis-id-subtype
       |     |  +--ro chassis-id?                 cfm-types:lldp-chassis-id
       |     |  +--rw transport-service-domain
       |     |  |  +--rw (management-address-domain)?
       |     |  |     +--:(udp-ipv4)
       |     |  |     |  +--rw domain-udp-ipv4?      yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv4-address?     inet:ipv4-address
       |     |  |     |  +--rw udp-ipv4-port?        inet:port-number
       |     |  |     +--:(udp-ipv6)
       |     |  |     |  +--rw domain-udp-ipv6?      yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv6-address?     inet:ipv6-address
       |     |  |     |  +--rw udp-ipv6-port?        inet:port-number
       |     |  |     +--:(udp-ipv4z)
       |     |  |     |  +--rw domain-udp-ipv4z?     yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw udp-ipv4z-index?      uint32
       |     |  |     |  +--rw udp-ipv4z-port?       inet:port-number
       |     |  |     +--:(udp-ipv6z)
       |     |  |     |  +--rw domain-udp-ipv6z?     yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv6z-address?    inet:ipv6-address
       |     |  |     |  +--rw udp-ipv6z-index?      uint32
       |     |  |     |  +--rw udp-ipv6z-port?       inet:port-number
       |     |  |     +--:(tcp-ipv4)
       |     |  |     |  +--rw domain-tcp-ipv4?      yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv4-address?     inet:ipv4-address
       |     |  |     |  +--rw tcp-ipv4-port?        inet:port-number
       |     |  |     +--:(tcp-ipv6)
       |     |  |     |  +--rw domain-tcp-ipv6?      yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv6-address?     inet:ipv6-address
       |     |  |     |  +--rw tcp-ipv6-port?        inet:port-number
       |     |  |     +--:(tcp-ipv4z)
       |     |  |     |  +--rw domain-tcp-ipv4z?     yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw tcp-ipv4z-index?      uint32
       |     |  |     |  +--rw tcp-ipv4z-port?       inet:port-number
       |     |  |     +--:(tcp-ipv6z)
       |     |  |     |  +--rw domain-tcp-ipv6z?     yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv6z-address?    inet:ipv6-address
       |     |  |     |  +--rw tcp-ipv6z-index?      uint32
       |     |  |     |  +--rw tcp-ipv6z-port?       inet:port-number
       |     |  |     +--:(sctp-ipv4)
       |     |  |     |  +--rw domain-sctp-ipv4?     yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv4-address?    inet:ipv4-address
       |     |  |     |  +--rw sctp-ipv4-port?       inet:port-number
       |     |  |     +--:(sctp-ipv6)
       |     |  |     |  +--rw domain-sctp-ipv6?     yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv6-address?    inet:ipv6-address
       |     |  |     |  +--rw sctp-ipv6-port?       inet:port-number
       |     |  |     +--:(sctp-ipv4z)
       |     |  |     |  +--rw domain-sctp-ipv4z?    yang:object-identifier-128
       |     |  |     |  +--rw sctp-iv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw sctp-ipv4z-index?     uint32
       |     |  |     |  +--rw sctp-ipv4z-port?      inet:port-number
       |     |  |     +--:(sctp-ipv6z)
       |     |  |     |  +--rw domain-sctp-ipv6z?    yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv6z-address?   inet:ipv6-address
       |     |  |     |  +--rw sctp-ipv6z-index?     uint32
       |     |  |     |  +--rw sctp-ipv6z-port?      inet:port-number
       |     |  |     +--:(local)
       |     |  |     |  +--rw domain-local?         yang:object-identifier-128
       |     |  |     |  +--rw local-address?        string
       |     |  |     +--:(udp-dns)
       |     |  |     |  +--rw domain-udp-dns?       yang:object-identifier-128
       |     |  |     |  +--rw udp-dns-address?      string
       |     |  |     +--:(tcp-dns)
       |     |  |     |  +--rw domain-tcp-dns?       yang:object-identifier-128
       |     |  |     |  +--rw tcp-dns-address?      string
       |     |  |     +--:(sctp-dns)
       |     |  |        +--rw domain-sctp-dns?      yang:object-identifier-128
       |     |  |        +--rw sctp-dns-address?     string
       |     |  +--rw rmep-is-active?             boolean
       |     +--rw continuity-check
       |     |  +--rw ccm-enabled?    boolean
       |     |  +--rw priority?       dot1q-types:priority-type
       |     |  +--rw ccm-interval?   cfm-types:cfm-interval-type
       |     +--rw loopback
       |     |  +--rw status?               boolean
       |     |  +--rw interval?             cfm-types:cfm-interval-type
       |     |  +--rw dest-mac-address?     ieee:mac-address
       |     |  +--rw dest-mep-id?          cfm-types:mep-id-or-zero-type
       |     |  +--rw dest-is-mep-id?       boolean
       |     |  +--rw message-count?        uint32
       |     |  +--rw data-tlv?             cfm-types:lbm-data-tlv-type
       |     |  +--rw priority?             dot1q-types:priority-type
       |     |  +--rw vlan-drop-eligible?   boolean
       |     |  +--ro result-ok?            boolean
       |     |  +--ro seq-number?           cfm-types:seq-number-type
       |     |  +--ro next-lbm-trans-id?    cfm-types:seq-number-type
       |     +--rw linktrace
       |     |  +--rw status?               boolean
       |     |  +--rw interval?             cfm-types:cfm-interval-type
       |     |  +--rw priority?             dot1q-types:priority-type
       |     |  +--rw flags?                cfm-types:mep-tx-ltm-flags-type
       |     |  +--rw target-mac-address?   ieee:mac-address
       |     |  +--rw target-mep-id?        cfm-types:mep-id-or-zero-type
       |     |  +--rw target-is-mep-id?     boolean
       |     |  +--rw ttl?                  uint32
       |     |  +--ro result?               boolean
       |     |  +--ro seq-number?           cfm-types:seq-number-type
       |     |  +--ro egress-identifier?    string
       |     |  +--ro next-seq-number?      cfm-types:seq-number-type
       |     +--ro stats
       |     |  +--ro mep-ccm-sequence-errors?   yang:counter64
       |     |  +--ro mep-ccms-sent?             yang:counter64
       |     |  +--ro mep-lbr-in?                yang:counter64
       |     |  +--ro mep-lbr-in-out-of-order?   yang:counter64
       |     |  +--ro mep-lbr-bad-msdu?          yang:counter64
       |     |  +--ro mep-unexpected-ltr-in?     yang:counter64
       |     |  +--ro mep-lbr-out?               yang:counter64
       |     +---n mep-fault-alarm
       |        +---- mep-priority-defect?   -> ../../highest-priority-defect
       +--rw cfm-operation* [maintenance-group mep-id]
          +--rw maintenance-group     -> /cfm/maintenance-group-list/maintenance-group
          +--rw mep-id                -> /cfm/maintenance-group-list[maintenance-group = current()/../maintenance-group]/mep/mep-id
          +---x transmit-loopback
          |  +---w input
          |  |  +---w lbm-dest-is-mep-id?     boolean
          |  |  +---w lbm-dest-mac-address?   ieee:mac-address
          |  |  +---w lbm-dest-mep-id?        cfm-types:mep-id-or-zero-type
          |  |  +---w interval?               cfm-types:cfm-interval-type
          |  |  +---w lbm-messages?           uint32
          |  |  +---w lbm-priority?           dot1q-types:priority-type
          |  |  +---w lbm-drop-eligible?      boolean
          |  |  +---w lbm-data-tlv?           cfm-types:lbm-data-tlv-type
          |  +--ro output
          |     +--ro lbm-result-ok?    boolean
          |     +--ro lbm-seq-number?   cfm-types:seq-number-type
          +---x transmit-linktrace
          |  +---w input
          |  |  +---w interval?                 cfm-types:cfm-interval-type
          |  |  +---w ltm-target-is-mep-id?     boolean
          |  |  +---w ltm-target-mac-address?   ieee:mac-address
          |  |  +---w ltm-target-mep-id?        cfm-types:mep-id-or-zero-type
          |  |  +---w ltm-priority?             dot1q-types:priority-type
          |  |  +---w ltm-drop-eligible?        boolean
          |  |  +---w ltm-ttl?                  uint32
          |  |  +---w ltm-flags?                cfm-types:mep-tx-ltm-flags-type
          |  +--ro output
          |     +--ro ltm-result-ok?           boolean
          |     +--ro ltm-seq-number?          cfm-types:seq-number-type
          |     +--ro ltm-egress-identifier?   string
          +--rw loopback-reply* [lbr-seq-number lbr-receive-order]
          |  +--rw lbr-seq-number       cfm-types:seq-number-type
          |  +--rw lbr-receive-order    uint32
          |  +--ro result-ok?           boolean
          +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
             +--rw ltr-seq-number                   cfm-types:seq-number-type
             +--rw ltr-receive-order                uint32
             +--ro ltr-ttl?                         uint32
             +--ro ltr-forwarded?                   boolean
             +--ro ltr-terminal-mep?                boolean
             +--ro ltr-last-egress-identifier?      string
             +--ro ltr-next-egress-identifier?      string
             +--ro ltr-relay?                       cfm-types:relay-action-field-value
             +--ro ltr-chassis-id-subtype?          cfm-types:lldp-chassis-id-subtype
             +--ro ltr-chassis-id?                  cfm-types:lldp-chassis-id
             +--ro ltr-transport-service-domain
             |  +--ro (management-address-domain)?
             |     +--:(udp-ipv4)
             |     |  +--ro domain-udp-ipv4?      yang:object-identifier-128
             |     |  +--ro udp-ipv4-address?     inet:ipv4-address
             |     |  +--ro udp-ipv4-port?        inet:port-number
             |     +--:(udp-ipv6)
             |     |  +--ro domain-udp-ipv6?      yang:object-identifier-128
             |     |  +--ro udp-ipv6-address?     inet:ipv6-address
             |     |  +--ro udp-ipv6-port?        inet:port-number
             |     +--:(udp-ipv4z)
             |     |  +--ro domain-udp-ipv4z?     yang:object-identifier-128
             |     |  +--ro udp-ipv4z-address?    inet:ipv4-address
             |     |  +--ro udp-ipv4z-index?      uint32
             |     |  +--ro udp-ipv4z-port?       inet:port-number
             |     +--:(udp-ipv6z)
             |     |  +--ro domain-udp-ipv6z?     yang:object-identifier-128
             |     |  +--ro udp-ipv6z-address?    inet:ipv6-address
             |     |  +--ro udp-ipv6z-index?      uint32
             |     |  +--ro udp-ipv6z-port?       inet:port-number
             |     +--:(tcp-ipv4)
             |     |  +--ro domain-tcp-ipv4?      yang:object-identifier-128
             |     |  +--ro tcp-ipv4-address?     inet:ipv4-address
             |     |  +--ro tcp-ipv4-port?        inet:port-number
             |     +--:(tcp-ipv6)
             |     |  +--ro domain-tcp-ipv6?      yang:object-identifier-128
             |     |  +--ro tcp-ipv6-address?     inet:ipv6-address
             |     |  +--ro tcp-ipv6-port?        inet:port-number
             |     +--:(tcp-ipv4z)
             |     |  +--ro domain-tcp-ipv4z?     yang:object-identifier-128
             |     |  +--ro tcp-ipv4z-address?    inet:ipv4-address
             |     |  +--ro tcp-ipv4z-index?      uint32
             |     |  +--ro tcp-ipv4z-port?       inet:port-number
             |     +--:(tcp-ipv6z)
             |     |  +--ro domain-tcp-ipv6z?     yang:object-identifier-128
             |     |  +--ro tcp-ipv6z-address?    inet:ipv6-address
             |     |  +--ro tcp-ipv6z-index?      uint32
             |     |  +--ro tcp-ipv6z-port?       inet:port-number
             |     +--:(sctp-ipv4)
             |     |  +--ro domain-sctp-ipv4?     yang:object-identifier-128
             |     |  +--ro sctp-ipv4-address?    inet:ipv4-address
             |     |  +--ro sctp-ipv4-port?       inet:port-number
             |     +--:(sctp-ipv6)
             |     |  +--ro domain-sctp-ipv6?     yang:object-identifier-128
             |     |  +--ro sctp-ipv6-address?    inet:ipv6-address
             |     |  +--ro sctp-ipv6-port?       inet:port-number
             |     +--:(sctp-ipv4z)
             |     |  +--ro domain-sctp-ipv4z?    yang:object-identifier-128
             |     |  +--ro sctp-iv4z-address?    inet:ipv4-address
             |     |  +--ro sctp-ipv4z-index?     uint32
             |     |  +--ro sctp-ipv4z-port?      inet:port-number
             |     +--:(sctp-ipv6z)
             |     |  +--ro domain-sctp-ipv6z?    yang:object-identifier-128
             |     |  +--ro sctp-ipv6z-address?   inet:ipv6-address
             |     |  +--ro sctp-ipv6z-index?     uint32
             |     |  +--ro sctp-ipv6z-port?      inet:port-number
             |     +--:(local)
             |     |  +--ro domain-local?         yang:object-identifier-128
             |     |  +--ro local-address?        string
             |     +--:(udp-dns)
             |     |  +--ro domain-udp-dns?       yang:object-identifier-128
             |     |  +--ro udp-dns-address?      string
             |     +--:(tcp-dns)
             |     |  +--ro domain-tcp-dns?       yang:object-identifier-128
             |     |  +--ro tcp-dns-address?      string
             |     +--:(sctp-dns)
             |        +--ro domain-sctp-dns?      yang:object-identifier-128
             |        +--ro sctp-dns-address?     string
             +--ro ltr-ingress?                     cfm-types:ingress-action-field-value
             +--ro ltr-ingress-mac?                 ieee:mac-address
             +--ro ltr-ingress-port-id-subtype?     cfm-types:lldp-port-id-subtype
             +--ro ltr-egress?                      cfm-types:egress-action-field-value
             +--ro ltr-egress-mac?                  ieee:mac-address
             +--ro ltr-egress-port-id-subtype?      cfm-types:lldp-port-id-subtype
             +--ro ltr-egress-port-id?              cfm-types:lldp-port-id
             +--ro ltr-organization-specific-tlv?   string
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm-mip.yang**
Pyang Validation
ieee802-dot1q-cfm-mip.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-mip
  augment /dot1q-cfm:cfm:
    +--rw mips
       +--rw mip* [mip-id]
          +--rw mip-id           cfm-types:name-key-type
          +--rw md-level?        cfm-types:md-level-type
          +--rw mhf-creation?    cfm-types:mhf-creation-type
          +--rw id-permission?   cfm-types:sender-id-permission-type
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm-types.yang**
Pyang Validation
ieee802-dot1q-cfm-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm-bridge.yang**
Pyang Validation
ieee802-dot1q-cfm-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-bridge
  augment /dot1q-cfm:cfm:
    +--ro cfm-stacks
    |  +--ro cfm-stack* [port md-level direction]
    |     +--ro port                 port-ref
    |     +--ro md-level             cfm-types:md-level-type
    |     +--ro direction            cfm-types:mp-direction-type
    |     +--ro service-id
    |     |  +--ro (service-id)?
    |     |     +--:(none)
    |     |     |  +--ro zero?         uint32
    |     |     +--:(vid)
    |     |     |  +--ro vid*          dot1q-types:vlanid
    |     |     +--:(isid)
    |     |     |  +--ro isid?         uint32
    |     |     +--:(tesid)
    |     |     |  +--ro tesid?        uint32
    |     |     +--:(segid)
    |     |     |  +--ro segid?        uint32
    |     |     +--:(path-tesid)
    |     |     |  +--ro path-tesid?   uint32
    |     |     +--:(group-isid)
    |     |        +--ro group-isid?   uint32
    |     +--ro maintenance-group?   -> /dot1q-cfm:cfm/maintenance-group-list/maintenance-group
    |     +--ro md-id?               cfm-types:name-key-type
    |     +--ro ma-id?               -> /dot1q-cfm:cfm/maintenance-domains/maintenance-domain[dot1q-cfm:md-id = current()/../md-id]/maintenance-association/ma-id
    |     +--ro mep-id?              -> /dot1q-cfm:cfm/maintenance-group-list[dot1q-cfm:maintenance-group = current()/../maintenance-group]/mep/mep-id
    |     +--ro mac-address?         ieee:mac-address
    +--rw default-md-levels
    |  +--rw default-md-level* [bridge-id component-id]
    |     +--rw bridge-id                 bridge-ref
    |     +--rw component-id              -> /dot1q:bridges/bridge[dot1q:name = current()/../bridge-id]/component/name
    |     +--rw primary-service-id
    |     |  +--rw (service-id)?
    |     |     +--:(none)
    |     |     |  +--rw zero?         uint32
    |     |     +--:(vid)
    |     |     |  +--rw vid*          dot1q-types:vlanid
    |     |     +--:(isid)
    |     |     |  +--rw isid?         uint32
    |     |     +--:(tesid)
    |     |     |  +--rw tesid?        uint32
    |     |     +--:(segid)
    |     |     |  +--rw segid?        uint32
    |     |     +--:(path-tesid)
    |     |     |  +--rw path-tesid?   uint32
    |     |     +--:(group-isid)
    |     |        +--rw group-isid?   uint32
    |     +--rw associated-service-ids
    |     |  +--rw (service-id)?
    |     |     +--:(none)
    |     |     |  +--rw zero?         uint32
    |     |     +--:(vid)
    |     |     |  +--rw vid*          dot1q-types:vlanid
    |     |     +--:(isid)
    |     |     |  +--rw isid?         uint32
    |     |     +--:(tesid)
    |     |     |  +--rw tesid?        uint32
    |     |     +--:(segid)
    |     |     |  +--rw segid?        uint32
    |     |     +--:(path-tesid)
    |     |     |  +--rw path-tesid?   uint32
    |     |     +--:(group-isid)
    |     |        +--rw group-isid?   uint32
    |     +--ro md-status?                boolean
    |     +--rw md-level?                 cfm-types:md-level-or-none-type
    |     +--rw mhf-creation?             cfm-types:mhf-creation-type
    |     +--rw id-permission?            cfm-types:sender-id-permission-type
    +--ro config-errors
       +--ro config-error* [port]
          +--ro port          port-ref
          +--ro service-id
          |  +--ro (service-id)?
          |     +--:(none)
          |     |  +--ro zero?         uint32
          |     +--:(vid)
          |     |  +--ro vid*          dot1q-types:vlanid
          |     +--:(isid)
          |     |  +--ro isid?         uint32
          |     +--:(tesid)
          |     |  +--ro tesid?        uint32
          |     +--:(segid)
          |     |  +--ro segid?        uint32
          |     +--:(path-tesid)
          |     |  +--ro path-tesid?   uint32
          |     +--:(group-isid)
          |        +--ro group-isid?   uint32
          +--ro error-type?   cfm-types:config-error-type
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-domains/dot1q-cfm:maintenance-domain/dot1q-cfm:maintenance-association:
    +--rw maintenance-association-component* [ma-component-id]
       +--rw ma-component-id      -> /dot1q-cfm:cfm/maintenance-group-list[dot1q-cfm:maintenance-group = current()/../maintenance-group]/component-name
       +--ro maintenance-group?   -> /dot1q-cfm:cfm/maintenance-group-list/maintenance-group
       +--rw (service-id)?
       |  +--:(none)
       |  |  +--rw zero?                uint32
       |  +--:(vid)
       |  |  +--rw vid*                 dot1q-types:vlanid
       |  +--:(isid)
       |  |  +--rw isid?                uint32
       |  +--:(tesid)
       |  |  +--rw tesid?               uint32
       |  +--:(segid)
       |  |  +--rw segid?               uint32
       |  +--:(path-tesid)
       |  |  +--rw path-tesid?          uint32
       |  +--:(group-isid)
       |     +--rw group-isid?          uint32
       +--rw mhf-creation?        cfm-types:mhf-creation-type
       +--rw id-permission?       cfm-types:sender-id-permission-type
  augment /dot1q-cfm:cfm/cfm-mip:mips/cfm-mip:mip:
    +--rw port?         port-ref
    +--rw (service-id)?
       +--:(none)
       |  +--rw zero?         uint32
       +--:(vid)
       |  +--rw vid*          dot1q-types:vlanid
       +--:(isid)
       |  +--rw isid?         uint32
       +--:(tesid)
       |  +--rw tesid?        uint32
       +--:(segid)
       |  +--rw segid?        uint32
       +--:(path-tesid)
       |  +--rw path-tesid?   uint32
       +--:(group-isid)
          +--rw group-isid?   uint32
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list:
    +--rw bridge-id?        bridge-ref
    +--rw component-name?   -> /dot1q:bridges/bridge[dot1q:name = current()/../cfm-bridge:bridge-id]/dot1q:component/name
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group-list/dot1q-cfm:mep:
    +--rw port?   port-ref
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors