### PR TITLE
Restructure CFM protocol session data attributes

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -214,12 +214,12 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv4";
           
-        leaf domain-udp-ipv4 {
+        leaf udp-ipv4-domain {
           type yang:object-identifier-128;
           must '. = "1.3.6.1.2.1.100.1"' {
             description
               "The value of the OID for this domain must be
-              1.3.6.1.2.1.100..1";
+              1.3.6.1.2.1.100.1";
             }
           default "1.3.6.1.2.1.100.1";
           description
@@ -245,8 +245,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv6";
           
-        leaf domain-udp-ipv6 {
+        leaf udp-ipv6-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.2"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.2";
+            }
+          default "1.3.6.1.2.1.100.1.2";
           description
             "The domain type transportDomainUdpIpv6";
         }
@@ -269,8 +275,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv4z";
           
-        leaf domain-udp-ipv4z {
+        leaf udp-ipv4z-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.3"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.3";
+            }
+          default "1.3.6.1.2.1.100.1.3";
           description
             "The domain type transportDomainUdpIpv4z";
         }
@@ -298,8 +310,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv6z";
           
-        leaf domain-udp-ipv6z {
+        leaf udp-ipv6z-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.4"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.4";
+            }
+          default "1.3.6.1.2.1.100.1.4";
           description
             "The domain type transportDomainUdpIpv6z";
         }
@@ -327,8 +345,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv4";
           
-        leaf domain-tcp-ipv4 {
+        leaf tcp-ipv4-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.5"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.5";
+            }
+          default "1.3.6.1.2.1.100.1.5";
           description
             "The domain type transportDomainTcpIpv4";
         }
@@ -351,8 +375,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv6";
 
-        leaf domain-tcp-ipv6 {
+        leaf tcp-ipv6-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.6"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.6";
+            }
+          default "1.3.6.1.2.1.100.1.6";
           description
             "The domain type transportDomainTcpIpv6";
         }
@@ -375,8 +405,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv4z";
           
-        leaf domain-tcp-ipv4z {
+        leaf tcp-ipv4z-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.7"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.7";
+            }
+          default "1.3.6.1.2.1.100.1.7";
           description
             "The domain type transportDomainTcpIpv4z";
         }
@@ -404,8 +440,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv6z";
           
-        leaf domain-tcp-ipv6z {
+        leaf tcp-ipv6z-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.8"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.8";
+            }
+          default "1.3.6.1.2.1.100.1.8";
           description
             "The domain type transportDomainTcpIpv6z";
         }
@@ -433,8 +475,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv4";
           
-        leaf domain-sctp-ipv4 {
+        leaf sctp-ipv4-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.9"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.9";
+            }
+          default "1.3.6.1.2.1.100.1.9";
           description
             "The domain type transportDomainSctpIpv4";
         }
@@ -457,8 +505,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv6";
           
-        leaf domain-sctp-ipv6 {
+        leaf sctp-ipv6-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.10"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.10";
+            }
+          default "1.3.6.1.2.1.100.1.10";
           description
             "The domain type transportDomainSctpIpv6";
         }
@@ -481,8 +535,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv4z";
           
-        leaf domain-sctp-ipv4z {
+        leaf sctp-ipv4z-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.11"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.11";
+            }
+          default "1.3.6.1.2.1.100.1.11";
           description
             "The domain type transportDomainSctpIpv4z";
         }
@@ -510,8 +570,14 @@ module ieee802-dot1q-cfm {
         reference
           "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv6z";
           
-        leaf domain-sctp-ipv6z {
+        leaf sctp-ipv6z-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.12"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.12";
+            }
+          default "1.3.6.1.2.1.100.1.12";
           description
             "The domain type transportDomainSctpIpv6z";
         }
@@ -533,8 +599,14 @@ module ieee802-dot1q-cfm {
       }
       
       case local {
-        leaf domain-local {
+        leaf local-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.13"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.13";
+            }
+          default "1.3.6.1.2.1.100.1.13";
           description
             "The domain type";
         }
@@ -548,8 +620,14 @@ module ieee802-dot1q-cfm {
       }
       
       case udp-dns {
-        leaf domain-udp-dns {
+        leaf udp-dns-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.14"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.14";
+            }
+          default "1.3.6.1.2.1.100.1.14";
           description
             "The domain type";
         }
@@ -568,8 +646,14 @@ module ieee802-dot1q-cfm {
       }
       
       case tcp-dns {
-        leaf domain-tcp-dns {
+        leaf tcp-dns-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.15"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.15";
+            }
+          default "1.3.6.1.2.1.100.1.15";
           description
             "The domain type";
         }
@@ -588,8 +672,14 @@ module ieee802-dot1q-cfm {
       }
       
       case sctp-dns {
-        leaf domain-sctp-dns {
+        leaf sctp-dns-domain {
           type yang:object-identifier-128;
+          must '. = "1.3.6.1.2.1.100.1.16"' {
+            description
+              "The value of the OID for this domain must be
+              1.3.6.1.2.1.100.1.16";
+            }
+          default "1.3.6.1.2.1.100.1.16";
           description
             "The domain type";
         }
@@ -744,8 +834,8 @@ module ieee802-dot1q-cfm {
       key "maintenance-group";
       description
         "The list of maintenance groups, which are uniquely associated
-        with a maintenance domain, maintenance association, and
-        maintenance association component, for which the MEPs belong.";
+        with a maintenance domain, maintenance association, for which
+        the MEPs belong.";
       leaf maintenance-group {
         type maintenance-group-type;
         description
@@ -1124,283 +1214,6 @@ module ieee802-dot1q-cfm {
               "12.14.6.1.3e of IEEE Std 802.1Q-2018";
           }
         } // continuity-check
-        
-        container loopback {
-          description
-            "Loopback protocol";
-          leaf status {
-            type boolean;
-            default "false";
-            description
-              "A Boolean flag set to TRUE by the MEP Loopback
-              Initiator state machine or YANG network configuration
-              manager to indicate that another LBM is being 
-              transmitted. Reset to FALSE by the MEP Loopback
-              initiator state machine.";
-            reference
-              "20.32, Figure 20-11 of IEEE Std 802.1Q-2018";
-          }
-          leaf interval {
-            type cfm-types:cfm-interval-type;
-            default 1sec;
-            description
-              "The interval between LBM transmissions to be used by all
-              MEPs in the Maintenance Association.";
-          }
-          leaf dest-mac-address {
-            type ieee:mac-address;
-            description
-              "The target MAC Address field to be transmitted.
-              A unicast destination MAC address. This address
-              is used if node mep-transmit-lbm-dest-is-mep-id
-              is FALSE.";
-            reference
-              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-          }
-          leaf dest-mep-id {
-            type cfm-types:mep-id-or-zero-type;
-            description
-              "The identifier of a remote MEP in the same MA to
-              which the LBM is to be sent. This address
-              is used if node mep-transmit-lbm-dest-is-mep-id
-              is TRUE.";
-            reference
-              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-          }
-          leaf dest-is-mep-id {
-            type boolean;
-            default "false";
-            description
-              "TRUE indicates that MEP ID of the target MEP is used
-              for Loopback transmissions. FALSE indicates that
-              unicast destination MAC address of the target MEP is
-              used for Loopback transmissions.";
-            reference
-              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-          }
-          leaf message-count {
-            type uint32 {
-              range "1..1024";
-            }
-            default 1;
-            description
-              "The number of Loopback messages to be transmitted.";
-            reference
-              "12.14.7.3.2c of IEEE Std 802.1Q-2018";
-          }
-          leaf data-tlv {
-            type cfm-types:lbm-data-tlv-type;
-            description
-              "An arbitrary amount of data to be included in the
-              Data TLV, if the Data TLV is selected to be sent. The
-              intent is to be able to fill the frame carrying the
-              CFM PDU to its maximum length.";
-            reference
-              "12.14.7.3.2d of IEEE Std 802.1Q-2018";
-          }
-          leaf priority {
-            type dot1q-types:priority-type;
-            description
-              "Priority. 3 bit value to be used in the VLAN tag, if
-              present in the transmitted frame. The default value
-              should be the CCM priority.";
-            reference
-              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-          }
-          leaf vlan-drop-eligible {
-            type boolean;
-            default "false";
-            description
-              "Drop eligible bit value to be used in the VLAN tag,
-              if present in the transmitted frame";
-            reference
-              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-          }
-          leaf result-ok {
-            type boolean;
-            default "true";
-            config false;
-            description
-              "Indicates the result of the operation:
-                 TRUE - The LBM will be (or has been) sent.
-                 FALSE - The LBM will not be sent.";
-            reference
-              "12.14.7.3.3a of IEEE Std 802.1Q-2018";
-          }
-          leaf seq-number {
-            type cfm-types:seq-number-type;
-            config false;
-            description
-              "The Loopback transaction identifier
-              (mep-next-lbm-trans-id) of the first LBM (to be) 
-              sent. The value returned is undefined if 
-              mep-transmit-lbm-result-ok is FALSE.";
-            reference
-              "12.14.7.3.3b of IEEE Std 802.1Q-2018";
-          }
-          leaf next-lbm-trans-id {
-            type cfm-types:seq-number-type;
-            config false;
-            description
-              "Next sequence number identifier to be sent in a
-              Loopback message. This sequence number can be zero
-              since it can wrap around.";
-            reference
-              "12.14.7.1.3x, 20.28.2 of IEEE Std 802.1Q-2018";
-          }
-        } // loopback
-        
-        container linktrace {
-          description
-            "Linktrace protocol";
-          leaf status {
-            type boolean;
-            default "false";
-            description
-              "A Boolean flag set to TRUE by the Bridge Port to 
-              indicate that another LTM may be transmitted. Reset
-              to FALSE by the MEP Linktrace initiator state 
-              machine.";
-            reference
-              "20.49, Figure 20-17 of IEEE Std 802.1Q-2018";
-          }
-          leaf interval {
-            type cfm-types:cfm-interval-type;
-            default 1sec;
-            description
-              "The interval between LTM transmissions to be used by all
-              MEPs in the Maintenance Association.";
-          }
-          leaf priority {
-            type dot1q-types:priority-type;
-            description
-              "The priority value for CCMs and LTMs transmitted by
-              the MEP. The default value is the highest priority 
-              allowed to pass through the Bridge Port for any of
-              the MEPs VID(s).";
-            reference
-              "12.14.7.1.3h of IEEE Std 802.1Q-2018";
-          }
-          leaf flags {
-            type cfm-types:mep-tx-ltm-flags-type;
-            default use-fdb-only;
-            description
-              "The flags field for the LTMs transmitted by the 
-              MEP.";
-            reference
-              "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
-            
-          }
-          leaf target-mac-address {
-            type ieee:mac-address;
-            description
-              "The target MAC address field to be transmitted. A
-              unicast MAC address. This address will be used if the
-              value of mep-transmit-ltm-target-is-mep-id is FALSE.";
-            reference
-              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-          }
-          leaf target-mep-id {
-            type cfm-types:mep-id-or-zero-type;
-            description
-              "The target MAC address field to be transmitted. The
-              MEP identifier of another MEP in the same MA. This
-              address will be used if the value of 
-              mep-transmit-ltm-target-is-mep-id is TRUE.";
-            reference
-              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-          }
-          leaf target-is-mep-id {
-            type boolean;
-            default "false";
-            description
-              "TRUE indicates that MEP id of the target MEP is used
-              for Linktrace transmission. FALSE indicates that
-              unicast destination MAC address of the target MEP is
-              used for LinkTrace transmission.";
-            reference
-              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-          }
-          leaf ttl {
-            type uint32 {
-              range "0..255";
-            }
-            default 64;
-            description
-              "The LTM TTL field. Indicates the number of hops 
-              remaining to the LTM. Decremented by 1 by each
-              Linktrace Responder that handles the LTM. The value
-              returned in the LTR is one less than that received in
-              the LTM. If the LTM TTL is 0 or 1, the LTM is not
-              forwarded to the next hop, and if 0, no LTR is 
-              generated.";
-            reference
-              "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
-          }
-          leaf result {
-            type boolean;
-            default "true";
-            config false;
-            description
-              "Indicates the result of the operation:
-                 TRUE - The Linktrace message will be (or has been) 
-                        sent.
-                 FALSE - The Linktrace message will not be sent.";
-            reference
-              "12.14.7.4.3a of IEEE Std 802.1Q-2018";
-          }
-          leaf seq-number {
-            type cfm-types:seq-number-type;
-            config false;
-            description
-              "The LTM transaction identifier 
-              (mep-ltm-next-seq-number) of the LTM sent. The value
-              returned is undefined if mep-transmit-ltm-result is 
-              FALSE.";
-            reference
-              "12.14.7.4.3b of IEEE Std 802.1Q-2018";
-          }
-          leaf egress-identifier {
-            type string {
-              length "8";
-            }
-            config false;
-            description
-              "Identifies the MEP Linktrace Initiator that is 
-              originating, or the Linktrace Responder that is
-              forwarding, this LTM.
-              
-              The low-order six octets contain a 48-bit IEEE MAC
-              address unique to the system in which the MEP 
-              Linktrace Initiator or Linktrace Responder resides.
-              The high-order two octets contain a value sufficient
-              to uniquely identify the MEP Linktrace Initiator or 
-              Linktrace Responder within that system.
-              
-              For most Bridges, the address of any MAC attached to
-              the Bridge will suffice for the low-order six octets,
-              and 0 for the high-order octets. In some situations,
-              e.g., if multiple virtual Bridges utilizing emulated
-              LANs are implemented in a single physical system, the
-              high-order two octets can be used to differentiate
-              among the transmitting entities.
-              
-              The value returned is undefined if 
-              mep-transmit-ltm-result is FALSE.";
-            reference
-              "12.14.7.4.3c of IEEE Std 802.1Q-2018";
-          }
-          leaf next-seq-number {
-            type cfm-types:seq-number-type;
-            config false;
-            description
-              "Next transaction identifier to be sent in a 
-              LinkTrace message.This sequence number can be zero
-              since it can wrap around.";
-            reference
-              "12.14.7.1.3ab, 20.41.1 of IEEE Std 802.1Q-2018";
-          }
-        } // linktrace
         
         container stats {
           config false;


### PR DESCRIPTION
Clean YANG Validation

**ieee802-dot1q-cfm.yang**
Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw maintenance-domains
       |  +--rw maintenance-domain* [md-id]
       |     +--rw md-id                        cfm-types:name-key-type
       |     +--rw (md-name)?
       |     |  +--:(ieee-reserved-0)
       |     |  |  +--rw name?                        string
       |     |  +--:(none)
       |     |  |  +--rw none?                        empty
       |     |  +--:(dns-like-name)
       |     |  |  +--rw dns-like-name?               string
       |     |  +--:(mac-address-and-uint)
       |     |  |  +--rw mac-address-and-uint-type
       |     |  |     +--rw address?   ieee:mac-address
       |     |  |     +--rw int?       uint16
       |     |  +--:(char-string)
       |     |     +--rw char-string?                 string
       |     +--rw md-level?                    cfm-types:md-level-type
       |     +--rw mhf-creation?                cfm-types:mhf-creation-type
       |     +--rw id-permission?               cfm-types:sender-id-permission-type
       |     +--rw fault-alarm-address?         cfm-types:fault-alarm-address-type
       |     +--rw maintenance-association* [ma-id]
       |        +--rw ma-id                               cfm-types:name-key-type
       |        +--rw (ma-name)?
       |        |  +--:(ieee-reserved-0)
       |        |  |  +--rw name?                               string
       |        |  +--:(primary-vid)
       |        |  |  +--rw primary-vid?                        dot1q-types:vlanid
       |        |  +--:(char-string)
       |        |  |  +--rw char-string?                        string
       |        |  +--:(unsigned-int16)
       |        |  |  +--rw unsigned-int16?                     uint16
       |        |  +--:(rfc2865-vpn-id)
       |        |  |  +--rw rfc2865-vpn-id?                     string
       |        |  +--:(icc-format)
       |        |     +--rw icc-format?                         string
       |        +--rw ccm-interval?                       cfm-types:cfm-interval-type
       |        +--rw fault-alarm-address?                cfm-types:fault-alarm-address-type
       |        +--rw maintenance-association-mep-list* [mep-id]
       |           +--rw mep-id    cfm-types:mep-id-type
       +--rw maintenance-association-group* [maintenance-group]
       |  +--rw maintenance-group    maintenance-group-type
       |  +--rw md-name              -> /cfm/maintenance-domains/maintenance-domain/md-id
       |  +--rw ma-name              -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../md-name]/maintenance-association/ma-id
       |  +--rw mhf-creation?        cfm-types:mhf-creation-type
       |  +--rw id-permission?       cfm-types:sender-id-permission-type
       |  +--rw mep* [mep-id]
       |     +--rw mep-id                     -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../../md-name]/maintenance-association[ma-id = current()/../../ma-name]/maintenance-association-mep-list/mep-id
       |     +--rw direction?                 cfm-types:mp-direction-type
       |     +--rw primary-vid?               uint32
       |     +--rw admin-state?               boolean
       |     +--ro fng-state?                 cfm-types:fng-state-type
       |     +--rw ccm-ltm-priority?          dot1q-types:priority-type
       |     +--ro mac-address?               ieee:mac-address
       |     +--rw fault-alarm-address?       cfm-types:fault-alarm-address-type
       |     +--rw lowest-priority-defect?    cfm-types:lowest-alarm-priority-type
       |     +--rw fng-alarm-time?            yang:zero-based-counter32
       |     +--rw fng-reset-time?            yang:zero-based-counter32
       |     +--ro highest-priority-defect?   cfm-types:highest-defect-priority-type
       |     +--ro defects?                   cfm-types:mep-defects-type
       |     +--ro error-ccm-last-failure?    string
       |     +--ro xcon-ccm-last-failure?     string
       |     +--rw mep-db* [rmep-id]
       |     |  +--rw rmep-id                     -> /cfm/maintenance-domains/maintenance-domain[md-id = current()/../../../md-name]/maintenance-association[ma-id = current()/../../../ma-name]/maintenance-association-mep-list/mep-id
       |     |  +--ro rmep-state?                 cfm-types:remote-mep-state-type
       |     |  +--ro rmep-failed-ok-time?        yang:zero-based-counter32
       |     |  +--ro mac-address?                ieee:mac-address
       |     |  +--ro rdi?                        boolean
       |     |  +--ro port-status-tlv?            cfm-types:port-status-tlv-value
       |     |  +--ro interface-status-tlv?       cfm-types:interface-status-tlv-value
       |     |  +--ro chassis-id-subtype?         cfm-types:lldp-chassis-id-subtype
       |     |  +--ro chassis-id?                 cfm-types:lldp-chassis-id
       |     |  +--rw transport-service-domain
       |     |  |  +--rw (management-address-domain)?
       |     |  |     +--:(udp-ipv4)
       |     |  |     |  +--rw udp-ipv4-domain?      yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv4-address?     inet:ipv4-address
       |     |  |     |  +--rw udp-ipv4-port?        inet:port-number
       |     |  |     +--:(udp-ipv6)
       |     |  |     |  +--rw udp-ipv6-domain?      yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv6-address?     inet:ipv6-address
       |     |  |     |  +--rw udp-ipv6-port?        inet:port-number
       |     |  |     +--:(udp-ipv4z)
       |     |  |     |  +--rw udp-ipv4z-domain?     yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw udp-ipv4z-index?      uint32
       |     |  |     |  +--rw udp-ipv4z-port?       inet:port-number
       |     |  |     +--:(udp-ipv6z)
       |     |  |     |  +--rw udp-ipv6z-domain?     yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv6z-address?    inet:ipv6-address
       |     |  |     |  +--rw udp-ipv6z-index?      uint32
       |     |  |     |  +--rw udp-ipv6z-port?       inet:port-number
       |     |  |     +--:(tcp-ipv4)
       |     |  |     |  +--rw tcp-ipv4-domain?      yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv4-address?     inet:ipv4-address
       |     |  |     |  +--rw tcp-ipv4-port?        inet:port-number
       |     |  |     +--:(tcp-ipv6)
       |     |  |     |  +--rw tcp-ipv6-domain?      yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv6-address?     inet:ipv6-address
       |     |  |     |  +--rw tcp-ipv6-port?        inet:port-number
       |     |  |     +--:(tcp-ipv4z)
       |     |  |     |  +--rw tcp-ipv4z-domain?     yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw tcp-ipv4z-index?      uint32
       |     |  |     |  +--rw tcp-ipv4z-port?       inet:port-number
       |     |  |     +--:(tcp-ipv6z)
       |     |  |     |  +--rw tcp-ipv6z-domain?     yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv6z-address?    inet:ipv6-address
       |     |  |     |  +--rw tcp-ipv6z-index?      uint32
       |     |  |     |  +--rw tcp-ipv6z-port?       inet:port-number
       |     |  |     +--:(sctp-ipv4)
       |     |  |     |  +--rw sctp-ipv4-domain?     yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv4-address?    inet:ipv4-address
       |     |  |     |  +--rw sctp-ipv4-port?       inet:port-number
       |     |  |     +--:(sctp-ipv6)
       |     |  |     |  +--rw sctp-ipv6-domain?     yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv6-address?    inet:ipv6-address
       |     |  |     |  +--rw sctp-ipv6-port?       inet:port-number
       |     |  |     +--:(sctp-ipv4z)
       |     |  |     |  +--rw sctp-ipv4z-domain?    yang:object-identifier-128
       |     |  |     |  +--rw sctp-iv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw sctp-ipv4z-index?     uint32
       |     |  |     |  +--rw sctp-ipv4z-port?      inet:port-number
       |     |  |     +--:(sctp-ipv6z)
       |     |  |     |  +--rw sctp-ipv6z-domain?    yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv6z-address?   inet:ipv6-address
       |     |  |     |  +--rw sctp-ipv6z-index?     uint32
       |     |  |     |  +--rw sctp-ipv6z-port?      inet:port-number
       |     |  |     +--:(local)
       |     |  |     |  +--rw local-domain?         yang:object-identifier-128
       |     |  |     |  +--rw local-address?        string
       |     |  |     +--:(udp-dns)
       |     |  |     |  +--rw udp-dns-domain?       yang:object-identifier-128
       |     |  |     |  +--rw udp-dns-address?      string
       |     |  |     +--:(tcp-dns)
       |     |  |     |  +--rw tcp-dns-domain?       yang:object-identifier-128
       |     |  |     |  +--rw tcp-dns-address?      string
       |     |  |     +--:(sctp-dns)
       |     |  |        +--rw sctp-dns-domain?      yang:object-identifier-128
       |     |  |        +--rw sctp-dns-address?     string
       |     |  +--rw rmep-is-active?             boolean
       |     +--rw continuity-check
       |     |  +--rw ccm-enabled?    boolean
       |     |  +--rw priority?       dot1q-types:priority-type
       |     |  +--rw ccm-interval?   cfm-types:cfm-interval-type
       |     +--ro stats
       |     |  +--ro mep-ccm-sequence-errors?   yang:counter64
       |     |  +--ro mep-ccms-sent?             yang:counter64
       |     |  +--ro mep-lbr-in?                yang:counter64
       |     |  +--ro mep-lbr-in-out-of-order?   yang:counter64
       |     |  +--ro mep-lbr-bad-msdu?          yang:counter64
       |     |  +--ro mep-unexpected-ltr-in?     yang:counter64
       |     |  +--ro mep-lbr-out?               yang:counter64
       |     +---n mep-fault-alarm
       |        +---- mep-priority-defect?   -> ../../highest-priority-defect
       +--rw cfm-operation* [maintenance-group mep-id]
          +--rw maintenance-group     -> /cfm/maintenance-association-group/maintenance-group
          +--rw mep-id                -> /cfm/maintenance-association-group[maintenance-group = current()/../maintenance-group]/mep/mep-id
          +---x transmit-loopback
          |  +---w input
          |  |  +---w lbm-dest-is-mep-id?     boolean
          |  |  +---w lbm-dest-mac-address?   ieee:mac-address
          |  |  +---w lbm-dest-mep-id?        cfm-types:mep-id-or-zero-type
          |  |  +---w interval?               cfm-types:cfm-interval-type
          |  |  +---w lbm-messages?           uint32
          |  |  +---w lbm-priority?           dot1q-types:priority-type
          |  |  +---w lbm-drop-eligible?      boolean
          |  |  +---w lbm-data-tlv?           cfm-types:lbm-data-tlv-type
          |  +--ro output
          |     +--ro lbm-result-ok?    boolean
          |     +--ro lbm-seq-number?   cfm-types:seq-number-type
          +---x transmit-linktrace
          |  +---w input
          |  |  +---w interval?                 cfm-types:cfm-interval-type
          |  |  +---w ltm-target-is-mep-id?     boolean
          |  |  +---w ltm-target-mac-address?   ieee:mac-address
          |  |  +---w ltm-target-mep-id?        cfm-types:mep-id-or-zero-type
          |  |  +---w ltm-priority?             dot1q-types:priority-type
          |  |  +---w ltm-drop-eligible?        boolean
          |  |  +---w ltm-ttl?                  uint32
          |  |  +---w ltm-flags?                cfm-types:mep-tx-ltm-flags-type
          |  +--ro output
          |     +--ro ltm-result-ok?           boolean
          |     +--ro ltm-seq-number?          cfm-types:seq-number-type
          |     +--ro ltm-egress-identifier?   string
          +--rw loopback-reply* [lbr-seq-number lbr-receive-order]
          |  +--rw lbr-seq-number       cfm-types:seq-number-type
          |  +--rw lbr-receive-order    uint32
          |  +--ro result-ok?           boolean
          +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
             +--rw ltr-seq-number                   cfm-types:seq-number-type
             +--rw ltr-receive-order                uint32
             +--ro ltr-ttl?                         uint32
             +--ro ltr-forwarded?                   boolean
             +--ro ltr-terminal-mep?                boolean
             +--ro ltr-last-egress-identifier?      string
             +--ro ltr-next-egress-identifier?      string
             +--ro ltr-relay?                       cfm-types:relay-action-field-value
             +--ro ltr-chassis-id-subtype?          cfm-types:lldp-chassis-id-subtype
             +--ro ltr-chassis-id?                  cfm-types:lldp-chassis-id
             +--ro ltr-transport-service-domain
             |  +--ro (management-address-domain)?
             |     +--:(udp-ipv4)
             |     |  +--ro udp-ipv4-domain?      yang:object-identifier-128
             |     |  +--ro udp-ipv4-address?     inet:ipv4-address
             |     |  +--ro udp-ipv4-port?        inet:port-number
             |     +--:(udp-ipv6)
             |     |  +--ro udp-ipv6-domain?      yang:object-identifier-128
             |     |  +--ro udp-ipv6-address?     inet:ipv6-address
             |     |  +--ro udp-ipv6-port?        inet:port-number
             |     +--:(udp-ipv4z)
             |     |  +--ro udp-ipv4z-domain?     yang:object-identifier-128
             |     |  +--ro udp-ipv4z-address?    inet:ipv4-address
             |     |  +--ro udp-ipv4z-index?      uint32
             |     |  +--ro udp-ipv4z-port?       inet:port-number
             |     +--:(udp-ipv6z)
             |     |  +--ro udp-ipv6z-domain?     yang:object-identifier-128
             |     |  +--ro udp-ipv6z-address?    inet:ipv6-address
             |     |  +--ro udp-ipv6z-index?      uint32
             |     |  +--ro udp-ipv6z-port?       inet:port-number
             |     +--:(tcp-ipv4)
             |     |  +--ro tcp-ipv4-domain?      yang:object-identifier-128
             |     |  +--ro tcp-ipv4-address?     inet:ipv4-address
             |     |  +--ro tcp-ipv4-port?        inet:port-number
             |     +--:(tcp-ipv6)
             |     |  +--ro tcp-ipv6-domain?      yang:object-identifier-128
             |     |  +--ro tcp-ipv6-address?     inet:ipv6-address
             |     |  +--ro tcp-ipv6-port?        inet:port-number
             |     +--:(tcp-ipv4z)
             |     |  +--ro tcp-ipv4z-domain?     yang:object-identifier-128
             |     |  +--ro tcp-ipv4z-address?    inet:ipv4-address
             |     |  +--ro tcp-ipv4z-index?      uint32
             |     |  +--ro tcp-ipv4z-port?       inet:port-number
             |     +--:(tcp-ipv6z)
             |     |  +--ro tcp-ipv6z-domain?     yang:object-identifier-128
             |     |  +--ro tcp-ipv6z-address?    inet:ipv6-address
             |     |  +--ro tcp-ipv6z-index?      uint32
             |     |  +--ro tcp-ipv6z-port?       inet:port-number
             |     +--:(sctp-ipv4)
             |     |  +--ro sctp-ipv4-domain?     yang:object-identifier-128
             |     |  +--ro sctp-ipv4-address?    inet:ipv4-address
             |     |  +--ro sctp-ipv4-port?       inet:port-number
             |     +--:(sctp-ipv6)
             |     |  +--ro sctp-ipv6-domain?     yang:object-identifier-128
             |     |  +--ro sctp-ipv6-address?    inet:ipv6-address
             |     |  +--ro sctp-ipv6-port?       inet:port-number
             |     +--:(sctp-ipv4z)
             |     |  +--ro sctp-ipv4z-domain?    yang:object-identifier-128
             |     |  +--ro sctp-iv4z-address?    inet:ipv4-address
             |     |  +--ro sctp-ipv4z-index?     uint32
             |     |  +--ro sctp-ipv4z-port?      inet:port-number
             |     +--:(sctp-ipv6z)
             |     |  +--ro sctp-ipv6z-domain?    yang:object-identifier-128
             |     |  +--ro sctp-ipv6z-address?   inet:ipv6-address
             |     |  +--ro sctp-ipv6z-index?     uint32
             |     |  +--ro sctp-ipv6z-port?      inet:port-number
             |     +--:(local)
             |     |  +--ro local-domain?         yang:object-identifier-128
             |     |  +--ro local-address?        string
             |     +--:(udp-dns)
             |     |  +--ro udp-dns-domain?       yang:object-identifier-128
             |     |  +--ro udp-dns-address?      string
             |     +--:(tcp-dns)
             |     |  +--ro tcp-dns-domain?       yang:object-identifier-128
             |     |  +--ro tcp-dns-address?      string
             |     +--:(sctp-dns)
             |        +--ro sctp-dns-domain?      yang:object-identifier-128
             |        +--ro sctp-dns-address?     string
             +--ro ltr-ingress?                     cfm-types:ingress-action-field-value
             +--ro ltr-ingress-mac?                 ieee:mac-address
             +--ro ltr-ingress-port-id-subtype?     cfm-types:lldp-port-id-subtype
             +--ro ltr-egress?                      cfm-types:egress-action-field-value
             +--ro ltr-egress-mac?                  ieee:mac-address
             +--ro ltr-egress-port-id-subtype?      cfm-types:lldp-port-id-subtype
             +--ro ltr-egress-port-id?              cfm-types:lldp-port-id
             +--ro ltr-organization-specific-tlv?   string
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
