### PR TITLE
Correct the zip codes in IEEE 802.1Qcp-2018 YANG models

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-bridge.yang
@@ -28,7 +28,7 @@ module ieee802-dot1q-bridge {
             445 Hoes Lane
             P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
     
     E-mail: STDS-802-1-L@IEEE.ORG";
@@ -1748,4 +1748,3 @@ module ieee802-dot1q-bridge {
     }
   }
 }
-

--- a/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-pb.yang
@@ -22,7 +22,7 @@ module ieee802-dot1q-pb {
             445 Hoes Lane
             P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
     
     E-mail: STDS-802-1-L@IEEE.ORG";
@@ -198,4 +198,3 @@ module ieee802-dot1q-pb {
     }
   }
 }
-

--- a/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-tpmr.yang
@@ -22,7 +22,7 @@ module ieee802-dot1q-tpmr {
             445 Hoes Lane
             P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
     
     E-mail: STDS-802-1-L@IEEE.ORG";
@@ -288,4 +288,3 @@ module ieee802-dot1q-tpmr {
     }
   }
 }
-

--- a/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-types.yang
@@ -16,7 +16,7 @@ module ieee802-dot1q-types {
             445 Hoes Lane
             P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
     
     E-mail: STDS-802-1-L@IEEE.ORG";

--- a/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-vlan-bridge.yang
@@ -13,7 +13,7 @@ module ieee802-dot1q-vlan-bridge {
             445 Hoes Lane
             P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
     
     E-mail: STDS-802-1-L@IEEE.ORG";
@@ -28,4 +28,3 @@ module ieee802-dot1q-vlan-bridge {
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
 }
-

--- a/standard/ieee/draft/ieee802-types.yang
+++ b/standard/ieee/draft/ieee802-types.yang
@@ -13,7 +13,7 @@ module ieee802-types {
             445 Hoes Lane
             P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
     
     E-mail: STDS-802-1-L@IEEE.ORG";
@@ -41,4 +41,3 @@ module ieee802-types {
       8.1 of IEEE Std 802-2014";
   }
 }
-


### PR DESCRIPTION
During the publication process of IEEE Std 802.1Qcp, the Zip codes in the YANG models were corrected.  This pull request changes the Zip codes in these models to match those in the published standard.