### PR TITLE
Updates to CFM YANG modules assocaited with P802.1Qcx draft 0.4

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1ab-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1ab-types.yang
@@ -1,0 +1,261 @@
+module ieee802-dot1ab-types {
+  yang-version 1.1;
+  
+  namespace "urn:ieee:std:802.1Q:yang:ieee802-dot1ab-types";
+  prefix "lldp-types";
+
+  organization
+    "IEEE 802.1 Working Group";
+
+  contact
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+  
+    E-mail: STDS-802-1-L@IEEE.ORG";
+
+  description
+    "Common types used within ieee802-dot1ab-lldp modules.";
+  
+  revision 2018-10-02 {
+    description
+      "Creation for Task Group review.";
+    reference
+      "IEEE Std 802.1AB-2016, Station and Media Access Control 
+	  Connectivity Discovery.";
+  }
+  
+  typedef chassis-id-subtype-type {
+    type enumeration {
+      enum chassis-component {
+        value 1;
+        description
+          "Represents a chassis identifier based on the value of
+          entPhysicalAlias object (defined in IETF RFC 2737) for a
+          chassis component (i.e., an entPhysicalClass value of
+          chassis(3))";
+      }
+      enum interface-alias {
+        value 2;
+        description
+          "Represents a chassis identifier based on the value of
+          ifAlias object (defined in IETF RFC 2863) for an interface
+          on the containing chassis.";
+      }
+      enum port-component {
+        value 3;
+        description
+          "Represents a chassis identifier based on the value of
+          entPhysicalAlias object (defined in IETF RFC 2737) for a
+          port or backplane component (i.e., entPhysicalClass value of
+          port(10) or backplane(4)), within the containing chassis.";
+      }
+      enum mac-address {
+        value 4;
+        description
+          "Represents a chassis identifier based on the value of a
+          unicast source address (encoded in network byte order and
+          IEEE 802.3 canonical bit order), of a port on the containing
+          chassis as defined in IEEE Std 802-2001.";
+      }
+      enum network-address {
+        value 5;
+        description
+          "Represents a chassis identifier based on a network address,
+          associated with a particular chassis.  The encoded address is
+          actually composed of two fields.  The first field is a
+          single octet, representing the IANA AddressFamilyNumbers
+          value for the specific address type, and the second field is
+          the network address value.";
+      }
+      enum interface-name {
+        value 6;
+        description
+          "Represents a chassis identifier based on the value of
+          ifName object (defined in IETF RFC 2863) for an interface
+          on the containing chassis.";
+      }
+      enum local {
+        value 7;
+        description
+          "Represents a chassis identifier based on a locally defined
+          value.";
+      }
+    }
+    description
+      "The source of a chassis identifier.";
+    reference
+      "LLDP MIB 20050506";
+  }
+  
+  typedef chassis-id-type {
+    type string {
+      length "1..255";
+    }
+    description
+      "The format of a chassis identifier string. Objects of this type
+      are always used with an associated lldp-chassis-is-subtype
+      object, which identifies the format of the particular
+      lldp-chassis-id object instance.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      chassis-component, then the octet string identifies
+      a particular instance of the entPhysicalAlias object
+      (defined in IETF RFC 2737) for a chassis component (i.e.,
+      an entPhysicalClass value of chassis(3)).
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of interface-alias, then the octet string identifies
+      a particular instance of the ifAlias object (defined in
+      IETF RFC 2863) for an interface on the containing chassis.
+      If the particular ifAlias object does not contain any values,
+      another chassis identifier type should be used.
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of port-component, then the octet string identifies a
+      particular instance of the entPhysicalAlias object (defined
+      in IETF RFC 2737) for a port or backplane component within
+      the containing chassis.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      mac-address, then this string identifies a particular
+      unicast source address (encoded in network byte order and
+      IEEE 802.3 canonical bit order), of a port on the containing
+      chassis as defined in IEEE Std 802-2001.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      network-address, then this string identifies a particular
+      network address, encoded in network byte order, associated
+      with one or more ports on the containing chassis.  The first
+      octet contains the IANA Address Family Numbers enumeration
+      value for the specific address type, and octets 2 through
+      N contain the network address value in network byte order.
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of interface-name, then the octet string identifies
+      a particular instance of the ifName object (defined in
+      IETF RFC 2863) for an interface on the containing chassis.
+      If the particular ifName object does not contain any values,
+      another chassis identifier type should be used.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      local, then this string identifies a locally assigned
+      Chassis ID.";
+    reference
+      "LLDP MIB 20050506";
+  }
+  
+  typedef port-id-subtype-type {
+    type enumeration {
+      enum interface-alias {
+        value 1;
+        description
+          "Represents a port identifier based on the ifAlias
+          MIB object, defined in IETF RFC 2863.";
+      }
+      enum port-component {
+        value 2;
+        description
+          "Represents a port identifier based on the value of
+          entPhysicalAlias (defined in IETF RFC 2737) for a port
+          component (i.e., entPhysicalClass value of port(10)), 
+          within the containing chassis.";
+      }
+      enum mac-address {
+        value 3;
+        description
+          "Represents a port identifier based on a unicast source
+          address (encoded in network byte order and IEEE 802.3
+          canonical bit order), which has been detected by the agent
+          and associated with a particular port (IEEE Std 802-2001).";
+      }
+      enum network-address {
+        value 4;
+        description
+          "Represents a port identifier based on a network address,
+          detected by the agent and associated with a particular 
+          port.";
+      }
+      enum interface-name {
+        value 5;
+        description
+          "Represents a port identifier based on the ifName MIB object,
+          defined in IETF RFC 2863.";
+      }
+      enum agent-circuit-id {
+        value 6;
+        description
+          "Represents a port identifier based on the agent-local
+          identifier of the circuit (defined in RFC 3046), detected by
+          the agent and associated with a particular port.";
+      }
+      enum local {
+        value 7;
+        description
+          "Represents a port identifier based on a value locally
+          assigned.";
+      }
+    }
+    description
+      "The source of a particular type of port identifier used
+      in the LLDP YANG module.";
+  }
+  
+  typedef port-id-type {
+    type string {
+      length "8";
+    }
+    description
+      "The format of a port identifier string. Objects of this type
+      are always used with an associated lldp-port-id-subtype object,
+      which identifies the format of the particular lldp-port-id
+      object instance.
+
+      If the associated lldp-port-id-subtype object has a value of
+      interface-alias, then the octet string identifies a
+      particular instance of the ifAlias object (defined in IETF
+      RFC 2863).  If the particular ifAlias object does not contain
+      any values, another port identifier type should be used.
+
+      If the associated lldp-port-id-subtype object has a value of
+      port-component, then the octet string identifies a
+      particular instance of the entPhysicalAlias object (defined
+      in IETF RFC 2737) for a port or backplane component.
+
+      If the associated lldp-port-id-subtype object has a value of
+      mac-address, then this string identifies a particular
+      unicast source address (encoded in network byte order
+      and IEEE 802.3 canonical bit order) associated with the port
+      (IEEE Std 802-2001).
+
+      If the associated lldp-port-id-subtype object has a value of
+      network-address, then this string identifies a network
+      address associated with the port.  The first octet contains
+      the IANA AddressFamilyNumbers enumeration value for the
+      specific address type, and octets 2 through N contain the
+      networkAddress address value in network byte order.
+
+      If the associated lldp-port-id-subtype object has a value of
+      interface-name, then the octet string identifies a
+      particular instance of the ifName object (defined in IETF
+      RFC 2863).  If the particular ifName object does not contain
+      any values, another port identifier type should be used.
+
+      If the associated lldp-port-id-subtype object has a value of
+      agent-circuit-id, then this string identifies a agent-local
+      identifier of the circuit (defined in RFC 3046).
+
+      If the associated lldp-port-id-subtype object has a value of
+      local, then this string identifies a locally assigned port ID.";
+  }
+  
+  
+} // ieee802-dot1ab-types

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-bridge.yang
@@ -6,7 +6,6 @@ module ieee802-dot1q-cfm-bridge {
 
   import ieee802-dot1q-bridge { prefix "dot1q"; }
   import ieee802-dot1q-cfm { prefix "dot1q-cfm"; }
-  import ieee802-dot1q-cfm-mip { prefix "cfm-mip"; }
   import ietf-interfaces { prefix "if"; }
   import ieee802-types { prefix "ieee"; }
   import ieee802-dot1q-cfm-types { prefix "cfm-types"; }
@@ -64,7 +63,7 @@ module ieee802-dot1q-cfm-bridge {
    * -------------------------------------------------
    */
   
-  grouping service-id {
+  grouping service-id-grouping {
     description
       "The list of VIDs, I-SID, or the TE-SID monitored by 
       this MA, or 0, if the MA is not attached to a VID, or
@@ -166,7 +165,7 @@ module ieee802-dot1q-cfm-bridge {
         configuration and operational data.";
       
       list cfm-stack {
-        key "port md-level direction";
+        key "port md-level direction service-selector service-id";
         description
           "The CFM Stack contains information about the Maintenance
           Points configured on a particular Bridge Port (or
@@ -205,14 +204,31 @@ module ieee802-dot1q-cfm-bridge {
           reference
             "12.14.2.1.2c of IEEE Std 802.1Q-2018";     
         }
+        leaf service-selector {
+          type cfm-types:service-selector-type;
+          description
+            "The type of the service selector";
+        }
+        leaf service-id {
+          type cfm-types:service-selector-value;
+          description
+            "A specific VID, I-SID, Traffic Engineering service 
+            instance Identifier (TE-SID), or Segment Identifier
+            (SEG-ID) associated with an MP, or 0, in the case that
+            the MP is associated with no VID, I-SID, TE-SID, or SEG-ID.";
+          reference
+            "12.14.2.1.2d of IEEE Std 802.1Q-2018";
+        }
+        /*
         container service-id {
           description 
             "A specific VID, I-SID, Traffic Engineering service 
             instance Identifier (TE-SID), or Segment Identifier
             (SEG-ID) associated with an MP, or 0, in the case that
             the MP is associated with no VID, I-SID, TE-SID, or SEG-ID";
-          uses service-id;
+          uses service-id-grouping;
         }
+        */
         leaf maintenance-group {
           type leafref {
             path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-association-group'
@@ -234,7 +250,6 @@ module ieee802-dot1q-cfm-bridge {
         leaf ma-id {
           type leafref {
             path '/dot1q-cfm:cfm'
-              + '/dot1q-cfm:maintenance-domains'
               + '/dot1q-cfm:maintenance-domain'
               + '[dot1q-cfm:md-id = current()/../md-id]'
               + '/dot1q-cfm:maintenance-association'
@@ -279,7 +294,7 @@ module ieee802-dot1q-cfm-bridge {
         ID TLV by those MHFs.";
       
       list default-md-level {
-        key "bridge-id component-id";
+        key "bridge-id component-id primary-service-id service-selector";
         description
           "For each bridge component, the Default MD Level Managed 
           Object controls MHF creation for VIDs that are not attached
@@ -322,13 +337,27 @@ module ieee802-dot1q-cfm-bridge {
           reference
             "12.3l of IEEE Std 802.1Q-2018";
         }
-        container primary-service-id {
+        leaf service-selector {
+          type cfm-types:service-selector-type;
+          description
+            "The type of the service selector";
+        }
+        leaf primary-service-id {
+          type cfm-types:service-selector-value;
           description
             "A vid or isid in an I or B component.";
-          uses service-id;
           reference
             "12.14.3.1.2a of IEEE Std 802.1Q-2018";
         }
+        /*
+        container primary-service-id {
+          description
+            "A vid or isid in an I or B component.";
+          uses service-id-grouping;
+          reference
+            "12.14.3.1.2a of IEEE Std 802.1Q-2018";
+        }
+        */
         container associated-service-ids {
           description
             "A list of VIDs associated with any MHF on the VID, always
@@ -337,7 +366,7 @@ module ieee802-dot1q-cfm-bridge {
             the I-SID. The first VID is the MAs Primary VID.
             
             List is empty if no primary VID specified.";
-          uses service-id;
+          uses service-id-grouping;
           reference
             "12.14.3.1.3a of IEEE Std 802.1Q-2018";
         }
@@ -401,7 +430,7 @@ module ieee802-dot1q-cfm-bridge {
         the identity of the configuration error.";
 
       list config-error {
-        key "port";
+        key "port service-id service-selector";
         description
           "The CFM Configuration Error List table provides a list of
           Interfaces and VIDs that are incorrectly configured.";
@@ -421,11 +450,15 @@ module ieee802-dot1q-cfm-bridge {
           reference
             "12.14.4.1.2b of IEEE Std 802.1Q-2018";
         }
-        container service-id {
-          description 
-            "The Service Selector Identifier of the Service with 
-            interfaces in error.";
-          uses service-id;
+        leaf service-selector {
+          type cfm-types:service-selector-type;
+          description
+            "The type of the service selector";
+        }
+        leaf service-id {
+          type cfm-types:service-selector-value;
+          description
+            "A vid or isid in an I or B component.";
           reference
             "12.14.4.1.2a of IEEE Std 802.1Q-2018";
         }
@@ -463,13 +496,17 @@ module ieee802-dot1q-cfm-bridge {
         the provided maintenance domain and maintenance association
         values.";
     }
-    container service-id {
-      description 
-        "A specific VID, I-SID, Traffic Engineering service 
-        instance Identifier (TE-SID), or Segment Identifier
-        (SEG-ID) associated with an MP, or 0, in the case that
-        the MP is associated with no VID, I-SID, TE-SID, or SEG-ID";
-      uses service-id;
+    leaf service-selector {
+      type cfm-types:service-selector-type;
+      description
+        "The type of the service selector";
+    }
+    leaf service-id {
+      type cfm-types:service-selector-value;
+      description
+        "A vid or isid in an I or B component.";
+      reference
+        "12.14.4.1.2a of IEEE Std 802.1Q-2018";
     }
   }
   
@@ -481,34 +518,21 @@ module ieee802-dot1q-cfm-bridge {
       attributes.";
     leaf port {
       type port-ref;
+      must '/dot1q-cfm:cfm'
+         + '/dot1q-cfm:maintenance-association-group'
+         + '/cfm-bridge:component-name = '
+         + '/if:interfaces/if:interface[current() = ./if:name]'
+         + '/dot1q:bridge-port/dot1q:component-name' {
+        description
+          "The component of the port (Interface) reference must be
+          the same as the bridge and component references by the 
+          maintenance association group.";
+      }
       description
         "The interface index of the interface (e.g., Bridge 
         Port) to which the MEP is attached.";
       reference
         "12.14.7.1.3b of IEEE Std 802.1Q-2018";
-    }
-  }
-  
-  augment "/dot1q-cfm:cfm/cfm-mip:mips/cfm-mip:mip" {
-    description
-      "Augment the MIP object defined in the ieee802-dot1q-mip
-      (CFM MIP) YANG module with IEEE 802.1Qcp bridge specific
-      attributes.";
-    leaf port {
-      type port-ref;
-      description
-        "The interface index of the interface (e.g., Bridge 
-        Port) to which the MIP is attached.";
-      reference
-        "12.14.7.1.3b of IEEE Std 802.1Q-2018";
-    }
-    container service-id {
-      description 
-        "A specific VID, I-SID, Traffic Engineering service 
-        instance Identifier (TE-SID), or Segment Identifier
-        (SEG-ID) associated with an MP, or 0, in the case that
-        the MP is associated with no VID, I-SID, TE-SID, or SEG-ID";
-      uses service-id;
     }
   }
   

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-mip.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-mip.yang
@@ -64,28 +64,19 @@ module ieee802-dot1q-cfm-mip {
           reference
             "12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
         }
-        leaf mhf-creation {
-          type cfm-types:mhf-creation-type;
-          default "mhf-default";
-          description
-            "A value indicating if the Management entity can create MHFs
-            (MIP Half Function) for this VID at this MD Level. If this
-            object has the value mhf-defer, MHF creation for this VLAN
-            is controlled by md-mhf-creation. The value of this variable
-            is meaningless if the values of md-status is false.";
-          reference
-            "12.14.3.1.3d of IEEE Std 802.1Q-2018";
-          
-        }
         leaf id-permission {
           type cfm-types:sender-id-permission-type;
+          must 'enum-value(.) != 5' {
+            description
+              "The sender-id-defer value is not valid.";
+          }
           default "send-id-none";
           description
             "Enumerated value indicating what, if anything, is to be
-            included in the Sender ID TLV transmitted by MHFs
-            created by the Default Maintenance Domain. If this object
-            has the value send-if-defer, Sender ID TLV transmission 
-            for this VLAN is controlled by md-id-permission-type.";
+            included in the Sender ID TLV transmitted by this MHF. If 
+            this object has the value send-id-defer, Sender ID TLV 
+            transmission for this VLAN is controlled by 
+            md-id-permission-type.";
           reference
             "12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
         }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-types.yang
@@ -32,238 +32,6 @@ module ieee802-dot1q-cfm-types {
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
   
-  /* -----------------------------------------------------
-   * Type definitions used by 802.1AB -LLDP YANG module.
-   *
-   *   NOTE: These types will be moved to the IEEE 802.1AB
-   *         YANG module at the appropriate time.
-   * -----------------------------------------------------
-   */
-  
-  typedef lldp-chassis-id-subtype {
-    type enumeration {
-      enum chassis-component {
-        value 1;
-        description
-          "Represents a chassis identifier based on the value of
-          entPhysicalAlias object (defined in IETF RFC 2737) for a
-          chassis component (i.e., an entPhysicalClass value of
-          chassis(3))";
-      }
-      enum interface-alias {
-        value 2;
-        description
-          "Represents a chassis identifier based on the value of
-          ifAlias object (defined in IETF RFC 2863) for an interface
-          on the containing chassis.";
-      }
-      enum port-component {
-        value 3;
-        description
-          "Represents a chassis identifier based on the value of
-          entPhysicalAlias object (defined in IETF RFC 2737) for a
-          port or backplane component (i.e., entPhysicalClass value of
-          port(10) or backplane(4)), within the containing chassis.";
-      }
-      enum mac-address {
-        value 4;
-        description
-          "Represents a chassis identifier based on the value of a
-          unicast source address (encoded in network byte order and
-          IEEE 802.3 canonical bit order), of a port on the containing
-          chassis as defined in IEEE Std 802-2001.";
-      }
-      enum network-address {
-        value 5;
-        description
-          "Represents a chassis identifier based on a network address,
-          associated with a particular chassis.  The encoded address is
-          actually composed of two fields.  The first field is a
-          single octet, representing the IANA AddressFamilyNumbers
-          value for the specific address type, and the second field is
-          the network address value.";
-      }
-      enum interface-name {
-        value 6;
-        description
-          "Represents a chassis identifier based on the value of
-          ifName object (defined in IETF RFC 2863) for an interface
-          on the containing chassis.";
-      }
-      enum local {
-        value 7;
-        description
-          "Represents a chassis identifier based on a locally defined
-          value.";
-      }
-    }
-    description
-      "The source of a chassis identifier.";
-    reference
-      "LLDP MIB 20050506";
-  }
-  
-  typedef lldp-chassis-id {
-    type string {
-      length "1..255";
-    }
-    description
-      "The format of a chassis identifier string. Objects of this type
-      are always used with an associated lldp-chassis-is-subtype
-      object, which identifies the format of the particular
-      lldp-chassis-id object instance.
-
-      If the associated lldp-chassis-id-subtype object has a value of
-      chassis-component, then the octet string identifies
-      a particular instance of the entPhysicalAlias object
-      (defined in IETF RFC 2737) for a chassis component (i.e.,
-      an entPhysicalClass value of chassis(3)).
-
-      If the associated lldp-chassis-id-subtype object has a value
-      of interface-alias, then the octet string identifies
-      a particular instance of the ifAlias object (defined in
-      IETF RFC 2863) for an interface on the containing chassis.
-      If the particular ifAlias object does not contain any values,
-      another chassis identifier type should be used.
-
-      If the associated lldp-chassis-id-subtype object has a value
-      of port-component, then the octet string identifies a
-      particular instance of the entPhysicalAlias object (defined
-      in IETF RFC 2737) for a port or backplane component within
-      the containing chassis.
-
-      If the associated lldp-chassis-id-subtype object has a value of
-      mac-address, then this string identifies a particular
-      unicast source address (encoded in network byte order and
-      IEEE 802.3 canonical bit order), of a port on the containing
-      chassis as defined in IEEE Std 802-2001.
-
-      If the associated lldp-chassis-id-subtype object has a value of
-      network-address, then this string identifies a particular
-      network address, encoded in network byte order, associated
-      with one or more ports on the containing chassis.  The first
-      octet contains the IANA Address Family Numbers enumeration
-      value for the specific address type, and octets 2 through
-      N contain the network address value in network byte order.
-
-      If the associated lldp-chassis-id-subtype object has a value
-      of interface-name, then the octet string identifies
-      a particular instance of the ifName object (defined in
-      IETF RFC 2863) for an interface on the containing chassis.
-      If the particular ifName object does not contain any values,
-      another chassis identifier type should be used.
-
-      If the associated lldp-chassis-id-subtype object has a value of
-      local, then this string identifies a locally assigned
-      Chassis ID.";
-    reference
-      "LLDP MIB 20050506";
-  }
-  
-  typedef lldp-port-id-subtype {
-    type enumeration {
-      enum interface-alias {
-        value 1;
-        description
-          "Represents a port identifier based on the ifAlias
-          MIB object, defined in IETF RFC 2863.";
-      }
-      enum port-component {
-        value 2;
-        description
-          "Represents a port identifier based on the value of
-          entPhysicalAlias (defined in IETF RFC 2737) for a port
-          component (i.e., entPhysicalClass value of port(10)), 
-          within the containing chassis.";
-      }
-      enum mac-address {
-        value 3;
-        description
-          "Represents a port identifier based on a unicast source
-          address (encoded in network byte order and IEEE 802.3
-          canonical bit order), which has been detected by the agent
-          and associated with a particular port (IEEE Std 802-2001).";
-      }
-      enum network-address {
-        value 4;
-        description
-          "Represents a port identifier based on a network address,
-          detected by the agent and associated with a particular 
-          port.";
-      }
-      enum interface-name {
-        value 5;
-        description
-          "Represents a port identifier based on the ifName MIB object,
-          defined in IETF RFC 2863.";
-      }
-      enum agent-circuit-id {
-        value 6;
-        description
-          "Represents a port identifier based on the agent-local
-          identifier of the circuit (defined in RFC 3046), detected by
-          the agent and associated with a particular port.";
-      }
-      enum local {
-        value 7;
-        description
-          "Represents a port identifier based on a value locally
-          assigned.";
-      }
-    }
-    description
-      "The source of a particular type of port identifier used
-      in the LLDP YANG module.";
-  }
-  
-  typedef lldp-port-id {
-    type string {
-      length "8";
-    }
-    description
-      "The format of a port identifier string. Objects of this type
-      are always used with an associated lldp-port-id-subtype object,
-      which identifies the format of the particular lldp-port-id
-      object instance.
-
-      If the associated lldp-port-id-subtype object has a value of
-      interface-alias, then the octet string identifies a
-      particular instance of the ifAlias object (defined in IETF
-      RFC 2863).  If the particular ifAlias object does not contain
-      any values, another port identifier type should be used.
-
-      If the associated lldp-port-id-subtype object has a value of
-      port-component, then the octet string identifies a
-      particular instance of the entPhysicalAlias object (defined
-      in IETF RFC 2737) for a port or backplane component.
-
-      If the associated lldp-port-id-subtype object has a value of
-      mac-address, then this string identifies a particular
-      unicast source address (encoded in network byte order
-      and IEEE 802.3 canonical bit order) associated with the port
-      (IEEE Std 802-2001).
-
-      If the associated lldp-port-id-subtype object has a value of
-      network-address, then this string identifies a network
-      address associated with the port.  The first octet contains
-      the IANA AddressFamilyNumbers enumeration value for the
-      specific address type, and octets 2 through N contain the
-      networkAddress address value in network byte order.
-
-      If the associated lldp-port-id-subtype object has a value of
-      interface-name, then the octet string identifies a
-      particular instance of the ifName object (defined in IETF
-      RFC 2863).  If the particular ifName object does not contain
-      any values, another port identifier type should be used.
-
-      If the associated lldp-port-id-subtype object has a value of
-      agent-circuit-id, then this string identifies a agent-local
-      identifier of the circuit (defined in RFC 3046).
-
-      If the associated lldp-port-id-subtype object has a value of
-      local, then this string identifies a locally assigned port ID.";
-  }
-  
   /* ------------------------------------------------------
    * Type definitions used by 802.1Qcx YANG module.
    * ------------------------------------------------------
@@ -375,22 +143,7 @@ module ieee802-dot1q-cfm-types {
       The value (-1) is reserved to indicate that no MA Level has
       been assigned.";
   }
-  
-  typedef component-identifier-type {
-    type uint32 {
-      range "1..4294967295";
-    }
-    description
-      "The component identifier is used to distinguish between the
-      multiple virtual Bridge instances within a PB or PBB. Each
-      virtual Bridge instance is called a component. In simple
-      situations where there is only a single component the default
-      value is 1. The component is identified by a component
-      identifier unique within the BEB and by a MAC address unique
-      within the PBBN. Each component is associated with a Backbone
-      Edge Bridge (BEB) Configuration managed object.";
-  }
-  
+
   typedef port-status-tlv-value {
     type enumeration {
       enum no-port-state-tlv {
@@ -957,5 +710,101 @@ module ieee802-dot1q-cfm-types {
     description
       "The transaction identifer or sequence number of the CFM PDU.";
   }
+  
+  typedef service-selector-type {
+    type enumeration {
+      enum ieee-reserved-0 {
+        value 0;
+        description
+        "Reserved for definition by IEEE 802.1 recommend to not
+        use zero unless absolutely needed.";
+      }
+      enum vlan-id {
+        value 1;
+        description
+        "12-bit identifier found in a VLAN tag.";
+      }
+      enum isid {
+        value 2;
+        description
+        "24-bit identifier found in an I-TAG.";
+      }
+      enum tesid {
+        value 3;
+        description
+        "32-bit identifier";
+      }
+      enum segid {
+        value 4;
+        description
+        "32-bit identifier";
+      }
+      enum path-tesid {
+        value 5;
+        description
+        "32-bit identifier";
+      }
+      enum group-isid {
+        value 6;
+        description
+        "24 bit identifier";
+      }
+      enum ieee-reserved {
+        value 7;
+        description
+        "Reserved for definition by IEEE 802.1";
+      }
+    }
+    default "vlan-id";
+    description
+      "A value that represents a type (and thereby the format)
+      of a service-selector-value.";
+    }
+  
+    typedef service-selector-value {
+      type uint32 {
+        range "1..4294967295";
+      }
+      description
+        "An integer that uniquely identifies a generic MAC Service,
+        or none. Examples of service selectors are a VLAN-ID
+        (IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
+        An service-selector-value value is always interpreted
+        within the context of an service-selector-type value.
+        Every usage of the service-selector-value textual
+        convention is required to specify the
+        service-selector-type object that provides the context.
+        The value of an service-selector-value object must
+        always be consistent with the value of the associated
+        service-selector-type object. Attempts to set an
+        service-selector-value object to a value inconsistent
+        with the associated service-selector-type must fail
+        with an inconsistent-value error.";
+    }
+    
+    typedef service-selector-value-or-none {
+      type uint32 {
+        range "0 | 1..4294967295";
+      }
+      description
+        "An integer that uniquely identifies a generic MAC Service,
+        or none. Examples of service selectors are a VLAN-ID
+        (IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
+        An service-selector-value value is always interpreted
+        within the context of an service-selector-type value.
+        Every usage of the service-selector-value textual
+        convention is required to specify the
+        service-selector-type object that provides the context.
+        The value of an service-selector-value object must
+        always be consistent with the value of the associated
+        service-selector-type object. Attempts to set an
+        service-selector-value object to a value inconsistent
+        with the associated service-selector-type must fail
+        with an inconsistent-value error.
+        The special value of zero is used to indicate that no
+        service selector is present or used. This can be used in
+        any situation where an object or a table entry MUST either
+        refer to a specific service, or not make a selection.";
+    }
   
 } // ieee802-dot1q-cfm-types

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -5,6 +5,7 @@ module ieee802-dot1q-cfm {
   prefix "dot1q-cfm";
   
   import ieee802-dot1q-cfm-types { prefix "cfm-types"; }
+  import ieee802-dot1ab-types { prefix "lldp-types"; }
   import ieee802-dot1q-types { prefix "dot1q-types"; }
   import ieee802-types { prefix "ieee"; }
   import ietf-yang-types { prefix "yang"; }
@@ -57,7 +58,7 @@ module ieee802-dot1q-cfm {
    * -------------------------------------------------
    */
   
-  grouping mac-address-and-uint-type {
+  grouping mac-address-and-uint-type-grouping {
     description
       "The MAC address and uint type grouping.";
     container mac-address-and-uint-type {
@@ -76,7 +77,7 @@ module ieee802-dot1q-cfm {
     }   
   }
   
-  grouping md-name-choice {
+  grouping md-name-choice-grouping {
     description
       "The Maintenance Domain name and name format choice.";
     choice md-name {
@@ -114,7 +115,7 @@ module ieee802-dot1q-cfm {
         }
       }
       case mac-address-and-uint {
-          uses mac-address-and-uint-type;
+          uses mac-address-and-uint-type-grouping;
           description
             "MAC address plus 2-octet (unsigned) integer.";
       }
@@ -132,7 +133,7 @@ module ieee802-dot1q-cfm {
     }
   }
   
-  grouping ma-name-choice {
+  grouping ma-name-choice-grouping {
     description
       "The Maintenance Association name and name format choice.";
     choice ma-name {
@@ -324,7 +325,7 @@ module ieee802-dot1q-cfm {
         leaf udp-ipv6z-address {
           type inet:ipv6-address;
           description
-            "UDP IPv6 zone index.";
+            "UDP IPv6 address.";
         }        
         leaf udp-ipv6z-index {
           type uint32;
@@ -709,133 +710,123 @@ module ieee802-dot1q-cfm {
       "Connectivity Fault Management configuration and operational
       information.";
     
-    container maintenance-domains {
+    list maintenance-domain {
+      key "md-id";
       description
-        "A Maintenance Domain object is required in order to create an
-        MA with a Maintenance Association Identifier (MAID) that
-        includes that Maintenance Domains Name. From this Maintenance
-        Domain managed object, all Maintenance Association managed
-        objects associated with that Maintenance Domain managed object
-        can be accessed, and thus controlled.";
-
-      list maintenance-domain {
-        key "md-id";
+        "Contains the Maintenance Domain configuration and 
+        operational data. A Maintenance Domain is the network or the
+        part of the network for which faults in connectivity can be
+        managed. The boundary of a Maintenance Domain is defined by
+        a set of Domain Service Access Points (DoSAPs), each of 
+        which can become a point of connectivity to a service 
+        instance.";
+      leaf md-id {
+        type cfm-types:name-key-type;
         description
-          "Contains the Maintenance Domain configuration and 
-          operational data. A Maintenance Domain is the network or the
-          part of the network for which faults in connectivity can be
-          managed. The boundary of a Maintenance Domain is defined by
-          a set of Domain Service Access Points (DoSAPs), each of 
-          which can become a point of connectivity to a service 
-          instance.";
-        leaf md-id {
+          "The index to the Maintenance Domain list.";
+      }
+      uses md-name-choice-grouping;
+      leaf md-level {
+        type cfm-types:md-level-type;
+        default 0;
+        description
+          "The Maintenance Domain level.";
+        reference
+          "3.122, 12.14.5.1.3b of IEEE Std 802.1Q-2018";
+      }
+      leaf mhf-creation {
+        type cfm-types:mhf-creation-type;
+        default mhf-none;
+        description
+          "Value indicating whether the management entity can
+          create MHFs (MIP Half Function) for this Maintenance
+          Domain. Since there is no encompassing Maintenance
+          Domain, the value mhf-defer is not allowed.";
+        reference
+          "3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
+      }
+      leaf id-permission {
+        type cfm-types:sender-id-permission-type;
+        default send-id-none;
+        description
+          "Value indicating what, if anything, is to be included in
+          the Sender ID TLV transmitted by Maintenance Points
+          configured in this Maintenance Domain. Since there is no
+          encompassing Maintenance Domain, the value send-id-defer
+          is not allowed.";
+        reference
+          "3.122, 12.14.5.1.3d of IEEE Std 802.1Q-2018";
+      }
+      leaf fault-alarm-address {
+        type cfm-types:fault-alarm-address-type;
+        default "not-transmitted";
+        description
+          "A value indicating whether Fault Alarms are to be 
+          transmitted or not. The default is not transmit.";
+        reference
+          "3.122, 12.14.5.1.3e of IEEE Std 802.1Q-2018";
+      }
+      
+      list maintenance-association {
+        key "ma-id";
+        description
+          "Provides configuration and operational data for the
+          Maintenance Associations. A Maintenance Association is a 
+          set of MEPs, each configured with the same MAID and MD 
+          level, established to verify the integrity of a single
+          service instance. A Maintenance Association can be thought
+          of as a full mesh of Maintenance Entities among a set of
+          MEPs so configured.";
+        leaf ma-id {
           type cfm-types:name-key-type;
-          description
-            "The index to the Maintenance Domain list.";
+          description 
+            "Key of the Maintenance Association list of entries.";
         }
-        uses md-name-choice;
-        leaf md-level {
-          type cfm-types:md-level-type;
-          default 0;
+        uses ma-name-choice-grouping;
+        leaf ccm-interval {
+          type cfm-types:cfm-interval-type;
+          default "1sec";
           description
-            "The Maintenance Domain level.";
+            "The interval between CCM transmissions to be used by all
+            MEPs in the Maintenance Association.";
           reference
-            "3.122, 12.14.5.1.3b of IEEE Std 802.1Q-2018";
-        }
-        leaf mhf-creation {
-          type cfm-types:mhf-creation-type;
-          default mhf-none;
-          description
-            "Value indicating whether the management entity can
-            create MHFs (MIP Half Function) for this Maintenance
-            Domain. Since there is no encompassing Maintenance
-            Domain, the value mhf-defer is not allowed.";
-          reference
-            "3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
-        }
-        leaf id-permission {
-          type cfm-types:sender-id-permission-type;
-          default send-id-none;
-          description
-            "Value indicating what, if anything, is to be included in
-            the Sender ID TLV transmitted by Maintenance Points
-            configured in this Maintenance Domain. Since there is no
-            encompassing Maintenance Domain, the value send-id-defer
-            is not allowed.";
-          reference
-            "3.122, 12.14.5.1.3d of IEEE Std 802.1Q-2018";
+            "12.14.6.1.3e of IEEE Std 802.1Q-2018";
         }
         leaf fault-alarm-address {
           type cfm-types:fault-alarm-address-type;
-          default "not-transmitted";
+          default "not-specified";
           description
             "A value indicating whether Fault Alarms are to be 
-            transmitted or not. The default is not transmit.";
+            transmitted or not. The default is not specified, 
+            which implies that the disposition of the fault-alarm
+            used by the MD should be used.";
           reference
             "3.122, 12.14.5.1.3e of IEEE Std 802.1Q-2018";
         }
         
-        list maintenance-association {
-          key "ma-id";
+        list maintenance-association-mep-list {
+          key mep-id;
           description
-            "Provides configuration and operational data for the
-            Maintenance Associations. A Maintenance Association is a 
-            set of MEPs, each configured with the same MAID and MD 
-            level, established to verify the integrity of a single
-            service instance. A Maintenance Association can be thought
-            of as a full mesh of Maintenance Entities among a set of
-            MEPs so configured.";
-          leaf ma-id {
-            type cfm-types:name-key-type;
-            description 
-              "Key of the Maintenance Association list of entries.";
-          }
-          uses ma-name-choice;
-          leaf ccm-interval {
-            type cfm-types:cfm-interval-type;
-            default "1sec";
+            "The list of all MEPs that belong to this Maintenance
+            Association.";
+          leaf mep-id {
+            type cfm-types:mep-id-type;
             description
-              "The interval between CCM transmissions to be used by all
-              MEPs in the Maintenance Association.";
+              "Integer that is unique among all the MEPs in the
+              same Maintenance Association.";
             reference
-              "12.14.6.1.3e of IEEE Std 802.1Q-2018";
+              "12.14.6.1.3g of IEEE Std 802.1Q-2018";
           }
-          leaf fault-alarm-address {
-            type cfm-types:fault-alarm-address-type;
-            default "not-specified";
-            description
-              "A value indicating whether Fault Alarms are to be 
-              transmitted or not. The default is not specified, 
-              which implies that the disposition of the fault-alarm
-              used by the MD should be used.";
-            reference
-              "3.122, 12.14.5.1.3e of IEEE Std 802.1Q-2018";
-          }
-          
-          list maintenance-association-mep-list {
-            key mep-id;
-            description
-              "The list of all MEPs that belong to this Maintenance
-              Association.";
-            leaf mep-id {
-              type cfm-types:mep-id-type;
-              description
-                "Integer that is unique among all the MEPs in the
-                same Maintenance Association.";
-              reference
-                "12.14.6.1.3g of IEEE Std 802.1Q-2018";
-            }
-          } // maintenance-association-mep-list
-        } // maintenance-association
-      } // maintenance-domain
-    } // maintenance-domains
+        } // maintenance-association-mep-list
+      } // maintenance-association
+    } // maintenance-domain
     
     list maintenance-association-group {
       key "maintenance-group";
       description
-        "The list of maintenance groups, which are uniquely associated
-        with a maintenance domain, maintenance association, for which
-        the MEPs belong.";
+        "The list of maintenance association groups, which are 
+        uniquely associated with a maintenance domain, maintenance
+        association, for which the MEPs belong.";
       leaf maintenance-group {
         type maintenance-group-type;
         description
@@ -844,17 +835,16 @@ module ieee802-dot1q-cfm {
       }
       leaf md-name {
         type leafref {
-          path '/cfm/maintenance-domains/maintenance-domain/md-id';
+          path '/cfm/maintenance-domain/md-id';
         }
         mandatory true;
         description
           "A reference to the maintenance domain that this
           maintenance group is associated with.";
       }
-
       leaf ma-name {
         type leafref {
-          path '/cfm/maintenance-domains'
+          path '/cfm'
              + '/maintenance-domain[md-id = current()/../md-name]'
              + '/maintenance-association/ma-id';
         }
@@ -898,8 +888,7 @@ module ieee802-dot1q-cfm {
           Entity for each of the other MEPs in the same MA.";
         leaf mep-id {
           type leafref {
-            path '/cfm/maintenance-domains'
-              + '/maintenance-domain'
+            path '/cfm/maintenance-domain'
               + '[md-id = current()/../../md-name]'
               + '/maintenance-association'
               + '[ma-id = current()/../../ma-name]'
@@ -1066,8 +1055,7 @@ module ieee802-dot1q-cfm {
             in the Maintenance Domain.";
           leaf rmep-id {
             type leafref {
-              path '/cfm/maintenance-domains'
-                + '/maintenance-domain'
+              path '/cfm/maintenance-domain'
                 + '[md-id = current()/../../../md-name]'
                 + '/maintenance-association'
                 + '[ma-id = current()/../../../ma-name]'
@@ -1147,7 +1135,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3g, 20.19.4 of IEEE Std 802.1Q-2018";
           }
           leaf chassis-id-subtype {
-            type cfm-types:lldp-chassis-id-subtype;
+            type lldp-types:chassis-id-subtype-type;
             config false;
             description
               "This object specifies the format of the Chassis ID
@@ -1156,7 +1144,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
           }
           leaf chassis-id {
-            type cfm-types:lldp-chassis-id;
+            type lldp-types:chassis-id-type;
             config false;
             description
               "The Chassis ID. The format of this object is
@@ -1204,14 +1192,6 @@ module ieee802-dot1q-cfm {
               the MEPs VID(s).";
             reference
               "12.14.7.1.3h of IEEE Std 802.1Q-2018";
-          }
-          leaf ccm-interval {
-            type cfm-types:cfm-interval-type;
-            description
-              "The interval between CCM transmissions to be used by all
-              MEPs in the Maintenance Association.";
-            reference
-              "12.14.6.1.3e of IEEE Std 802.1Q-2018";
           }
         } // continuity-check
         
@@ -1319,36 +1299,64 @@ module ieee802-dot1q-cfm {
         description
           "To signal to the MEP to transmit some number of LBMs.";
         input {
-          leaf lbm-dest-is-mep-id {
-            type boolean;
-            default "false";
+          choice destination {
+            default dest-ucast-mac-address;
             description
-              "TRUE indicates that MEP ID of the target MEP is used
-              for Loopback transmissions. FALSE indicates that
-              unicast destination MAC address of the target MEP is
-              used for Loopback transmissions.";
-            reference
-              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-          }
-          leaf lbm-dest-mac-address {
-            type ieee:mac-address;
-            description
-              "The target MAC Address field to be transmitted.
-              A unicast destination MAC address. This address
-              is used if node lbm-dest-is-mep-id is FALSE.";
-            reference
-              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-          }
-          leaf lbm-dest-mep-id {
-            type cfm-types:mep-id-or-zero-type;
-            default 0;
-            description
-              "The identifier of a remote MEP in the same MA to
-              which the LBM is to be sent. This address
-              is used if node mep-transmit-lbm-dest-is-mep-id
-              is TRUE.";
-            reference
-              "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+              "Selects the destination address type (which is
+              either MEP identifier or MAC address) used
+              for the Loopback transmissions.";
+            case dest-ucast-mac-address {
+              description
+                "The target unicast MAC Address field to be 
+                transmitted. A unicast destination MAC address.";
+              leaf lbm-dest-ucast-mac-address {
+                type ieee:mac-address;
+                description
+                  "The target MAC Address field to be transmitted.
+                  A unicast destination MAC address.";
+                reference
+                  "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+              }
+            }
+            case dest-mcast-class1-mac-address {
+              description
+                "The target multicast Class 1 MAC address field to be
+                transmitted.";
+              leaf lbm-dest-mcast-class1-mac-address {
+                type ieee:mac-address;
+                must '. = "01-80-C2-00-00-30" or '+
+                     '. = "01-80-C2-00-00-31" or '+
+                     '. = "01-80-C2-00-00-32" or '+
+                     '. = "01-80-C2-00-00-33" or '+
+                     '. = "01-80-C2-00-00-34" or '+
+                     '. = "01-80-C2-00-00-35" or '+
+                     '. = "01-80-C2-00-00-36" or '+
+                     '. = "01-80-C2-00-00-37"' {
+                 description
+                   "The multicast class 1 MAC address must take the
+                   form of 01-80-C2-00-00-3x, where x represents
+                   the MEG level, with x being a value in the range
+                   of 0..7.";
+               }
+                description
+                  "The target multicast Class 1 MAC address field to
+                  be transmitted";
+              }
+            }
+            case dest-mep-id {
+              description
+                "The identifier of a remote MEP in the same MA to
+                which the LBM is to be sent.";
+              leaf lbm-dest-mep-id {
+                type cfm-types:mep-id-or-zero-type;
+                default 0;
+                description
+                  "The identifier of a remote MEP in the same MA to
+                  which the LBM is to be sent.";
+                reference
+                  "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+              }
+            }
           }
           leaf interval {
             type cfm-types:cfm-interval-type;
@@ -1432,36 +1440,39 @@ module ieee802-dot1q-cfm {
               "The interval between LTM transmissions to be used by all
               MEPs in the Maintenance Association.";
           }
-          leaf ltm-target-is-mep-id {
-            type boolean;
-            default "false";
+          choice target {
+            default target-ucast-mac-address;
             description
-              "TRUE indicates that MEP id of the target MEP is used
-              for Linktrace transmission. FALSE indicates that
-              unicast destination MAC address of the target MEP is
-              used for LinkTrace transmission.";
-            reference
-              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-          }
-          leaf ltm-target-mac-address {
-            type ieee:mac-address;
-            description
-              "The target MAC address field to be transmitted. A
-              unicast MAC address. This address will be used if the
-              value of mep-transmit-ltm-target-is-mep-id is FALSE.";
-            reference
-              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-          }
-          leaf ltm-target-mep-id {
-            type cfm-types:mep-id-or-zero-type;
-            default 0;
-            description
-              "The target MAC address field to be transmitted. The
-              MEP identifier of another MEP in the same MA. This
-              address will be used if the value of 
-              mep-transmit-ltm-target-is-mep-id is TRUE.";
-            reference
-              "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+              "Selects the target address type (which is
+              either MEP identifier or MAC address) used
+              for the Linktrace transmissions.";
+            case target-ucast-mac-address {
+              description
+                "The target MAC address field to be transmitted. A
+                unicast MAC address.";
+              leaf ltm-target-mac-address {
+                type ieee:mac-address;
+                description
+                  "The target MAC address field to be transmitted. A
+                  unicast MAC address.";
+                reference
+                  "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+              }
+            }
+            case target-mep-id {
+              description
+                "The target MAC address field to be transmitted. The
+                MEP identifier of another MEP in the same MA.";
+              leaf ltm-target-mep-id {
+                type cfm-types:mep-id-or-zero-type;
+                default 0;
+                description
+                  "The target MAC address field to be transmitted. The
+                  MEP identifier of another MEP in the same MA.";
+                reference
+                  "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+              }
+            }
           }
           leaf ltm-priority {
             type dot1q-types:priority-type;
@@ -1695,7 +1706,7 @@ module ieee802-dot1q-cfm {
             "12.14.7.5.3g, 20.41.2.5 of IEEE Std 802.1Q-2018";
         }           
         leaf ltr-chassis-id-subtype {
-          type cfm-types:lldp-chassis-id-subtype;
+          type lldp-types:chassis-id-subtype-type;
           config false;
           description
             "Specifies the format of the Chassis ID returned
@@ -1706,7 +1717,7 @@ module ieee802-dot1q-cfm {
             "12.14.7.5.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
         }           
         leaf ltr-chassis-id {
-          type cfm-types:lldp-chassis-id;
+          type lldp-types:chassis-id-type;
           config false;
           description
             "The Chassis ID returned in the Sender ID TLV of 
@@ -1747,7 +1758,7 @@ module ieee802-dot1q-cfm {
             "12.14.7.5.3l, 20.41.2.7 of IEEE Std 802.1Q-2018";
         }           
         leaf ltr-ingress-port-id-subtype {
-          type cfm-types:lldp-port-id-subtype;
+          type lldp-types:port-id-subtype-type;
           config false;
           description
             "Ingress Port ID. The format of this object is 
@@ -1781,7 +1792,7 @@ module ieee802-dot1q-cfm {
             "12.14.7.5.3p, 20.41.2.11 of IEEE Std 802.1Q-2018";
         }           
         leaf ltr-egress-port-id-subtype {
-          type cfm-types:lldp-port-id-subtype;
+          type lldp-types:port-id-subtype-type;
           config false;
           description
             "Format of the egress Port ID. If the ltr-egress
@@ -1791,7 +1802,7 @@ module ieee802-dot1q-cfm {
             "12.14.7.5.3q, 20.41.2.12 of IEEE Std 802.1Q-2018";
         }           
         leaf ltr-egress-port-id {
-          type cfm-types:lldp-port-id;
+          type lldp-types:port-id-type;
           config false;
           description
             "Egress Port ID. The format of this object is
@@ -1817,7 +1828,6 @@ module ieee802-dot1q-cfm {
         }
       } // linktrace-reply
     } // cfm-operation
-    
   } // cfm
   
 } // ieee802-dot1q-cfm


### PR DESCRIPTION
Clean YANG Validation

**ieee802-dot1q-types.yang**
Pyang Validation
ieee802-dot1q-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm.yang**
Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw maintenance-domain* [md-id]
       |  +--rw md-id                        cfm-types:name-key-type
       |  +--rw (md-name)?
       |  |  +--:(ieee-reserved-0)
       |  |  |  +--rw name?                        string
       |  |  +--:(none)
       |  |  |  +--rw none?                        empty
       |  |  +--:(dns-like-name)
       |  |  |  +--rw dns-like-name?               string
       |  |  +--:(mac-address-and-uint)
       |  |  |  +--rw mac-address-and-uint-type
       |  |  |     +--rw address?   ieee:mac-address
       |  |  |     +--rw int?       uint16
       |  |  +--:(char-string)
       |  |     +--rw char-string?                 string
       |  +--rw md-level?                    cfm-types:md-level-type
       |  +--rw mhf-creation?                cfm-types:mhf-creation-type
       |  +--rw id-permission?               cfm-types:sender-id-permission-type
       |  +--rw fault-alarm-address?         cfm-types:fault-alarm-address-type
       |  +--rw maintenance-association* [ma-id]
       |     +--rw ma-id                               cfm-types:name-key-type
       |     +--rw (ma-name)?
       |     |  +--:(ieee-reserved-0)
       |     |  |  +--rw name?                               string
       |     |  +--:(primary-vid)
       |     |  |  +--rw primary-vid?                        dot1q-types:vlanid
       |     |  +--:(char-string)
       |     |  |  +--rw char-string?                        string
       |     |  +--:(unsigned-int16)
       |     |  |  +--rw unsigned-int16?                     uint16
       |     |  +--:(rfc2865-vpn-id)
       |     |  |  +--rw rfc2865-vpn-id?                     string
       |     |  +--:(icc-format)
       |     |     +--rw icc-format?                         string
       |     +--rw ccm-interval?                       cfm-types:cfm-interval-type
       |     +--rw fault-alarm-address?                cfm-types:fault-alarm-address-type
       |     +--rw maintenance-association-mep-list* [mep-id]
       |        +--rw mep-id    cfm-types:mep-id-type
       +--rw maintenance-association-group* [maintenance-group]
       |  +--rw maintenance-group    maintenance-group-type
       |  +--rw md-name              -> /cfm/maintenance-domain/md-id
       |  +--rw ma-name              -> /cfm/maintenance-domain[md-id = current()/../md-name]/maintenance-association/ma-id
       |  +--rw mhf-creation?        cfm-types:mhf-creation-type
       |  +--rw id-permission?       cfm-types:sender-id-permission-type
       |  +--rw mep* [mep-id]
       |     +--rw mep-id                     -> /cfm/maintenance-domain[md-id = current()/../../md-name]/maintenance-association[ma-id = current()/../../ma-name]/maintenance-association-mep-list/mep-id
       |     +--rw direction?                 cfm-types:mp-direction-type
       |     +--rw primary-vid?               uint32
       |     +--rw admin-state?               boolean
       |     +--ro fng-state?                 cfm-types:fng-state-type
       |     +--rw ccm-ltm-priority?          dot1q-types:priority-type
       |     +--ro mac-address?               ieee:mac-address
       |     +--rw fault-alarm-address?       cfm-types:fault-alarm-address-type
       |     +--rw lowest-priority-defect?    cfm-types:lowest-alarm-priority-type
       |     +--rw fng-alarm-time?            yang:zero-based-counter32
       |     +--rw fng-reset-time?            yang:zero-based-counter32
       |     +--ro highest-priority-defect?   cfm-types:highest-defect-priority-type
       |     +--ro defects?                   cfm-types:mep-defects-type
       |     +--ro error-ccm-last-failure?    string
       |     +--ro xcon-ccm-last-failure?     string
       |     +--rw mep-db* [rmep-id]
       |     |  +--rw rmep-id                     -> /cfm/maintenance-domain[md-id = current()/../../../md-name]/maintenance-association[ma-id = current()/../../../ma-name]/maintenance-association-mep-list/mep-id
       |     |  +--ro rmep-state?                 cfm-types:remote-mep-state-type
       |     |  +--ro rmep-failed-ok-time?        yang:zero-based-counter32
       |     |  +--ro mac-address?                ieee:mac-address
       |     |  +--ro rdi?                        boolean
       |     |  +--ro port-status-tlv?            cfm-types:port-status-tlv-value
       |     |  +--ro interface-status-tlv?       cfm-types:interface-status-tlv-value
       |     |  +--ro chassis-id-subtype?         lldp-types:chassis-id-subtype-type
       |     |  +--ro chassis-id?                 lldp-types:chassis-id-type
       |     |  +--rw transport-service-domain
       |     |  |  +--rw (management-address-domain)?
       |     |  |     +--:(udp-ipv4)
       |     |  |     |  +--rw udp-ipv4-domain?      yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv4-address?     inet:ipv4-address
       |     |  |     |  +--rw udp-ipv4-port?        inet:port-number
       |     |  |     +--:(udp-ipv6)
       |     |  |     |  +--rw udp-ipv6-domain?      yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv6-address?     inet:ipv6-address
       |     |  |     |  +--rw udp-ipv6-port?        inet:port-number
       |     |  |     +--:(udp-ipv4z)
       |     |  |     |  +--rw udp-ipv4z-domain?     yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw udp-ipv4z-index?      uint32
       |     |  |     |  +--rw udp-ipv4z-port?       inet:port-number
       |     |  |     +--:(udp-ipv6z)
       |     |  |     |  +--rw udp-ipv6z-domain?     yang:object-identifier-128
       |     |  |     |  +--rw udp-ipv6z-address?    inet:ipv6-address
       |     |  |     |  +--rw udp-ipv6z-index?      uint32
       |     |  |     |  +--rw udp-ipv6z-port?       inet:port-number
       |     |  |     +--:(tcp-ipv4)
       |     |  |     |  +--rw tcp-ipv4-domain?      yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv4-address?     inet:ipv4-address
       |     |  |     |  +--rw tcp-ipv4-port?        inet:port-number
       |     |  |     +--:(tcp-ipv6)
       |     |  |     |  +--rw tcp-ipv6-domain?      yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv6-address?     inet:ipv6-address
       |     |  |     |  +--rw tcp-ipv6-port?        inet:port-number
       |     |  |     +--:(tcp-ipv4z)
       |     |  |     |  +--rw tcp-ipv4z-domain?     yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw tcp-ipv4z-index?      uint32
       |     |  |     |  +--rw tcp-ipv4z-port?       inet:port-number
       |     |  |     +--:(tcp-ipv6z)
       |     |  |     |  +--rw tcp-ipv6z-domain?     yang:object-identifier-128
       |     |  |     |  +--rw tcp-ipv6z-address?    inet:ipv6-address
       |     |  |     |  +--rw tcp-ipv6z-index?      uint32
       |     |  |     |  +--rw tcp-ipv6z-port?       inet:port-number
       |     |  |     +--:(sctp-ipv4)
       |     |  |     |  +--rw sctp-ipv4-domain?     yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv4-address?    inet:ipv4-address
       |     |  |     |  +--rw sctp-ipv4-port?       inet:port-number
       |     |  |     +--:(sctp-ipv6)
       |     |  |     |  +--rw sctp-ipv6-domain?     yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv6-address?    inet:ipv6-address
       |     |  |     |  +--rw sctp-ipv6-port?       inet:port-number
       |     |  |     +--:(sctp-ipv4z)
       |     |  |     |  +--rw sctp-ipv4z-domain?    yang:object-identifier-128
       |     |  |     |  +--rw sctp-iv4z-address?    inet:ipv4-address
       |     |  |     |  +--rw sctp-ipv4z-index?     uint32
       |     |  |     |  +--rw sctp-ipv4z-port?      inet:port-number
       |     |  |     +--:(sctp-ipv6z)
       |     |  |     |  +--rw sctp-ipv6z-domain?    yang:object-identifier-128
       |     |  |     |  +--rw sctp-ipv6z-address?   inet:ipv6-address
       |     |  |     |  +--rw sctp-ipv6z-index?     uint32
       |     |  |     |  +--rw sctp-ipv6z-port?      inet:port-number
       |     |  |     +--:(local)
       |     |  |     |  +--rw local-domain?         yang:object-identifier-128
       |     |  |     |  +--rw local-address?        string
       |     |  |     +--:(udp-dns)
       |     |  |     |  +--rw udp-dns-domain?       yang:object-identifier-128
       |     |  |     |  +--rw udp-dns-address?      string
       |     |  |     +--:(tcp-dns)
       |     |  |     |  +--rw tcp-dns-domain?       yang:object-identifier-128
       |     |  |     |  +--rw tcp-dns-address?      string
       |     |  |     +--:(sctp-dns)
       |     |  |        +--rw sctp-dns-domain?      yang:object-identifier-128
       |     |  |        +--rw sctp-dns-address?     string
       |     |  +--rw rmep-is-active?             boolean
       |     +--rw continuity-check
       |     |  +--rw ccm-enabled?   boolean
       |     |  +--rw priority?      dot1q-types:priority-type
       |     +--ro stats
       |     |  +--ro mep-ccm-sequence-errors?   yang:counter64
       |     |  +--ro mep-ccms-sent?             yang:counter64
       |     |  +--ro mep-lbr-in?                yang:counter64
       |     |  +--ro mep-lbr-in-out-of-order?   yang:counter64
       |     |  +--ro mep-lbr-bad-msdu?          yang:counter64
       |     |  +--ro mep-unexpected-ltr-in?     yang:counter64
       |     |  +--ro mep-lbr-out?               yang:counter64
       |     +---n mep-fault-alarm
       |        +---- mep-priority-defect?   -> ../../highest-priority-defect
       +--rw cfm-operation* [maintenance-group mep-id]
          +--rw maintenance-group     -> /cfm/maintenance-association-group/maintenance-group
          +--rw mep-id                -> /cfm/maintenance-association-group[maintenance-group = current()/../maintenance-group]/mep/mep-id
          +---x transmit-loopback
          |  +---w input
          |  |  +---w (destination)?
          |  |  |  +--:(dest-ucast-mac-address)
          |  |  |  |  +---w lbm-dest-ucast-mac-address?          ieee:mac-address
          |  |  |  +--:(dest-mcast-class1-mac-address)
          |  |  |  |  +---w lbm-dest-mcast-class1-mac-address?   ieee:mac-address
          |  |  |  +--:(dest-mep-id)
          |  |  |     +---w lbm-dest-mep-id?                     cfm-types:mep-id-or-zero-type
          |  |  +---w interval?                            cfm-types:cfm-interval-type
          |  |  +---w lbm-messages?                        uint32
          |  |  +---w lbm-priority?                        dot1q-types:priority-type
          |  |  +---w lbm-drop-eligible?                   boolean
          |  |  +---w lbm-data-tlv?                        cfm-types:lbm-data-tlv-type
          |  +--ro output
          |     +--ro lbm-result-ok?    boolean
          |     +--ro lbm-seq-number?   cfm-types:seq-number-type
          +---x transmit-linktrace
          |  +---w input
          |  |  +---w interval?                 cfm-types:cfm-interval-type
          |  |  +---w (target)?
          |  |  |  +--:(target-ucast-mac-address)
          |  |  |  |  +---w ltm-target-mac-address?   ieee:mac-address
          |  |  |  +--:(target-mep-id)
          |  |  |     +---w ltm-target-mep-id?        cfm-types:mep-id-or-zero-type
          |  |  +---w ltm-priority?             dot1q-types:priority-type
          |  |  +---w ltm-drop-eligible?        boolean
          |  |  +---w ltm-ttl?                  uint32
          |  |  +---w ltm-flags?                cfm-types:mep-tx-ltm-flags-type
          |  +--ro output
          |     +--ro ltm-result-ok?           boolean
          |     +--ro ltm-seq-number?          cfm-types:seq-number-type
          |     +--ro ltm-egress-identifier?   string
          +--rw loopback-reply* [lbr-seq-number lbr-receive-order]
          |  +--rw lbr-seq-number       cfm-types:seq-number-type
          |  +--rw lbr-receive-order    uint32
          |  +--ro result-ok?           boolean
          +--rw linktrace-reply* [ltr-seq-number ltr-receive-order]
             +--rw ltr-seq-number                   cfm-types:seq-number-type
             +--rw ltr-receive-order                uint32
             +--ro ltr-ttl?                         uint32
             +--ro ltr-forwarded?                   boolean
             +--ro ltr-terminal-mep?                boolean
             +--ro ltr-last-egress-identifier?      string
             +--ro ltr-next-egress-identifier?      string
             +--ro ltr-relay?                       cfm-types:relay-action-field-value
             +--ro ltr-chassis-id-subtype?          lldp-types:chassis-id-subtype-type
             +--ro ltr-chassis-id?                  lldp-types:chassis-id-type
             +--ro ltr-transport-service-domain
             |  +--ro (management-address-domain)?
             |     +--:(udp-ipv4)
             |     |  +--ro udp-ipv4-domain?      yang:object-identifier-128
             |     |  +--ro udp-ipv4-address?     inet:ipv4-address
             |     |  +--ro udp-ipv4-port?        inet:port-number
             |     +--:(udp-ipv6)
             |     |  +--ro udp-ipv6-domain?      yang:object-identifier-128
             |     |  +--ro udp-ipv6-address?     inet:ipv6-address
             |     |  +--ro udp-ipv6-port?        inet:port-number
             |     +--:(udp-ipv4z)
             |     |  +--ro udp-ipv4z-domain?     yang:object-identifier-128
             |     |  +--ro udp-ipv4z-address?    inet:ipv4-address
             |     |  +--ro udp-ipv4z-index?      uint32
             |     |  +--ro udp-ipv4z-port?       inet:port-number
             |     +--:(udp-ipv6z)
             |     |  +--ro udp-ipv6z-domain?     yang:object-identifier-128
             |     |  +--ro udp-ipv6z-address?    inet:ipv6-address
             |     |  +--ro udp-ipv6z-index?      uint32
             |     |  +--ro udp-ipv6z-port?       inet:port-number
             |     +--:(tcp-ipv4)
             |     |  +--ro tcp-ipv4-domain?      yang:object-identifier-128
             |     |  +--ro tcp-ipv4-address?     inet:ipv4-address
             |     |  +--ro tcp-ipv4-port?        inet:port-number
             |     +--:(tcp-ipv6)
             |     |  +--ro tcp-ipv6-domain?      yang:object-identifier-128
             |     |  +--ro tcp-ipv6-address?     inet:ipv6-address
             |     |  +--ro tcp-ipv6-port?        inet:port-number
             |     +--:(tcp-ipv4z)
             |     |  +--ro tcp-ipv4z-domain?     yang:object-identifier-128
             |     |  +--ro tcp-ipv4z-address?    inet:ipv4-address
             |     |  +--ro tcp-ipv4z-index?      uint32
             |     |  +--ro tcp-ipv4z-port?       inet:port-number
             |     +--:(tcp-ipv6z)
             |     |  +--ro tcp-ipv6z-domain?     yang:object-identifier-128
             |     |  +--ro tcp-ipv6z-address?    inet:ipv6-address
             |     |  +--ro tcp-ipv6z-index?      uint32
             |     |  +--ro tcp-ipv6z-port?       inet:port-number
             |     +--:(sctp-ipv4)
             |     |  +--ro sctp-ipv4-domain?     yang:object-identifier-128
             |     |  +--ro sctp-ipv4-address?    inet:ipv4-address
             |     |  +--ro sctp-ipv4-port?       inet:port-number
             |     +--:(sctp-ipv6)
             |     |  +--ro sctp-ipv6-domain?     yang:object-identifier-128
             |     |  +--ro sctp-ipv6-address?    inet:ipv6-address
             |     |  +--ro sctp-ipv6-port?       inet:port-number
             |     +--:(sctp-ipv4z)
             |     |  +--ro sctp-ipv4z-domain?    yang:object-identifier-128
             |     |  +--ro sctp-iv4z-address?    inet:ipv4-address
             |     |  +--ro sctp-ipv4z-index?     uint32
             |     |  +--ro sctp-ipv4z-port?      inet:port-number
             |     +--:(sctp-ipv6z)
             |     |  +--ro sctp-ipv6z-domain?    yang:object-identifier-128
             |     |  +--ro sctp-ipv6z-address?   inet:ipv6-address
             |     |  +--ro sctp-ipv6z-index?     uint32
             |     |  +--ro sctp-ipv6z-port?      inet:port-number
             |     +--:(local)
             |     |  +--ro local-domain?         yang:object-identifier-128
             |     |  +--ro local-address?        string
             |     +--:(udp-dns)
             |     |  +--ro udp-dns-domain?       yang:object-identifier-128
             |     |  +--ro udp-dns-address?      string
             |     +--:(tcp-dns)
             |     |  +--ro tcp-dns-domain?       yang:object-identifier-128
             |     |  +--ro tcp-dns-address?      string
             |     +--:(sctp-dns)
             |        +--ro sctp-dns-domain?      yang:object-identifier-128
             |        +--ro sctp-dns-address?     string
             +--ro ltr-ingress?                     cfm-types:ingress-action-field-value
             +--ro ltr-ingress-mac?                 ieee:mac-address
             +--ro ltr-ingress-port-id-subtype?     lldp-types:port-id-subtype-type
             +--ro ltr-egress?                      cfm-types:egress-action-field-value
             +--ro ltr-egress-mac?                  ieee:mac-address
             +--ro ltr-egress-port-id-subtype?      lldp-types:port-id-subtype-type
             +--ro ltr-egress-port-id?              lldp-types:port-id-type
             +--ro ltr-organization-specific-tlv?   string
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1ab-types.yang**
Pyang Validation
ieee802-dot1ab-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm-mip.yang**
Pyang Validation
ieee802-dot1q-cfm-mip.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-mip
  augment /dot1q-cfm:cfm:
    +--rw mips
       +--rw mip* [mip-id]
          +--rw mip-id           cfm-types:name-key-type
          +--rw md-level?        cfm-types:md-level-type
          +--rw id-permission?   cfm-types:sender-id-permission-type
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ieee802-dot1q-bridge.yang
Pyang Validation


ieee802-dot1q-cfm-types.yang
----------------------------
Pyang Validation
ieee802-dot1q-cfm-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

**ieee802-dot1q-cfm-bridge.yang**
Pyang Validation
ieee802-dot1q-cfm-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-bridge
  augment /dot1q-cfm:cfm:
    +--ro cfm-stacks
    |  +--ro cfm-stack* [port md-level direction service-selector service-id]
    |     +--ro port                 port-ref
    |     +--ro md-level             cfm-types:md-level-type
    |     +--ro direction            cfm-types:mp-direction-type
    |     +--ro service-selector     cfm-types:service-selector-type
    |     +--ro service-id           cfm-types:service-selector-value
    |     +--ro maintenance-group?   -> /dot1q-cfm:cfm/maintenance-association-group/maintenance-group
    |     +--ro md-id?               cfm-types:name-key-type
    |     +--ro ma-id?               -> /dot1q-cfm:cfm/maintenance-domain[dot1q-cfm:md-id = current()/../md-id]/maintenance-association/ma-id
    |     +--ro mep-id?              -> /dot1q-cfm:cfm/maintenance-association-group[dot1q-cfm:maintenance-group = current()/../maintenance-group]/mep/mep-id
    |     +--ro mac-address?         ieee:mac-address
    +--rw default-md-levels
    |  +--rw default-md-level* [bridge-id component-id primary-service-id service-selector]
    |     +--rw bridge-id                 bridge-ref
    |     +--rw component-id              -> /dot1q:bridges/bridge[dot1q:name = current()/../bridge-id]/component/name
    |     +--rw service-selector          cfm-types:service-selector-type
    |     +--rw primary-service-id        cfm-types:service-selector-value
    |     +--rw associated-service-ids
    |     |  +--rw (service-id)?
    |     |     +--:(none)
    |     |     |  +--rw zero?         uint32
    |     |     +--:(vid)
    |     |     |  +--rw vid*          dot1q-types:vlanid
    |     |     +--:(isid)
    |     |     |  +--rw isid?         uint32
    |     |     +--:(tesid)
    |     |     |  +--rw tesid?        uint32
    |     |     +--:(segid)
    |     |     |  +--rw segid?        uint32
    |     |     +--:(path-tesid)
    |     |     |  +--rw path-tesid?   uint32
    |     |     +--:(group-isid)
    |     |        +--rw group-isid?   uint32
    |     +--ro md-status?                boolean
    |     +--rw md-level?                 cfm-types:md-level-or-none-type
    |     +--rw mhf-creation?             cfm-types:mhf-creation-type
    |     +--rw id-permission?            cfm-types:sender-id-permission-type
    +--ro config-errors
       +--ro config-error* [port service-id service-selector]
          +--ro port                port-ref
          +--ro service-selector    cfm-types:service-selector-type
          +--ro service-id          cfm-types:service-selector-value
          +--ro error-type?         cfm-types:config-error-type
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-association-group:
    +--rw bridge-id?          bridge-ref
    +--rw component-name?     -> /dot1q:bridges/bridge[dot1q:name = current()/../cfm-bridge:bridge-id]/dot1q:component/name
    +--rw service-selector?   cfm-types:service-selector-type
    +--rw service-id?         cfm-types:service-selector-value
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-association-group/dot1q-cfm:mep:
    +--rw port?   port-ref
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
