### PR TITLE
Make 802.1Qcx D0.5 updates

### DIFF
--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-bridge.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-bridge.yang
@@ -156,324 +156,278 @@ module ieee802-dot1q-cfm-bridge {
       "Augment the base/common CFM model with CFM IEEE 802.1Qcp 
       Bridge configuration specific attributes.";
     
-    container cfm-stacks {
+    list cfm-stack {
+      key "port md-level direction service-selector service-id";
       config false;
-      description 
+      description
         "The CFM Stack contains information about the Maintenance
         Points configured on a particular Bridge Port (or
         aggregated port). It contains all CFM Stack specific related
-        configuration and operational data.";
-      
-      list cfm-stack {
-        key "port md-level direction service-selector service-id";
+        configuration and operational data.
+        
+        Upon a restart of the system, the system SHALL, if necessary,
+        change the value of this variable, and rearrange the
+        cfm-stack, so that it indexes the entry in the
+        interface table with the same value of interface-ref that it
+        indexed before the system restart. If no such entry exists,
+        then the system SHALL delete all entries in the
+        cfm-stack with the interface index.";     
+      leaf port {
+        type port-ref;
         description
-          "The CFM Stack contains information about the Maintenance
-          Points configured on a particular Bridge Port (or
-          aggregated port). It contains all CFM Stack specific related
-          configuration and operational data.
-          
-          Upon a restart of the system, the system SHALL, if necessary,
-          change the value of this variable, and rearrange the
-          cfm-stack, so that it indexes the entry in the
-          interface table with the same value of interface-ref that it
-          indexed before the system restart. If no such entry exists,
-          then the system SHALL delete all entries in the
-          cfm-stack with the interface index.";     
-        leaf port {
-          type port-ref;
-          description
-            "An interface on which maintenance points might be 
-            configured. This object represents the Bridge Port or 
-            aggregated port on which MEPs or MHFs might be 
-            configured.";
-          reference
-            "12.14.2.1.2a of IEEE Std 802.1Q-2018";
+          "An interface on which maintenance points might be 
+          configured. This object represents the Bridge Port or 
+          aggregated port on which MEPs or MHFs might be 
+          configured.";
+        reference
+          "12.14.2.1.2a of IEEE Std 802.1Q-2018";
+      }
+      leaf md-level {
+        type cfm-types:md-level-type;
+        description
+          "The MD level of the maintenance point";
+        reference
+          "12.14.2.1.2b  of IEEE Std 802.1Q-2018";
+      }
+      leaf direction {
+        type cfm-types:mp-direction-type;
+        description
+          "The direction in which the maintenance point faces on the 
+          Bridge Port.";
+        reference
+          "12.14.2.1.2c of IEEE Std 802.1Q-2018";     
+      }
+      leaf service-selector {
+        type cfm-types:service-selector-type;
+        description
+          "The type of the service selector";
+      }
+      leaf service-id {
+        type cfm-types:service-selector-value-type;
+        description
+          "A VID, I-SID, Traffic Engineering service 
+          instance Identifier (TE-SID), or Segment Identifier
+          (SEG-ID) associated with an MP, or 0, in the case that
+          the MP is associated with no VID, I-SID, TE-SID, or SEG-ID.";
+        reference
+          "12.14.2.1.2d of IEEE Std 802.1Q-2018";
+      }
+      leaf maintenance-group-id {
+        type leafref {
+          path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-group'
+            + '/dot1q-cfm:maintenance-group-id';
         }
-        leaf md-level {
-          type cfm-types:md-level-type;
-          description
-            "The MD level of the maintenance point";
-          reference
-            "12.14.2.1.2b  of IEEE Std 802.1Q-2018";
+        config false;
+        description
+          "The maintenance group to which the Maintenance Points
+          is associated with.";
+      }
+      leaf mep-id {
+        type leafref {
+          path '/dot1q-cfm:cfm'
+            + '/dot1q-cfm:maintenance-group'
+            + '[dot1q-cfm:maintenance-group-id = current()'
+            + '/../maintenance-group-id]'
+            + '/dot1q-cfm:mep/dot1q-cfm:mep-id';
         }
-        leaf direction {
-          type cfm-types:mp-direction-type;
-          description
-            "The direction in which the maintenance point faces on the 
-            Bridge Port.";
-          reference
-            "12.14.2.1.2c of IEEE Std 802.1Q-2018";     
-        }
-        leaf service-selector {
-          type cfm-types:service-selector-type;
-          description
-            "The type of the service selector";
-        }
-        leaf service-id {
-          type cfm-types:service-selector-value;
-          description
-            "A specific VID, I-SID, Traffic Engineering service 
-            instance Identifier (TE-SID), or Segment Identifier
-            (SEG-ID) associated with an MP, or 0, in the case that
-            the MP is associated with no VID, I-SID, TE-SID, or SEG-ID.";
-          reference
-            "12.14.2.1.2d of IEEE Std 802.1Q-2018";
-        }
-        /*
-        container service-id {
-          description 
-            "A specific VID, I-SID, Traffic Engineering service 
-            instance Identifier (TE-SID), or Segment Identifier
-            (SEG-ID) associated with an MP, or 0, in the case that
-            the MP is associated with no VID, I-SID, TE-SID, or SEG-ID";
-          uses service-id-grouping;
-        }
-        */
-        leaf maintenance-group {
-          type leafref {
-            path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-association-group'
-              + '/dot1q-cfm:maintenance-group';
-          }
-          description
-            "The maintenance group to which the Maintenance Points
-            is associated with.";
-        }
-        leaf md-id {
-          type cfm-types:name-key-type;
-          description
-            "The Maintenance Domain reference to which the Maintenance
-            Points Maintenance Association is associated. If none,
-            then null string.";
-          reference
-            "12.14.2.1.3b of IEEE Std 802.1Q-2018";
-        }
-        leaf ma-id {
-          type leafref {
-            path '/dot1q-cfm:cfm'
-              + '/dot1q-cfm:maintenance-domain'
-              + '[dot1q-cfm:md-id = current()/../md-id]'
-              + '/dot1q-cfm:maintenance-association'
-              + '/dot1q-cfm:ma-id';
-          }
-          description
-            "The Maintenance Association reference to which the 
-            Maintenance Point is associated. If none, then 0.";
-          reference
-            "12.14.2.1.3c of IEEE Std 802.1Q-2018";
-        }
-        leaf mep-id {
-          type leafref {
-            path '/dot1q-cfm:cfm'
-              + '/dot1q-cfm:maintenance-association-group'
-              + '[dot1q-cfm:maintenance-group = current()'
-              + '/../maintenance-group]'
-              + '/dot1q-cfm:mep/dot1q-cfm:mep-id';
-          }
-          description
-            "The MEP identifier if a MEP is configured. Otherwise is 0.";
-          reference
-            "12.14.2.1.3d of IEEE Std 802.1Q-2018";
-        }
-        leaf mac-address {
-          type ieee:mac-address;
-          description
-            "The MAC address of the maintenance point.";
-          reference
-            "12.14.2.1.3e of IEEE Std 802.1Q-2018";
-        }
-      }  // cfm-stack
-    } // cfm-stacks
+        description
+          "The MEP identifier if a MEP is configured. Does not exist
+          if the maintenance point is a MHF.";
+        reference
+          "12.14.2.1.3d of IEEE Std 802.1Q-2018";
+      }
+      leaf mac-address {
+        type ieee:mac-address;
+        mandatory true;
+        description
+          "The MAC address of the maintenance point.";
+        reference
+          "12.14.2.1.3e of IEEE Std 802.1Q-2018";
+      }
+      leaf mp {
+        type cfm-types:mp-type;
+        config false;
+        description
+          "Indicates the type of maintenance point. That is whether a
+          MEP or MHF.";
+        reference
+          "12.14.2.1.3a of IEEE Std 802.1Q-2018";
+      }
+    }  // cfm-stack
     
-    container default-md-levels {
+    list default-md-level {
+      key "bridge-id component-id primary-service-id service-selector";
       description
-        "There is a single Default MD Level managed object per Bridge
-        Component. It controls MIP Half Function (MHF) creation for
-        VIDs or I-SIDs of I- or B-components that are not contained in
-        the list of VIDs attached to any specific Maintenance 
-        Association managed object, and the transmission of the Sender
-        ID TLV by those MHFs.";
-      
-      list default-md-level {
-        key "bridge-id component-id primary-service-id service-selector";
+        "For each bridge component, the Default MD Level Managed 
+        Object controls MHF creation for VIDs that are not attached
+        to a specific Maintenance Association Managed Object, and
+        Sender ID TLV transmission by those MHFs.
+        
+        For each Bridge Port, and for each VLAN ID whose data can
+        pass through that Bridge Port, an entry in this table is
+        used by the algorithm in subclause 22.2.3 only if there is no
+        entry in the Maintenance Association table defining an MA
+        for the same VLAN ID and MD Level as this table's entry, and
+        on which MA an Up MEP is defined. If there exists such an
+        MA, that MA's objects are used by the algorithm in
+        subclause 22.2.3 in place of this table entry objects.
+        
+        The agent maintains the value of md-status to indicate
+        whether this entry is overridden by an MA. When first
+        initialized, the agent creates this table automatically with
+        entries for all VLAN IDs, with the default values specified
+        for each object. After this initialization, the writable
+        objects in this table need to be persistent upon reboot or
+        restart of a device.";
+      leaf bridge-id {
+        type bridge-ref;
         description
-          "For each bridge component, the Default MD Level Managed 
-          Object controls MHF creation for VIDs that are not attached
-          to a specific Maintenance Association Managed Object, and
-          Sender ID TLV transmission by those MHFs.
+          "The reference to the IEEE 802.1Q Bridge associated with
+          the CFM objects.";
+      }
+      leaf component-id {
+        type leafref {
+          path '/dot1q:bridges/dot1q:bridge'
+            + '[dot1q:name = current()/../bridge-id]'
+            + '/dot1q:component/dot1q:name';
+        }
+        description
+          "The Bridge component within the system to which the
+          information in this entry applies. If the system is not a
+          Bridge, or if only one component is present in the Bridge,
+          then this variable (index) MUST be equal to 1.";
+        reference
+          "12.3l of IEEE Std 802.1Q-2018";
+      }
+      leaf service-selector {
+        type cfm-types:service-selector-type;
+        description
+          "The type of the service selector";
+      }
+      leaf primary-service-id {
+        type cfm-types:service-selector-value-type;
+        description
+          "A vid or isid in an I or B component.";
+        reference
+          "12.14.3.1.2a of IEEE Std 802.1Q-2018";
+      }
+      container associated-service-ids {
+        description
+          "A list of VIDs associated with any MHF on the VID, always
+          including that VID, or the Backbone-SID of the B-component
+          or VIP-SID of the I-component associated with any MHF on
+          the I-SID. The first VID is the MAs Primary VID.
           
-          For each Bridge Port, and for each VLAN ID whose data can
-          pass through that Bridge Port, an entry in this table is
-          used by the algorithm in subclause 22.2.3 only if there is no
-          entry in the Maintenance Association table defining an MA
-          for the same VLAN ID and MD Level as this table's entry, and
-          on which MA an Up MEP is defined. If there exists such an
-          MA, that MA's objects are used by the algorithm in
-          subclause 22.2.3 in place of this table entry objects.
-          
-          The agent maintains the value of md-status to indicate
-          whether this entry is overridden by an MA. When first
-          initialized, the agent creates this table automatically with
-          entries for all VLAN IDs, with the default values specified
-          for each object. After this initialization, the writable
-          objects in this table need to be persistent upon reboot or
-          restart of a device.";
-        leaf bridge-id {
-          type bridge-ref;
+          List is empty if no primary VID specified.";
+        uses service-id-grouping;
+        reference
+          "12.14.3.1.3a of IEEE Std 802.1Q-2018";
+      }
+      leaf md-status {
+        type boolean;
+        config false;
+        mandatory true;
+        description
+          "A Boolean value indicating whether this entry is in effect
+          or has been overridden by the existence of a Maintenance
+          Association managed object associated with the same VID or
+          I-SID of I- or Bcomponents and MD Level, and on which is
+          configured an Up MEP. True if this Maintenance Domain
+          managed object is in effect.";
+        reference
+          "12.14.3.1.3b of IEEE Std 802.1Q-2018";
+      }
+      leaf md-level {
+        type cfm-types:md-level-type;
+        mandatory true;
+        description
+          "A value indicating the MD Level at which MHFs are to be
+          created, and Sender ID TLV transmission by those MHFs is to
+          be controlled, for the VLAN to which this entry's objects
+          apply.";
+        reference
+          "12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
+      }
+      leaf mhf-creation {
+        type cfm-types:mhf-creation-type;
+        must '. != "mhf-defer"' {
           description
-            "The reference to the IEEE 802.1Q Bridge associated with
-            the CFM objects.";
+            "The value can not be mhf-defer. Must be one of mhf-none,
+            mhf-default, or mfh-explicit.";
         }
-        leaf component-id {
-          type leafref {
-            path '/dot1q:bridges/dot1q:bridge'
-              + '[dot1q:name = current()/../bridge-id]'
-              + '/dot1q:component/dot1q:name';
-          }
+        default "mhf-none";
+        description
+          "An enumerated value indicating whether the management 
+          entity can create MHFs for this VID(s) or I-SID(s) of I- or
+          B-components.";
+        reference
+          "12.14.3.1.3d of IEEE Std 802.1Q-2018";
+        
+      }
+      leaf id-permission {
+        type cfm-types:sender-id-permission-type;
+        must '. != "send-id-defer"' {
           description
-            "The Bridge component within the system to which the
-            information in this entry applies. If the system is not a
-            Bridge, or if only one component is present in the Bridge,
-            then this variable (index) MUST be equal to 1.";
-          reference
-            "12.3l of IEEE Std 802.1Q-2018";
+            "The value can not be send-id-defer. Must be one of 
+            send-id-none, send-id-chassis, send-id-manage,
+            send-id-chassis-manage.";
         }
-        leaf service-selector {
-          type cfm-types:service-selector-type;
-          description
-            "The type of the service selector";
-        }
-        leaf primary-service-id {
-          type cfm-types:service-selector-value;
-          description
-            "A vid or isid in an I or B component.";
-          reference
-            "12.14.3.1.2a of IEEE Std 802.1Q-2018";
-        }
-        /*
-        container primary-service-id {
-          description
-            "A vid or isid in an I or B component.";
-          uses service-id-grouping;
-          reference
-            "12.14.3.1.2a of IEEE Std 802.1Q-2018";
-        }
-        */
-        container associated-service-ids {
-          description
-            "A list of VIDs associated with any MHF on the VID, always
-            including that VID, or the Backbone-SID of the B-component
-            or VIP-SID of the I-component associated with any MHF on
-            the I-SID. The first VID is the MAs Primary VID.
-            
-            List is empty if no primary VID specified.";
-          uses service-id-grouping;
-          reference
-            "12.14.3.1.3a of IEEE Std 802.1Q-2018";
-        }
-        leaf md-status {
-          type boolean;
-          config false;
-          description
-            "State of this Default MD Level table entry. True if there
-            is no entry in the Maintenance Association table defining
-            an MA for the same VLAN ID and MD Level as this tables
-            entry, and on which MA an Up MEP is defined, else false.";
-          reference
-            "12.14.3.1.3b of IEEE Std 802.1Q-2018";
-        }
-        leaf md-level {
-          type cfm-types:md-level-or-none-type;
-          default -1;
-          description
-            "A value indicating the MD Level at which MHFs are to be
-            created, and Sender ID TLV transmission by those MHFs is to
-            be controlled, for the VLAN to which this entry's objects
-            apply.";
-          reference
-            "12.14.3.1.3c, 12.14.3.2.2b of IEEE Std 802.1Q-2018";
-        }
-        leaf mhf-creation {
-          type cfm-types:mhf-creation-type;
-          default "mhf-defer";
-          description
-            "A value indicating if the Management entity can create MHFs
-            (MIP Half Function) for this VID at this MD Level. If this
-            object has the value mhf-defer, MHF creation for this VLAN
-            is controlled by md-mhf-creation. The value of this variable
-            is meaningless if the values of md-status is false.";
-          reference
-            "12.14.3.1.3d of IEEE Std 802.1Q-2018";
-          
-        }
-        leaf id-permission {
-          type cfm-types:sender-id-permission-type;
-          default "send-id-defer";
-          description
-            "Enumerated value indicating what, if anything, is to be
-            included in the Sender ID TLV transmitted by MHFs
-            created by the Default Maintenance Domain. If this object
-            has the value send-if-defer, Sender ID TLV transmission 
-            for this VLAN is controlled by md-id-permission-type. The
-            value of this variable is meaningless if the values of
-            md-status is false.";
-          reference
-            "12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
-        }
-      } // default-md-level
-    } // default-md-levels
+        default "send-id-none";
+        description
+          "An enumerated value indicating what, if anything, is to be
+          included in the Sender ID TLV transmitted by MPs configured
+          in the Default Maintenance Domain..";
+        reference
+          "12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
+      }
+    } // default-md-level
     
-    container config-errors {
+    list config-error {
+      key "port service-id service-selector";
       config false;
       description
-        "The Configuration Error List managed object is a list of
-        {identifier, port} pairs configured in error together with
-        the identity of the configuration error.";
-
-      list config-error {
-        key "port service-id service-selector";
+        "The CFM Configuration Error List table provides a list of
+        Interfaces and VIDs that are incorrectly configured.";
+      leaf port {
+        type port-ref;
         description
-          "The CFM Configuration Error List table provides a list of
-          Interfaces and VIDs that are incorrectly configured.";
-        leaf port {
-          type port-ref;
-          description
-            "The interface index of the interface (i.e., Bridge 
-            Port).
-            
-            Upon a restart of the system, the system SHALL, if 
-            necessary, change the value of this variable so that it
-            indexes the entry in the interface table with the same
-            value of the index that it indexed before the system
-            restart. If no such entry exists, then the system SHALL
-            delete any entries in config-error-list indexed by that
-            interface-ref.";
-          reference
-            "12.14.4.1.2b of IEEE Std 802.1Q-2018";
-        }
-        leaf service-selector {
-          type cfm-types:service-selector-type;
-          description
-            "The type of the service selector";
-        }
-        leaf service-id {
-          type cfm-types:service-selector-value;
-          description
-            "A vid or isid in an I or B component.";
-          reference
-            "12.14.4.1.2a of IEEE Std 802.1Q-2018";
-        }
-        leaf error-type {
-          type cfm-types:config-error-type;
-          description
-            "vector of Boolean error conditions from 22.2.4.";
-          reference
-            "12.14.4.1.3b of IEEE Std 802.1Q-2018";
-        }
-      } // config-error
-    } // config-errors
+          "The interface index of the interface (i.e., Bridge 
+          Port).
+          
+          Upon a restart of the system, the system SHALL, if 
+          necessary, change the value of this variable so that it
+          indexes the entry in the interface table with the same
+          value of the index that it indexed before the system
+          restart. If no such entry exists, then the system SHALL
+          delete any entries in config-error-list indexed by that
+          interface-ref.";
+        reference
+          "12.14.4.1.2b of IEEE Std 802.1Q-2018";
+      }
+      leaf service-selector {
+        type cfm-types:service-selector-type;
+        description
+          "The type of the service selector";
+      }
+      leaf service-id {
+        type cfm-types:service-selector-value-type;
+        description
+          "A vid or isid in an I or B component.";
+        reference
+          "12.14.4.1.2a of IEEE Std 802.1Q-2018";
+      }
+      leaf error-type {
+        type cfm-types:config-error-type;
+        mandatory true;
+        description
+          "vector of Boolean error conditions from 22.2.4.";
+        reference
+          "12.14.4.1.3b of IEEE Std 802.1Q-2018";
+      }
+    } // config-error
   }
   
-  augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-association-group" {
+  augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-group" {
     description
       "Augment the maintenance group list object with the
       maintenance association component identifier, since the 
@@ -486,11 +440,13 @@ module ieee802-dot1q-cfm-bridge {
         the CFM objects.";
     }
     leaf component-name {
+      when "../bridge-id";
       type leafref {
         path '/dot1q:bridges/dot1q:bridge'
           + '[dot1q:name = current()/../cfm-bridge:bridge-id]'
           + '/dot1q:component/dot1q:name';
       }
+      //mandatory true;
       description
         "A reference to the maintenance association component within
         the provided maintenance domain and maintenance association
@@ -502,7 +458,9 @@ module ieee802-dot1q-cfm-bridge {
         "The type of the service selector";
     }
     leaf service-id {
-      type cfm-types:service-selector-value;
+      when "../service-selector";
+      type cfm-types:service-selector-value-type;
+      //mandatory true;
       description
         "A vid or isid in an I or B component.";
       reference
@@ -510,16 +468,17 @@ module ieee802-dot1q-cfm-bridge {
     }
   }
   
-  augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-association-group"
+  augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-group"
         + "/dot1q-cfm:mep" {
     description
       "Augment the MEP object defined in the ieee802-dot1q-mep
       (CFM MEP) YANG module with IEEE 802.1Qcp bridge specific
       attributes.";
     leaf port {
+      when "../../service-selector";
       type port-ref;
       must '/dot1q-cfm:cfm'
-         + '/dot1q-cfm:maintenance-association-group'
+         + '/dot1q-cfm:maintenance-group'
          + '/cfm-bridge:component-name = '
          + '/if:interfaces/if:interface[current() = ./if:name]'
          + '/dot1q:bridge-port/dot1q:component-name' {
@@ -528,6 +487,7 @@ module ieee802-dot1q-cfm-bridge {
           the same as the bridge and component references by the 
           maintenance association group.";
       }
+      //mandatory true;
       description
         "The interface index of the interface (e.g., Bridge 
         Port) to which the MEP is attached.";

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm-types.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm-types.yang
@@ -37,6 +37,27 @@ module ieee802-dot1q-cfm-types {
    * ------------------------------------------------------
    */
   
+  typedef mp-type {
+    type enumeration {
+      enum none {
+        value 0;
+        description
+          "No MP";
+      }
+      enum mhf {
+        value 1;
+        description
+          "Indicates a MHF.";
+      }
+      enum mep {
+        value 2;
+        description
+          "Indicates a MEP.";
+      }
+    }
+    description
+      "Indicates the type of Maintenance Point.";
+  }
   typedef mhf-creation-type {
     type enumeration {
       enum mhf-none {
@@ -102,18 +123,6 @@ module ieee802-dot1q-cfm-types {
       unique over a given Maintenance Association.";
   }
   
-  typedef mep-id-or-zero-type {
-    type uint32 {
-      range "0 | 1..8191";
-    }
-    description
-      "Maintenance association End Point Identifier, which is
-      unique over a given Maintenance Association.
-      
-      The special value 0 is allowed to indicate a special case when
-      there is no MEPID configured.";
-  }
-  
   typedef md-level-type {
     type uint32 {
       range "0..7";
@@ -127,24 +136,8 @@ module ieee802-dot1q-cfm-types {
       physical reach, with the lowest values for CFM PDUs
       protecting single bridges or physical links.";
   }
-  
-  typedef md-level-or-none-type {
-    type int32 {
-      range "-1 | 0..7";
-    }
-    description
-      "Integer identifying the Maintenance Domain Level (MD Level).
-      Higher numbers correspond to higher Maintenance Domains,
-      those with the greatest physical reach, with the highest
-      values for customers CFM packets. Lower numbers correspond
-      to lower Maintenance Domains, those with more limited
-      physical reach, with the lowest values for CFM PDUs
-      protecting single bridges or physical links.
-      The value (-1) is reserved to indicate that no MA Level has
-      been assigned.";
-  }
 
-  typedef port-status-tlv-value {
+  typedef port-status-tlv-value-type {
     type enumeration {
       enum no-port-state-tlv {
         value 0;
@@ -172,48 +165,48 @@ module ieee802-dot1q-cfm-types {
       ordinary data, regardless of the status of the MAC.";
   }
   
-  typedef interface-status-tlv-value {
+  typedef interface-status-tlv-value-type {
     type enumeration {
-      enum is-no-interface-status-tlv {
+      enum no-interface-status-tlv {
         value 0;
         description
           "Indicates either that no CCM has been received or that
           no interface status TLV was present in the last CCM
           received.";
       }
-      enum is-up {
+      enum up {
         value 1;
         description
           "The interface is ready to pass packets.";
       }
-      enum is-down {
+      enum down {
         value 2;
         description
           "The interface can not pass packets.";
       }
-      enum is-testing {
+      enum testing {
         value 3;
         description
           "The interface is in same test mode.";
       }
-      enum is-unknown {
+      enum unknown {
         value 4;
         description
           "The interface status cannot be determined for some
           reason.";
       }
-      enum is-dormant {
+      enum dormant {
         value 5;
         description
           "The interface is not in a state to pass packets but is in
           a pending state, waiting for some extrnal event.";
       }
-      enum is-not-present {
+      enum not-present {
         value 6;
         description
           "Some component of the interface is mssing.";
       }
-      enum is-lower-layer-down {
+      enum lower-layer-down {
         value 7;
         description
           "The interface is down due to state of the lower layer
@@ -354,13 +347,8 @@ module ieee802-dot1q-cfm-types {
       ID TLV transmitted in CCMs, LBMs, LTMs, and LTRs.";
   }
   
-  typedef cfm-interval-type {
+  typedef ccm-interval-type {
     type enumeration {
-      enum invalid {
-        value 0;
-        description
-          "No CFM PDUs are to be sent";
-      }
       enum 300hz {
         value 1;
         description
@@ -438,7 +426,7 @@ module ieee802-dot1q-cfm-types {
       Generator State Machine.";
   }
   
-  typedef relay-action-field-value {
+  typedef relay-action-field-value-type {
     type enumeration {
       enum relay-hit {
         value 1;
@@ -463,13 +451,8 @@ module ieee802-dot1q-cfm-types {
       "Possible values the Relay action field can take.";
   }
   
-  typedef ingress-action-field-value {
+  typedef ingress-action-field-value-type {
     type enumeration {
-      enum ingress-no-tlv {
-        value 0;
-        description
-          "Indicates that no Reply Ingress TLV was returned in the LTM.";
-      }
       enum ingress-ok {
         value 1;
         description
@@ -499,13 +482,8 @@ module ieee802-dot1q-cfm-types {
       "Possible values returned in the ingress action field.";
   }
   
-  typedef egress-action-field-value {
+  typedef egress-action-field-value-type {
     type enumeration {
-      enum egress-no-tlv {
-        value 0;
-        description
-          "Indicates that no Reply Egress TLV was returned in the LTM.";
-      }
       enum egress-okay {
         value 1;
         description
@@ -611,7 +589,7 @@ module ieee802-dot1q-cfm-types {
   
   typedef config-error-type {
     type bits {
-      bit cfm-leaf {
+      bit cfm-leak {
         position 0;
         description
           "MA x is associated with a specific VID list, one or more 
@@ -651,8 +629,13 @@ module ieee802-dot1q-cfm-types {
   
   typedef mep-tx-ltm-flags-type {
     type bits {
-      bit use-fdb-only {
+      bit no-flags {
         position 0;
+        description
+          "No flags set";
+      }
+      bit use-fdb-only {
+        position 1;
         description
           "Use FDB only";
       }
@@ -669,12 +652,6 @@ module ieee802-dot1q-cfm-types {
           "Indicates that a Network address to which Fault Alarms
           are to be transmitted should be used.";
       }
-      enum not-specified {
-        value 2;
-        description
-          "Indicates not specified. In the case of a MA, then the
-          selection used by the MD should be used.";
-      }
       enum not-transmitted {
         value 3;
         description
@@ -686,7 +663,7 @@ module ieee802-dot1q-cfm-types {
   }
   
   typedef lbm-data-tlv-type {
-    type string {
+    type binary {
       length "1..1480";
     }
     description
@@ -696,7 +673,7 @@ module ieee802-dot1q-cfm-types {
   typedef name-key-type {
     type string {
       length "1..255";
-      pattern "[0-9a-zA-Z]*";
+      pattern '[0-9a-zA-Z\-_.]*';
     }
     description
       "The maintenance domains and maintenance association list key type.";
@@ -761,7 +738,7 @@ module ieee802-dot1q-cfm-types {
       of a service-selector-value.";
     }
   
-    typedef service-selector-value {
+    typedef service-selector-value-type {
       type uint32 {
         range "1..4294967295";
       }
@@ -782,7 +759,7 @@ module ieee802-dot1q-cfm-types {
         with an inconsistent-value error.";
     }
     
-    typedef service-selector-value-or-none {
+    typedef service-selector-value-or-none-type {
       type uint32 {
         range "0 | 1..4294967295";
       }

--- a/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/802.1/draft/ieee802-dot1q-cfm.yang
@@ -44,15 +44,6 @@ module ieee802-dot1q-cfm {
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
   
-  typedef maintenance-group-type {
-    type string {
-      length "1..45";
-      pattern "[0-9a-zA-Z]*";
-    }
-    description
-      "The Maintenance Group type";
-  }
-  
   /* -------------------------------------------------
    * Grouping definitions used by 802.1Qcx YANG module
    * -------------------------------------------------
@@ -66,11 +57,13 @@ module ieee802-dot1q-cfm {
         "The MAC address and uint type definition.";
       leaf address {
         type ieee:mac-address;
+        mandatory true;
         description
           "The MAC address.";
       }
       leaf int {
         type uint16;
+        mandatory true;
         description
           "The additional 2-octet (unsigned) integer.";
       }
@@ -84,17 +77,6 @@ module ieee802-dot1q-cfm {
       default char-string;
       description
         "The Maintenance Domain name type.";
-      case ieee-reserved-0 {
-        leaf name {
-          type string {
-            length "0..43";
-          }
-          default "0";
-          description
-            "Reserved for definition by IEEE 802.1 recommend to not use
-            zero unless absolutely needed.";
-        }
-      }
       case none {
         leaf none {
           type empty;
@@ -107,7 +89,7 @@ module ieee802-dot1q-cfm {
       case dns-like-name {
         leaf dns-like-name {
           type string {
-            length "0..43";
+            length "1..43";
           }
           description
             "Domain name like string, globally unique text string
@@ -137,20 +119,9 @@ module ieee802-dot1q-cfm {
     description
       "The Maintenance Association name and name format choice.";
     choice ma-name {
-      default char-string;
+      mandatory true;
       description
         "The Maintenance Association name type.";
-      case ieee-reserved-0 {
-        leaf name {
-          type string {
-            length "1..45";
-          }
-          default "0";
-          description
-            "Reserved for definition by IEEE 802.1. Recommend not to use
-            zero unless absolutely needed.";
-        }
-      }
       case primary-vid {
         leaf primary-vid {
           type dot1q-types:vlanid;
@@ -176,20 +147,28 @@ module ieee802-dot1q-cfm {
         }
       }
       case rfc2865-vpn-id {
-        leaf rfc2865-vpn-id {
-          type string {
-            length "1..45";
-          }
+        container vpn-id {
           description
             "RFC2685 VPN ID. 3 octet VPN authority Organizationally
             Unique Identifier followed by 4 octet VPN index identifying
             VPN according to the OUI.";
+          leaf vpn-oui {
+            type uint32;
+            description
+              "3 octet VPN authority Organizationally Unique
+              Identifier.";
+          }
+          leaf vpn-idex {
+            type uint32;
+            description
+              "4 octet VPN index identifying VPN according to OUI.";
+          }
         }
       }
       case icc-format {
         leaf icc-format {
           type string {
-            length "1..45";
+            length "1..13";
           }
           description
             "ICC-based format as specified in ITU-T Y.1731.";
@@ -229,13 +208,15 @@ module ieee802-dot1q-cfm {
         }
         leaf udp-ipv4-address {
           type inet:ipv4-address;
+          mandatory true;
           description
             "UDP IPv4 address.";
         }
         leaf udp-ipv4-port {
           type inet:port-number;
-            description
-              "UDP IPv4 port.";
+          mandatory true;
+          description
+            "UDP IPv4 port.";
         }
       }
       
@@ -259,11 +240,13 @@ module ieee802-dot1q-cfm {
         }
         leaf udp-ipv6-address {
           type inet:ipv6-address;
+          mandatory true;
           description
             "UDP IPv6 address.";
         }        
         leaf udp-ipv6-port {
           type inet:port-number;
+          mandatory true;
           description
             "UDP IPv6 port.";
         }
@@ -289,16 +272,19 @@ module ieee802-dot1q-cfm {
         }
         leaf udp-ipv4z-address {
           type inet:ipv4-address;
+          mandatory true;
           description
             "UDP IPv4 address.";
         }        
         leaf udp-ipv4z-index {
           type uint32;
+          mandatory true;
           description
             "UDP IPv4 zone index.";
         }
         leaf udp-ipv4z-port {
           type inet:port-number;
+          mandatory true;
           description
             "UDP IPv4 port.";
         }
@@ -324,16 +310,19 @@ module ieee802-dot1q-cfm {
         }
         leaf udp-ipv6z-address {
           type inet:ipv6-address;
+          mandatory true;
           description
             "UDP IPv6 address.";
         }        
         leaf udp-ipv6z-index {
           type uint32;
+          mandatory true;
           description
             "UDP IPv6 zone index.";
         }
         leaf udp-ipv6z-port {
           type inet:port-number;
+          mandatory true;
           description
             "UDP IPv6 port.";
         }
@@ -359,11 +348,13 @@ module ieee802-dot1q-cfm {
         }
         leaf tcp-ipv4-address {
           type inet:ipv4-address;
+          mandatory true;
           description
             "TCP IPv4 address.";
         }        
         leaf tcp-ipv4-port {
           type inet:port-number;
+          mandatory true;
           description
             "TCP IPv4 port.";
         }
@@ -389,11 +380,13 @@ module ieee802-dot1q-cfm {
         }
         leaf tcp-ipv6-address {
           type inet:ipv6-address;
+          mandatory true;
           description
             "TCP IPv6 address.";
         }
         leaf tcp-ipv6-port {
           type inet:port-number;
+          mandatory true;
           description
             "TCP IPv6 port.";
         }
@@ -419,16 +412,19 @@ module ieee802-dot1q-cfm {
         }
         leaf tcp-ipv4z-address {
           type inet:ipv4-address;
+          mandatory true;
           description
             "TCP IPv4 address.";
         }        
         leaf tcp-ipv4z-index {
           type uint32;
+          mandatory true;
           description
             "TCP IPv4 zone index.";
         }
         leaf tcp-ipv4z-port {
           type inet:port-number;
+          mandatory true;
           description
             "TCP IPv4 port.";
         }
@@ -454,16 +450,19 @@ module ieee802-dot1q-cfm {
         }
         leaf tcp-ipv6z-address {
             type inet:ipv6-address;
-          description
-          "TCP IPv6 address.";
+            mandatory true;
+            description
+              "TCP IPv6 address.";
         }          
         leaf tcp-ipv6z-index {
           type uint32;
+          mandatory true;
           description
             "TCP IPv6 zone index.";
         }        
         leaf tcp-ipv6z-port {
           type inet:port-number;
+          mandatory true;
           description
             "TCP IPv6 port.";
         }
@@ -489,11 +488,13 @@ module ieee802-dot1q-cfm {
         }
         leaf sctp-ipv4-address {
           type inet:ipv4-address;
+          mandatory true;
           description
             "SCTP IPv4 address.";
         }        
         leaf sctp-ipv4-port {
           type inet:port-number;
+          mandatory true;
           description
             "SCTP IPv4 port.";
         }
@@ -519,11 +520,13 @@ module ieee802-dot1q-cfm {
         }
         leaf sctp-ipv6-address {
           type inet:ipv6-address;
+          mandatory true;
           description
             "SCTP IPv6 address.";
         }        
         leaf sctp-ipv6-port {
           type inet:port-number;
+          mandatory true;
           description
             "SCTP IPv6 port.";
         }
@@ -549,16 +552,19 @@ module ieee802-dot1q-cfm {
         }
         leaf sctp-iv4z-address {
           type inet:ipv4-address;
+          mandatory true;
           description
             "SCTP IPv4 address.";
         }        
         leaf sctp-ipv4z-index {
           type uint32;
+          mandatory true;
           description
             "SCTP IPv4 zone index.";
         }        
         leaf sctp-ipv4z-port {
           type inet:port-number;
+          mandatory true;
           description
             "SCTP IPv4 port.";
         }
@@ -584,16 +590,19 @@ module ieee802-dot1q-cfm {
         }
         leaf sctp-ipv6z-address {
           type inet:ipv6-address;
+          mandatory true;
           description
             "SCTP IPv6 address.";
         }        
         leaf sctp-ipv6z-index {
           type uint32;
+          mandatory true;
           description
             "SCTP IPv6 zone index.";
         }        
         leaf sctp-ipv6z-port {
           type inet:port-number;
+          mandatory true;
           description
             "SCTP IPv6 port.";
         }
@@ -615,6 +624,7 @@ module ieee802-dot1q-cfm {
           type string {
             length '1..255';
           }
+          mandatory true;
           description
             "Represents a POSIX Local IPC transport address.";
         }
@@ -636,6 +646,7 @@ module ieee802-dot1q-cfm {
           type string {
             length "1..255";
           }
+          mandatory true;
           description
             "The UDP transport domain using fully qualified domain 
              names. Represents a DNS domain name followed by a colon 
@@ -662,6 +673,7 @@ module ieee802-dot1q-cfm {
           type string {
             length "1..255";
           }
+          mandatory true;
           description
             "The TCP transport domain using fully qualified domain 
              names. Represents a DNS domain name followed by a colon 
@@ -688,6 +700,7 @@ module ieee802-dot1q-cfm {
           type string {
             length "1..255";
           }
+          mandatory true;
           description
             "The SCTP transport domain using fully qualified domain 
              names. Represents a DNS domain name followed by a colon 
@@ -784,7 +797,7 @@ module ieee802-dot1q-cfm {
         }
         uses ma-name-choice-grouping;
         leaf ccm-interval {
-          type cfm-types:cfm-interval-type;
+          type cfm-types:ccm-interval-type;
           default "1sec";
           description
             "The interval between CCM transmissions to be used by all
@@ -794,14 +807,33 @@ module ieee802-dot1q-cfm {
         }
         leaf fault-alarm-address {
           type cfm-types:fault-alarm-address-type;
-          default "not-specified";
           description
             "A value indicating whether Fault Alarms are to be 
-            transmitted or not. The default is not specified, 
-            which implies that the disposition of the fault-alarm
+            transmitted or not. If this leaf node is not present
+            then the disposition of the fault-alarm
             used by the MD should be used.";
           reference
             "3.122, 12.14.5.1.3e of IEEE Std 802.1Q-2018";
+        }
+        leaf mhf-creation {
+          type cfm-types:mhf-creation-type;
+          default mhf-defer;
+          description
+            "Value indicating whether the management entity can
+            create MHFs (MIP Half Function) for this Maintenance
+            Domain.";
+          reference
+            "3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
+        }
+        leaf id-permission {
+          type cfm-types:sender-id-permission-type;
+          default "send-id-defer";
+          description
+            "Enumerated value indicating what, if anything, is to
+            be included in the Sender ID TLV (21.5.3) transmitted
+            by MPs configured in this MA.";
+          reference
+            "12.14.3.1.3d of IEEE Std 802.1Q-2018";
         }
         
         list maintenance-association-mep-list {
@@ -821,19 +853,19 @@ module ieee802-dot1q-cfm {
       } // maintenance-association
     } // maintenance-domain
     
-    list maintenance-association-group {
-      key "maintenance-group";
+    list maintenance-group {
+      key "maintenance-group-id";
       description
         "The list of maintenance association groups, which are 
         uniquely associated with a maintenance domain, maintenance
         association, for which the MEPs belong.";
-      leaf maintenance-group {
-        type maintenance-group-type;
+      leaf maintenance-group-id {
+        type cfm-types:name-key-type;
         description
           "The maintenance group provides a handle
           for the MD and MA combination.";
       }
-      leaf md-name {
+      leaf md-id {
         type leafref {
           path '/cfm/maintenance-domain/md-id';
         }
@@ -842,10 +874,10 @@ module ieee802-dot1q-cfm {
           "A reference to the maintenance domain that this
           maintenance group is associated with.";
       }
-      leaf ma-name {
+      leaf ma-id {
         type leafref {
           path '/cfm'
-             + '/maintenance-domain[md-id = current()/../md-name]'
+             + '/maintenance-domain[md-id = current()/../md-id]'
              + '/maintenance-association/ma-id';
         }
         mandatory true;
@@ -853,27 +885,6 @@ module ieee802-dot1q-cfm {
           "A reference to the maintenance association in the specified
           maintenance domain, that this maintanance group is 
           associated with.";
-      }
-      leaf mhf-creation {
-        type cfm-types:mhf-creation-type;
-        default mhf-defer;
-        description
-          "Value indicating whether the management entity can
-          create MHFs (MIP Half Function) for this Maintenance
-          Domain. Since there is no encompassing Maintenance
-          Domain, the value mhf-defer is not allowed.";
-        reference
-          "3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
-      }
-      leaf id-permission {
-        type cfm-types:sender-id-permission-type;
-        default "send-id-defer";
-        description
-          "Enumerated value indicating what, if anything, is to
-          be included in the Sender ID TLV (21.5.3) transmitted
-          by MPs configured in this MA.";
-        reference
-          "12.14.3.1.3d of IEEE Std 802.1Q-2018";
       }
       
       list mep {
@@ -889,9 +900,9 @@ module ieee802-dot1q-cfm {
         leaf mep-id {
           type leafref {
             path '/cfm/maintenance-domain'
-              + '[md-id = current()/../../md-name]'
+              + '[md-id = current()/../../md-id]'
               + '/maintenance-association'
-              + '[ma-id = current()/../../ma-name]'
+              + '[ma-id = current()/../../ma-id]'
               + '/maintenance-association-mep-list'
               + '/mep-id';
           }
@@ -903,6 +914,7 @@ module ieee802-dot1q-cfm {
         }
         leaf direction {
           type cfm-types:mp-direction-type;
+          mandatory true;
           description
             "The direction in which the MEP faces on the Bridge
             Port. Example, up or down.";
@@ -933,18 +945,9 @@ module ieee802-dot1q-cfm {
           reference
             "12.14.7.1.3e, 20.9.1 of IEEE Std 802.1Q-2018";
         }
-        leaf fng-state {
-          type cfm-types:fng-state-type;
-          default "fng-reset";
-          config false;
-          description
-            "The current state of the MEP Fault Notification 
-            Generator state machine.";
-          reference
-            "12.14.7.1.3f, 20.35 of IEEE Std 802.1Q-2018";
-        }
         leaf ccm-ltm-priority {
           type dot1q-types:priority-type;
+          mandatory true;
           description
             "The priority value for CCMs and LTMs transmitted by
             the MEP. The default value is the highest priority 
@@ -956,99 +959,16 @@ module ieee802-dot1q-cfm {
         leaf mac-address {
           type ieee:mac-address;
           config false;
+          mandatory true;
           description
             "The MAC address of the MEP.";
           reference
             "12.14.7.1.3i, 19.4 of IEEE Std 802.1Q-2018";
         }
-        leaf fault-alarm-address {
-          type cfm-types:fault-alarm-address-type;
-          default "not-specified";
-          description
-            "A value indicating whether Fault Alarms are to be 
-            transmitted or not. The default is not specified, 
-            which implies that the disposition of the fault-alarm
-            used by the MD should be used.";
-          reference
-            "3.122, 12.14.7.1.3j of IEEE Std 802.1Q-2018";
-        }
-        leaf lowest-priority-defect {
-          type cfm-types:lowest-alarm-priority-type;
-          default "mac-remote-error-xcon";
-          description
-            "The lowest priority defect that is allowed to
-            generate fault alarms.";
-          reference
-            "12.14.7.1.3k, 20.9.5 of IEEE Std 802.1Q-2018";
-        }
-        leaf fng-alarm-time {
-          type yang:zero-based-counter32 {
-            range "250..1000";
-          }
-          units deciseconds;
-          default 250;
-          description
-            "The time that defect must be present before a Fault
-            Alarm is issued.";
-          reference
-            "12.14.7.1.3l, 20.35.3 of IEEE Std 802.1Q-2018";
-        }
-        leaf fng-reset-time {
-          type yang:zero-based-counter32 {
-            range "250..1000";
-          }
-          units deciseconds;
-          default 1000;
-          description
-            "The time that defects must be absent before 
-            resetting a Fault Alarm.";
-          reference
-            "12.14.7.1.3m, 20.35.4 of IEEE Std 802.1Q-2018";
-        }
-        leaf highest-priority-defect {
-          type cfm-types:highest-defect-priority-type;
-          config false;
-          description
-            "The highest priority defect that has been present
-            sicne the MEPs Fault Notification Generator state
-            machine was last in the FNG_RESET state.";
-          reference
-            "12.14.7.1.3n, 20.35.9 of IEEE Std 802.1Q-2018";
-        }
-        leaf defects {
-          type cfm-types:mep-defects-type;
-          config false;
-          description
-            "Vector of boolean error conditions";
-          reference
-            "12.14.7.1.3o-s, 20.21.3,
-            20.23.3, 20.35.5, 20.35.6, 20.35.7 of IEEE Std 802.1Q-2018";
-        }
-        leaf error-ccm-last-failure {
-          type string {
-            length "1..2000";
-          }
-          config false;
-          description
-            "The last received CCM that triggered a def-error-ccm
-            fault.";
-          reference
-            "12.14.7.1.3t, 20.21.2 of IEEE Std 802.1Q-2018";
-        }
-        leaf xcon-ccm-last-failure {
-          type string {
-            length "1..2000";
-          }
-          config false;
-          description
-            "The last received CCM that triggered a def-xcon-ccm
-            fault.";
-          reference
-            "12.14.7.1.3u, 20.23.2 of IEEE Std 802.1Q-2018";
-        }
         
         list mep-db {
           key rmep-id;
+          config false;
           description
             "The MEP CCM Database. A database, maintained by every 
             MEP, that maintains received information about other MEPs
@@ -1056,9 +976,9 @@ module ieee802-dot1q-cfm {
           leaf rmep-id {
             type leafref {
               path '/cfm/maintenance-domain'
-                + '[md-id = current()/../../../md-name]'
+                + '[md-id = current()/../../../md-id]'
                 + '/maintenance-association'
-                + '[ma-id = current()/../../../ma-name]'
+                + '[ma-id = current()/../../../ma-id]'
                 + '/maintenance-association-mep-list'
                 + '/mep-id';
             }
@@ -1071,7 +991,7 @@ module ieee802-dot1q-cfm {
           }
           leaf rmep-state {
             type cfm-types:remote-mep-state-type;
-            config false;
+            mandatory true;
             description 
               "The operational state of the remote MEP  state
               machine";
@@ -1079,9 +999,9 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3b, 20.20 of IEEE Std 802.1Q-2018";
           }
           leaf rmep-failed-ok-time {
-            type yang:zero-based-counter32;
-            units seconds;
-            config false;
+            type yang:zero-based-counter64;
+            units milliseconds;
+            mandatory true;
             description
               "The time (SysUpTime) at which the Remote MEP state
               machine last entered either the RMEP_FAILED or
@@ -1091,7 +1011,7 @@ module ieee802-dot1q-cfm {
           }
           leaf mac-address {
             type ieee:mac-address;
-            config false;
+            mandatory true;
             description
               "The MAC address of the remote MEP.";
             reference
@@ -1099,7 +1019,7 @@ module ieee802-dot1q-cfm {
           }
           leaf rdi {
             type boolean;
-            config false;
+            mandatory true;
             description
               "State of the RDI bit in the last received CCM
               (true for RDI=1), or false if none has been 
@@ -1108,9 +1028,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3e, 20.19.2 of IEEE Std 802.1Q-2018";
           }
           leaf port-status-tlv {
-            type cfm-types:port-status-tlv-value;
-            default "no-port-state-tlv";
-            config false;
+            type cfm-types:port-status-tlv-value-type;
             description
               "An enumerated value of the Port status TLV 
               received in the last CCM from the remote MEP or 
@@ -1121,9 +1039,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3f, 20.19.3 of IEEE Std 802.1Q-2018";
           }
           leaf interface-status-tlv {
-            type cfm-types:interface-status-tlv-value;
-            default "is-no-interface-status-tlv";
-            config false;
+            type cfm-types:interface-status-tlv-value-type;
             description
               "An enumerated value of the Interface status TLV
               received in the last CCM from the remote MEP or the
@@ -1136,7 +1052,6 @@ module ieee802-dot1q-cfm {
           }
           leaf chassis-id-subtype {
             type lldp-types:chassis-id-subtype-type;
-            config false;
             description
               "This object specifies the format of the Chassis ID
               received in the last CCM.";
@@ -1145,7 +1060,6 @@ module ieee802-dot1q-cfm {
           }
           leaf chassis-id {
             type lldp-types:chassis-id-type;
-            config false;
             description
               "The Chassis ID. The format of this object is
               determined by the value of the 
@@ -1163,6 +1077,7 @@ module ieee802-dot1q-cfm {
           }
           leaf rmep-is-active {
             type boolean;
+            default "true";
             description
               "A Boolean value statign if the remote MEP is 
               active.";
@@ -1183,15 +1098,101 @@ module ieee802-dot1q-cfm {
             reference
               "12.14.7.1.3g, 20.10.1 of IEEE Std 802.1Q-2018";
           }
-          leaf priority {
-            type dot1q-types:priority-type;
+          leaf fng-state {
+            type cfm-types:fng-state-type;
+            default "fng-reset";
+            config false;
             description
-              "The priority value for CCMs and LTMs transmitted by
-              the MEP. The default value is the highest priority 
-              allowed to pass through the Bridge Port for any of
-              the MEPs VID(s).";
+              "The current state of the MEP Fault Notification 
+              Generator state machine.";
             reference
-              "12.14.7.1.3h of IEEE Std 802.1Q-2018";
+              "12.14.7.1.3f, 20.35 of IEEE Std 802.1Q-2018";
+          }
+          leaf fault-alarm-address {
+            type cfm-types:fault-alarm-address-type;
+            description
+              "A value indicating whether Fault Alarms are to be 
+              transmitted or not. The default is not specified, 
+              which implies that the disposition of the fault-alarm
+              used by the MD should be used.";
+            reference
+              "3.122, 12.14.7.1.3j of IEEE Std 802.1Q-2018";
+          }
+          leaf lowest-priority-defect {
+            type cfm-types:lowest-alarm-priority-type;
+            default "mac-remote-error-xcon";
+            description
+              "The lowest priority defect that is allowed to
+              generate fault alarms.";
+            reference
+              "12.14.7.1.3k, 20.9.5 of IEEE Std 802.1Q-2018";
+          }
+          leaf fng-alarm-time {
+            type yang:zero-based-counter32 {
+              range "2500..10000";
+            }
+            units milliseconds;
+            default 2500;
+            description
+              "The time that defect must be present before a Fault
+              Alarm is issued.";
+            reference
+              "12.14.7.1.3l, 20.35.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf fng-reset-time {
+            type yang:zero-based-counter32 {
+              range "2500..10000";
+            }
+            units milliseconds;
+            default 10000;
+            description
+              "The time that defects must be absent before 
+              resetting a Fault Alarm.";
+            reference
+              "12.14.7.1.3m, 20.35.4 of IEEE Std 802.1Q-2018";
+          }
+          leaf highest-priority-defect {
+            type cfm-types:highest-defect-priority-type;
+            config false;
+            mandatory true;
+            description
+              "The highest priority defect that has been present
+              sicne the MEPs Fault Notification Generator state
+              machine was last in the FNG_RESET state.";
+            reference
+              "12.14.7.1.3n, 20.35.9 of IEEE Std 802.1Q-2018";
+          }
+          leaf defects {
+            type cfm-types:mep-defects-type;
+            config false;
+            mandatory true;
+            description
+              "Vector of boolean error conditions";
+            reference
+              "12.14.7.1.3o-s, 20.21.3,
+              20.23.3, 20.35.5, 20.35.6, 20.35.7 of IEEE Std 802.1Q-2018";
+          }
+          leaf error-ccm-last-failure {
+            type binary {
+              length "1..128";
+            }
+            config false;
+            description
+              "The last received CCM that triggered a def-error-ccm
+              fault.";
+            reference
+              "12.14.7.1.3t, 20.21.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf xcon-ccm-last-failure {
+            type binary {
+              length "1..128";
+            }
+            config false;
+            description
+              "The last received CCM that triggered a def-xcon-ccm
+              fault.";
+            reference
+              "12.14.7.1.3u, 20.23.2 of IEEE Std 802.1Q-2018";
           }
         } // continuity-check
         
@@ -1201,6 +1202,7 @@ module ieee802-dot1q-cfm {
             "Contains the counters associated with the MEP.";
           leaf mep-ccm-sequence-errors {
             type yang:counter64;
+            mandatory true;
             description
               "The total number of out-of-sequence CCMs received
               from all remote MEPs.";
@@ -1209,6 +1211,7 @@ module ieee802-dot1q-cfm {
           }
           leaf mep-ccms-sent {
             type yang:counter64;
+            mandatory true;
             description
               "Total number of CCMs transmitted";
             reference
@@ -1216,6 +1219,7 @@ module ieee802-dot1q-cfm {
           }
           leaf mep-lbr-in {
             type yang:counter64;
+            mandatory true;
             description
               "Total number of valid, in-order Loopback Replies
               received.";
@@ -1224,6 +1228,7 @@ module ieee802-dot1q-cfm {
           }
           leaf mep-lbr-in-out-of-order {
             type yang:counter64;
+            mandatory true;
             description
               "The total number of valid, out-of-order
               Loopback Replies received";
@@ -1232,6 +1237,7 @@ module ieee802-dot1q-cfm {
           }
           leaf mep-lbr-bad-msdu {
             type yang:counter64;
+            mandatory true;
             description
               "The total number of LBRs received whose
               mac_service_data_unit did not match (except for the
@@ -1241,6 +1247,7 @@ module ieee802-dot1q-cfm {
           }
           leaf mep-unexpected-ltr-in {
             type yang:counter64;
+            mandatory true;
             description
               "The total number of unexpected LTRs received.";
             reference
@@ -1248,6 +1255,7 @@ module ieee802-dot1q-cfm {
           }
           leaf mep-lbr-out {
             type yang:counter64;
+            mandatory true;
             description
               "Total number of Loopback Replies transmitted.";
             reference
@@ -1255,52 +1263,247 @@ module ieee802-dot1q-cfm {
           }
         } // stats
         
-        notification mep-fault-alarm {
+        action transmit-loopback {
           description
-            "To alert the Manager to the existence of a fault in a
-            monitored MA by issuing a Fault Alarm.";
-          leaf mep-priority-defect {
-            type leafref {
-              path "../../highest-priority-defect";
+            "To signal to the MEP to transmit some number of LBMs.";
+          input {
+            choice destination {
+              mandatory true;
+              description
+                "Selects the destination address type (which is
+                either MEP identifier or MAC address) used
+                for the Loopback transmissions.";
+              case dest-ucast-mac-address {
+                description
+                  "The target unicast MAC Address field to be 
+                  transmitted. A unicast destination MAC address.";
+                leaf lbm-dest-ucast-mac-address {
+                  type ieee:mac-address;
+                  description
+                    "The target MAC Address field to be transmitted.
+                    A unicast destination MAC address.";
+                  reference
+                    "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+                }
+              }
+              case dest-mcast-class1-mac-address {
+                description
+                  "The target multicast Class 1 MAC address field to be
+                  transmitted.";
+                leaf lbm-dest-mcast-class1-mac-address {
+                  type ieee:mac-address;
+                  must '. = "01-80-C2-00-00-30" or '+
+                       '. = "01-80-C2-00-00-31" or '+
+                       '. = "01-80-C2-00-00-32" or '+
+                       '. = "01-80-C2-00-00-33" or '+
+                       '. = "01-80-C2-00-00-34" or '+
+                       '. = "01-80-C2-00-00-35" or '+
+                       '. = "01-80-C2-00-00-36" or '+
+                       '. = "01-80-C2-00-00-37"' {
+                   description
+                     "The multicast class 1 MAC address must take the
+                     form of 01-80-C2-00-00-3x, where x represents
+                     the MEG level, with x being a value in the range
+                     of 0..7.";
+                 }
+                  description
+                    "The target multicast Class 1 MAC address field to
+                    be transmitted";
+                }
+              }
+              case dest-mep-id {
+                description
+                  "The identifier of a remote MEP in the same MA to
+                  which the LBM is to be sent.";
+                leaf lbm-dest-mep-id {
+                  type cfm-types:mep-id-type;
+                  description
+                    "The identifier of a remote MEP in the same MA to
+                    which the LBM is to be sent.";
+                  reference
+                    "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+                }
+              }
             }
+            leaf lbm-messages {
+              type uint32 {
+                range "1..1024";
+              }
+              default 1;
+              description
+                "The number of Loopback messages to be transmitted.";
+              reference
+                "12.14.7.3.2c of IEEE Std 802.1Q-2018";
+            }
+            leaf lbm-priority {
+              type dot1q-types:priority-type;
+              mandatory true;
+              description
+                "Priority. 3 bit value to be used in the VLAN tag, if
+                present in the transmitted frame. The default value
+                should be the CCM priority.";
+              reference
+                "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+            }
+            leaf lbm-drop-eligible {
+              type boolean;
+              default "false";
+              description
+                "Drop eligible bit value to be used in the VLAN tag, if
+                present in the transmitted frame";
+              reference
+                "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+            }
+            leaf lbm-data-tlv {
+              type cfm-types:lbm-data-tlv-type;
+              description
+                "An arbitrary amount of data to be included in the
+                Data TLV, if the Data TLV is selected to be sent. The
+                intent is to be able to fill the frame carrying the
+                CFM PDU to its maximum length.";
+              reference
+                "12.14.7.3.2d of IEEE Std 802.1Q-2018";
+            }
+          } // input
+          output {
+            leaf lbm-request-id {
+              type cfm-types:seq-number-type;
+              mandatory true;
+              description
+                "The Loopback transaction identifier
+                of the first LBM (to be) sent.
+                The value returned is undefined if an RPC
+                error is returned.";
+              reference
+                "12.14.7.3.3b of IEEE Std 802.1Q-2018";
+            }     
+          } // output        
+        } // transmit-loopback
+        
+        action transmit-linktrace {
+          description
+            "To signal to the MEP to transmit an LTM and to create an LTM
+            entry in the MEPs Linktrace Database.";
+          input {
+            choice target {
+              mandatory true;
+              description
+                "Selects the target address type (which is
+                either MEP identifier or MAC address) used
+                for the Linktrace transmissions.";
+              case target-ucast-mac-address {
+                description
+                  "The target MAC address field to be transmitted. A
+                  unicast MAC address.";
+                leaf ltm-target-mac-address {
+                  type ieee:mac-address;
+                  description
+                    "The target MAC address field to be transmitted. A
+                    unicast MAC address.";
+                  reference
+                    "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+                }
+              }
+              case target-mep-id {
+                description
+                  "The target MAC address field to be transmitted. The
+                  MEP identifier of another MEP in the same MA.";
+                leaf ltm-target-mep-id {
+                  type cfm-types:mep-id-type;
+                  description
+                    "The target MAC address field to be transmitted. The
+                    MEP identifier of another MEP in the same MA.";
+                  reference
+                    "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+                }
+              }
+            }
+            leaf ltm-ttl {
+              type uint32 {
+                range "0..255";
+              }
+              default 64;
+              description
+                "The LTM TTL field. Indicates the number of hops 
+                remaining to the LTM. Decremented by 1 by each
+                Linktrace Responder that handles the LTM. The value
+                returned in the LTR is one less than that received in
+                the LTM. If the LTM TTL is 0 or 1, the LTM is not
+                forwarded to the next hop, and if 0, no LTR is 
+                generated.";
+              reference
+                "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
+            }
+            leaf ltm-flags {
+              type cfm-types:mep-tx-ltm-flags-type;
+              default no-flags;
+              description
+                "The flags field for the LTMs transmitted by the MEP.";
+              reference
+                "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
+              
+            }
+          } // input
+          output {
+            leaf ltm-transaction-id {
+              type cfm-types:seq-number-type;
+              mandatory true;
+              description
+                "The LTM transaction identifier 
+                of the LTM sent. The value returned is undefined
+                if and RPC error is returned.";
+              reference
+                "12.14.7.4.3b of IEEE Std 802.1Q-2018";
+            }
+            leaf ltm-egress-identifier {
+              type binary {
+                length "8";
+              }
+              mandatory true;
+              description
+                "Identifies the MEP Linktrace Initiator that is 
+                originating this LTM.
+                
+                The low-order six octets contain a 48-bit IEEE MAC
+                address unique to the system in which the MEP Linktrace
+                Initiator or Linktrace Responder resides. The 
+                high-order two octets contain a value sufficient to 
+                uniquely identify the MEP Linktrace Initiator or 
+                Linktrace Responder within that system.
+                
+                For most Bridges, the address of any MAC attached to
+                the Bridge will suffice for the low-order six octets,
+                and 0 for the high-order octets. In some situations,
+                e.g., if multiple virtual Bridges utilizing emulated
+                LANs are implemented in a single physical system, the
+                high-order two octets can be used to differentiate
+                among the transmitting entities.
+                
+                The value returned is undefined if 
+                mep-transmit-ltm-result is FALSE.";
+              reference
+                "12.14.7.4.3c of IEEE Std 802.1Q-2018";
+            }
+          } // output
+        } // transmit-linktrace
+        
+        list loopback-reply {
+          key "lbm-request-id";
+          config false;
+          description 
+            "This table extends the MEP table and contains a list
+            of Loopback replies received by a specific MEP in
+            response to a loopback message.";
+          leaf lbm-request-id {
+            type cfm-types:seq-number-type;
             description
-              "The highest priority defect that has been present
-              since the MEPs Fault Notification Generator state
-              machine was last in the FNG_RESET state.";
+              "The Loopback transaction identifier
+              of the first LBM (to be) sent.";
+            reference
+              "12.14.7.3.3b of IEEE Std 802.1Q-2018";
           }
-        } // mep-fault-alarm
-      } // mep
-    } // maintenance-association-group
-    
-    list cfm-operation {
-      key "maintenance-group mep-id";
-      description 
-        "A list of CFM commands that can be performed.";
-      leaf maintenance-group {
-        type leafref {
-          path '/cfm/maintenance-association-group/maintenance-group';
-        }
-        description
-          "A reference to the maintenance group.";
-      }
-      leaf mep-id {
-        type leafref {
-          path '/cfm'
-            + '/maintenance-association-group'
-            + '[maintenance-group = current()/../maintenance-group]'
-            + '/mep/mep-id';
-        }
-        description
-          "A reference to a MEP associated with the maintenance
-          group.";
-      }
-      
-      action transmit-loopback {
-        description
-          "To signal to the MEP to transmit some number of LBMs.";
-        input {
           choice destination {
-            default dest-ucast-mac-address;
+            mandatory true;
             description
               "Selects the destination address type (which is
               either MEP identifier or MAC address) used
@@ -1348,8 +1551,7 @@ module ieee802-dot1q-cfm {
                 "The identifier of a remote MEP in the same MA to
                 which the LBM is to be sent.";
               leaf lbm-dest-mep-id {
-                type cfm-types:mep-id-or-zero-type;
-                default 0;
+                type cfm-types:mep-id-type;
                 description
                   "The identifier of a remote MEP in the same MA to
                   which the LBM is to be sent.";
@@ -1357,13 +1559,6 @@ module ieee802-dot1q-cfm {
                   "12.14.7.3.2b of IEEE Std 802.1Q-2018";
               }
             }
-          }
-          leaf interval {
-            type cfm-types:cfm-interval-type;
-            default 1sec;
-            description
-              "The interval between LBM transmissions to be used by all
-              MEPs in the Maintenance Association.";
           }
           leaf lbm-messages {
             type uint32 {
@@ -1377,6 +1572,7 @@ module ieee802-dot1q-cfm {
           }
           leaf lbm-priority {
             type dot1q-types:priority-type;
+            mandatory true;
             description
               "Priority. 3 bit value to be used in the VLAN tag, if
               present in the transmitted frame. The default value
@@ -1403,45 +1599,43 @@ module ieee802-dot1q-cfm {
             reference
               "12.14.7.3.2d of IEEE Std 802.1Q-2018";
           }
-        } // input
-        output {
-          leaf lbm-result-ok {
-            type boolean;
-            default "true";
+          list responses {
+            key "lbr-receive-order";
             description
-              "Indicates the result of the operation:
-                 TRUE - The LBM will be (or has been) sent.
-                 FALSE - The LBM will not be sent.";
-            reference
-              "12.14.7.3.3a of IEEE Std 802.1Q-2018";
+              "The responses associated with the request.";
+            leaf lbr-receive-order {
+              type uint32 {
+                range "1..4294967295";
+              }
+              description
+                "An index to distinguish among multiple LBRs with
+                the same LBR Transaction Identifier field value. 
+                Assigned sequentially from 1, in the order that the 
+                Loopback Initiator received the LBRs. Also used to
+                distinguish between LBRs with different transaction
+                IDs in the same request.";
+            }
           }
-          leaf lbm-seq-number {
+        } // loopback-reply
+        
+        list linktrace-reply {
+          key "ltr-transaction-id";
+          config false;
+          description
+            "This table extends the MEP table and contains a list
+            of Linktrace replies received by a specific MEP in
+            response to a linktrace message.";
+          leaf ltr-transaction-id {
             type cfm-types:seq-number-type;
             description
-              "The Loopback transaction identifier
-              (mep-next-lbm-trans-id) of the first LBM (to be) sent.
-              The value returned is undefined if 
-              mep-transmit-lbm-result-ok is FALSE.";
+              "Transaction identifier returned by a previous
+              transmit linktrace message command, indicating
+              which LTMs response is going to be returned.";
             reference
-              "12.14.7.3.3b of IEEE Std 802.1Q-2018";
-          }     
-        } // output        
-      } // transmit-loopback
-      
-      action transmit-linktrace {
-        description
-          "To signal to the MEP to transmit an LTM and to create an LTM
-          entry in the MEPs Linktrace Database.";
-        input {
-          leaf interval {
-            type cfm-types:cfm-interval-type;
-            default 1sec;
-            description
-              "The interval between LTM transmissions to be used by all
-              MEPs in the Maintenance Association.";
+              "12.14.7.5.2b of IEEE Std 802.1Q-2018";
           }
           choice target {
-            default target-ucast-mac-address;
+            mandatory true;
             description
               "Selects the target address type (which is
               either MEP identifier or MAC address) used
@@ -1464,8 +1658,7 @@ module ieee802-dot1q-cfm {
                 "The target MAC address field to be transmitted. The
                 MEP identifier of another MEP in the same MA.";
               leaf ltm-target-mep-id {
-                type cfm-types:mep-id-or-zero-type;
-                default 0;
+                type cfm-types:mep-id-type;
                 description
                   "The target MAC address field to be transmitted. The
                   MEP identifier of another MEP in the same MA.";
@@ -1474,23 +1667,9 @@ module ieee802-dot1q-cfm {
               }
             }
           }
-          leaf ltm-priority {
-            type dot1q-types:priority-type;
-            description
-              "Priority. 3 bit value to be used in the VLAN tag, if
-              present in the transmitted frame. The default value
-              should be the CCM priority.";
-          }
-          leaf ltm-drop-eligible {
-            type boolean;
-            default "false";
-            description
-              "Drop eligible bit value to be used in the VLAN tag, if
-              present in the transmitted frame";
-          }
           leaf ltm-ttl {
             type uint32 {
-              range "0..255";
+              range "1..255";
             }
             default 64;
             description
@@ -1506,328 +1685,260 @@ module ieee802-dot1q-cfm {
           }
           leaf ltm-flags {
             type cfm-types:mep-tx-ltm-flags-type;
-            default use-fdb-only;
+            default no-flags;
             description
               "The flags field for the LTMs transmitted by the MEP.";
             reference
               "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
             
           }
-        } // input
-        output {
-          leaf ltm-result-ok {
-            type boolean;
-            default "true";
+          
+          list responses {
+            key "ltr-receive-order";
             description
-              "Indicates the result of the operation:
-                 TRUE - The Linktrace message will be (or has been) 
-                        sent.
-                 FALS - The Linktrace message will not be sent.";
-            reference
-              "12.14.7.4.3a of IEEE Std 802.1Q-2018";
-          }
-          leaf ltm-seq-number {
-            type cfm-types:seq-number-type;
-            description
-              "The LTM transaction identifier 
-              (mep-ltm-next-seq-number) of the LTM sent. The value
-              returned is undefined if mep-transmit-ltm-result is 
-              FALSE.";
-            reference
-              "12.14.7.4.3b of IEEE Std 802.1Q-2018";
-          }
-          leaf ltm-egress-identifier {
-            type string {
-              length "8";
+              "The responses associated with the request.";
+            leaf ltr-receive-order {
+              type uint32 {
+                range "1..4294967295";
+              }
+              description
+                "An index to distinguish among multiple LTRs with
+                the same LTR Transaction Identifier field value. 
+                Assigned sequentially from 1, in the order that the 
+                Linktrace Initiator received the LTRs.";
             }
+            leaf ltr-ttl {
+              type uint32 {
+                range "0..255";
+              }
+              config false;
+              mandatory true;
+              description
+                "TTL field value for a returned LTR.";
+              reference
+                "12.14.7.5, 20.41.2.2 of IEEE Std 802.1Q-2018";
+            }
+            leaf ltr-forwarded {
+              type boolean;
+              config false;
+              mandatory true;
+              description
+                "Indicates if a LTM was forwarded by the responding
+                MP, as returned in the FwdYes flag of the flags 
+                field.";
+              reference
+                "12.14.7.5.3c, 20.41.2.1 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-terminal-mep {
+              type boolean;
+              config false;
+              mandatory true;
+              description
+                "A Boolean value stating whether the forwarded LTM
+                reached a MEP enclosing its MA, as returned in the
+                Terminal MEP flag of the Flags field";
+              reference
+                "12.14.7.5.3d, 20.41.2.1 of IEEE Std 802.1Q-2018";
+            }
+            leaf ltr-last-egress-identifier {
+              type binary {
+                length "8";
+              }
+              config false;
+              mandatory true;
+              description
+                "An octet field holding the Last Egress Identifier
+                returned in the LTR Egress Identifier TLV of the
+                LTR. The Last Egress Identifier identifies the MEP
+                Linktrace Initiator that originated, or the 
+                Linktrace Responder that forwarded, the LTM to
+                which this LTR is the response. This is the same
+                value as the Egress Identifier TLV of that LTM.";
+              reference
+                "12.14.7.5.3e, 20.41.2.3 of IEEE Std 802.1Q-2018";
+            }
+            leaf ltr-next-egress-identifier {
+              type binary {
+                length "8";
+              }
+              config false;
+              mandatory true;
+              description
+                "An octet field holding the Next Egress Identifier
+                returned in the LTR Egress Identifier TLV of the 
+                LTR. The Next Egress Identifier Identifies the
+                Linktrace Responder that transmitted this LTR, and
+                can forward the LTM to the next hop. This is the
+                same value as the Egress Identifier TLV of the
+                forwarded LTM, if any. If the FwdYes bit of the
+                Flags field is false, the contents of this field
+                are undefined, i.e., any value can be transmitted,
+                and the field is ignored by the receiver.";
+              reference
+                "12.14.7.5.3f, 20.41.2.4 of IEEE Std 802.1Q-2018";
+            }
+            leaf ltr-relay {
+              type cfm-types:relay-action-field-value-type;
+              config false;
+              mandatory true;
+              description
+                "Value returned in the Relay Action field.";
+              reference
+                "12.14.7.5.3g, 20.41.2.5 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-chassis-id-subtype {
+              type lldp-types:chassis-id-subtype-type;
+              config false;
+              description
+                "Specifies the format of the Chassis ID returned
+                in the Sender ID TLV of the LTR, if any. This value
+                is meaningless if the ltr-chassis-id has a length
+                of 0.";
+              reference
+                "12.14.7.5.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-chassis-id {
+              type lldp-types:chassis-id-type;
+              config false;
+              description
+                "The Chassis ID returned in the Sender ID TLV of 
+                the LTR, if any. The format of this object is
+                determined by the value of the 
+                ltr-chassis-id-subtype object.";
+              reference
+                "12.14.7.5.3i, 21.5.3.2 of IEEE Std 802.1Q-2018";
+            }
+            container ltr-transport-service-domain {
+              config false;
+              description
+                "The transport management domain and address.";
+              uses management-address-grouping;
+              reference
+                "12.14.7.5.3j, 21.5.3.5, 21.5.3.7,
+                21.9.6 of IEEE Std 802.1Q-2018";
+            }
+            leaf ltr-ingress {
+              type cfm-types:ingress-action-field-value-type;
+              config false;
+              description
+                "The value returned in the Ingress Action Field of
+                the LTM. This leaf is not present if no
+                Reply Ingress TLV was returned in the LTM.";
+              reference
+                "12.14.7.5.3k, 20.41.2.6 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-ingress-mac {
+              type ieee:mac-address;
+              config false;
+              description
+                "MAC address returned in the ingress MAC address
+                field. If the ltr-ingress object is not present,
+                then the contents of this object are meaningless.";
+              reference
+                "12.14.7.5.3l, 20.41.2.7 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-ingress-port-id-subtype {
+              type lldp-types:port-id-subtype-type;
+              config false;
+              description
+                "Ingress Port ID. The format of this object is 
+                determined by the value of the 
+                ltr-ingress-port-id-subtype object. If the
+                ltr-ingress object is not present, then the contents
+                of this object are meaningless.";
+              reference
+                "12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
+            }
+            leaf ltr-ingress-port-id {
+              type lldp-types:port-id-type;
+              config false;
+              description
+                "Ingress Port ID. The format of this object is
+                determined by the value of the
+                ltr-ingress-port-id-subtype object. If the
+                ltr-igress object is not present, then the contents of
+                this object are meaningless.";
+              reference
+                "12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
+            }
+            leaf ltr-egress {
+              type cfm-types:egress-action-field-value-type;
+              config false;
+              description
+                "The value returned in the Egress Action Field of
+                the LTM. The node is not present if
+                no Reply Egress TLV was returned in the LTM.";
+              reference
+                "12.14.7.5.3o, 20.41.2.10 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-egress-mac {
+              type ieee:mac-address;
+              config false;
+              description
+                "MAC address returned in the egress MAC address
+                field. If the ltr-egress object is not present,
+                then the contents of this object are
+                meaningless.";
+              reference
+                "12.14.7.5.3p, 20.41.2.11 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-egress-port-id-subtype {
+              type lldp-types:port-id-subtype-type;
+              config false;
+              description
+                "Format of the egress Port ID. If the ltr-egress
+                object is not present, then the
+                contents of this object are meaningless.";
+              reference
+                "12.14.7.5.3q, 20.41.2.12 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-egress-port-id {
+              type lldp-types:port-id-type;
+              config false;
+              description
+                "Egress Port ID. The format of this object is
+                determined by the value of the
+                ltr-egress-port-id-subtype object. If the 
+                ltr-egress object is not present, 
+                then the contents of this object are meaningless.";
+              reference
+                "12.14.7.5.3r, 20.41.2.13 of IEEE Std 802.1Q-2018";
+            }           
+            leaf ltr-organization-specific-tlv {
+              type binary {
+                length "0 | 4..1500";
+              }
+              config false;
+              description
+                "All Organization specific TLVs returned in the 
+                LTR, if any. Includes all octets including and
+                following the TLV Length field of each TLV, 
+                concatenated together.";
+              reference
+                "12.14.7.5.3s, 21.5.2 of IEEE Std 802.1Q-2018";
+            }
+          }
+        } // linktrace-reply
+        
+        notification mep-fault-alarm {
+          description
+            "To alert the Manager to the existence of a fault in a
+            monitored MA by issuing a Fault Alarm.";
+          leaf mep-priority-defect {
+            type leafref {
+              path "../../continuity-check/highest-priority-defect";
+            }
+            mandatory true;
             description
-              "Identifies the MEP Linktrace Initiator that is 
-              originating, or the Linktrace Responder that is
-              forwarding, this LTM.
-              
-              The low-order six octets contain a 48-bit IEEE MAC
-              address unique to the system in which the MEP Linktrace
-              Initiator or Linktrace Responder resides. The 
-              high-order two octets contain a value sufficient to 
-              uniquely identify the MEP Linktrace Initiator or 
-              Linktrace Responder within that system.
-              
-              For most Bridges, the address of any MAC attached to
-              the Bridge will suffice for the low-order six octets,
-              and 0 for the high-order octets. In some situations,
-              e.g., if multiple virtual Bridges utilizing emulated
-              LANs are implemented in a single physical system, the
-              high-order two octets can be used to differentiate
-              among the transmitting entities.
-              
-              The value returned is undefined if 
-              mep-transmit-ltm-result is FALSE.";
-            reference
-              "12.14.7.4.3c of IEEE Std 802.1Q-2018";
+              "The highest priority defect that has been present
+              since the MEPs Fault Notification Generator state
+              machine was last in the FNG_RESET state.";
           }
-        } // output
-      } // transmit-linktrace
-      
-      list loopback-reply {
-        key "lbr-seq-number lbr-receive-order";
-        description 
-          "This table extends the MEP table and contains a list
-          of Loopback replies received by a specific MEP in
-          response to a loopback message.";
-        leaf lbr-seq-number {
-          type cfm-types:seq-number-type;
-          description
-            "The Loopback transaction identifier
-            (mep-next-lbm-trans-id) of the first LBM (to be) 
-            sent. The value returned is undefined if 
-            mep-transmit-lbm-result-ok is FALSE.";
           reference
-            "12.14.7.3.3b of IEEE Std 802.1Q-2018";
-        }
-        leaf lbr-receive-order {
-          type uint32 {
-            range "1..4294967295";
-          }
-          description
-            "An index to distinguish among multiple LBRs with
-            the same LBR Transaction Identifier field value. 
-            Assigned sequentially from 1, in the order that the 
-            Loopback Initiator received the LBRs.";
-        }
-        leaf result-ok {
-          type boolean;
-          default "true";
-          config false;
-          description
-            "Indicates the result of the operation:
-               TRUE - The LBM will be (or has been) sent.
-               FALSE - The LBM will not be sent.";
-          reference
-            "12.14.7.3.3a of IEEE Std 802.1Q-2018";
-        }
-      } // loopback-reply
-      
-      list linktrace-reply {
-        key "ltr-seq-number ltr-receive-order";
-        description
-          "This table extends the MEP table and contains a list
-          of Linktrace replies received by a specific MEP in
-          response to a linktrace message.";
-        leaf ltr-seq-number {
-          type cfm-types:seq-number-type;
-          description
-            "Transaction identifier returned by a previous
-            transmit linktrace message command, indicating
-            which LTMs response is going to be returned.";
-          reference
-            "12.14.7.5.2b of IEEE Std 802.1Q-2018";
-        }
-        leaf ltr-receive-order {
-          type uint32 {
-            range "1..4294967295";
-          }
-          description
-            "An index to distinguish among multiple LTRs with
-            the same LTR Transaction Identifier field value. 
-            Assigned sequentially from 1, in the order that the 
-            Linktrace Initiator received the LTRs.";
-        }
-        leaf ltr-ttl {
-          type uint32 {
-            range "0..255";
-          }
-          config false;
-          description
-            "TTL field value for a returned LTR.";
-          reference
-            "12.14.7.5, 20.41.2.2 of IEEE Std 802.1Q-2018";
-        }
-        leaf ltr-forwarded {
-          type boolean;
-          config false;
-          description
-            "Indicates if a LTM was forwarded by the responding
-            MP, as returned in the FwdYes flag of the flags 
-            field.";
-          reference
-            "12.14.7.5.3c, 20.41.2.1 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-terminal-mep {
-          type boolean;
-          config false;
-          description
-            "A Boolean value stating whether the forwarded LTM
-            reached a MEP enclosing its MA, as returned in the
-            Terminal MEP flag of the Flags field";
-          reference
-            "12.14.7.5.3d, 20.41.2.1 of IEEE Std 802.1Q-2018";
-        }
-        leaf ltr-last-egress-identifier {
-          type string {
-            length "8";
-          }
-          config false;
-          description
-            "An octet field holding the Last Egress Identifier
-            returned in the LTR Egress Identifier TLV of the
-            LTR. The Last Egress Identifier identifies the MEP
-            Linktrace Initiator that originated, or the 
-            Linktrace Responder that forwarded, the LTM to
-            which this LTR is the response. This is the same
-            value as the Egress Identifier TLV of that LTM.";
-          reference
-            "12.14.7.5.3e, 20.41.2.3 of IEEE Std 802.1Q-2018";
-        }
-        leaf ltr-next-egress-identifier {
-          type string {
-            length "8";
-          }
-          config false;
-          description
-            "An octet field holding the Next Egress Identifier
-            returned in the LTR Egress Identifier TLV of the 
-            LTR. The Next Egress Identifier Identifies the
-            Linktrace Responder that transmitted this LTR, and
-            can forward the LTM to the next hop. This is the
-            same value as the Egress Identifier TLV of the
-            forwarded LTM, if any. If the FwdYes bit of the
-            Flags field is false, the contents of this field
-            are undefined, i.e., any value can be transmitted,
-            and the field is ignored by the receiver.";
-          reference
-            "12.14.7.5.3f, 20.41.2.4 of IEEE Std 802.1Q-2018";
-        }
-        leaf ltr-relay {
-          type cfm-types:relay-action-field-value;
-          config false;
-          description
-            "Value returned in the Relay Action field.";
-          reference
-            "12.14.7.5.3g, 20.41.2.5 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-chassis-id-subtype {
-          type lldp-types:chassis-id-subtype-type;
-          config false;
-          description
-            "Specifies the format of the Chassis ID returned
-            in the Sender ID TLV of the LTR, if any. This value
-            is meaningless if the ltr-chassis-id has a length
-            of 0.";
-          reference
-            "12.14.7.5.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-chassis-id {
-          type lldp-types:chassis-id-type;
-          config false;
-          description
-            "The Chassis ID returned in the Sender ID TLV of 
-            the LTR, if any. The format of this object is
-            determined by the value of the 
-            ltr-chassis-id-subtype object.";
-          reference
-            "12.14.7.5.3i, 21.5.3.2 of IEEE Std 802.1Q-2018";
-        }
-        container ltr-transport-service-domain {
-          config false;
-          description
-            "The transport management domain and address.";
-          uses management-address-grouping;
-          reference
-            "12.14.7.5.3j, 21.5.3.5, 21.5.3.7,
-            21.9.6 of IEEE Std 802.1Q-2018";
-        }
-        leaf ltr-ingress {
-          type cfm-types:ingress-action-field-value;
-          config false;
-          description
-            "The value returned in the Ingress Action Field of
-            the LTM. The value ingress-no-tlv indicates that no
-            Reply Ingress TLV was returned in the LTM.";
-          reference
-            "12.14.7.5.3k, 20.41.2.6 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-ingress-mac {
-          type ieee:mac-address;
-          config false;
-          description
-            "MAC address returned in the ingress MAC address
-            field. If the ltr-ingress object contains the value 
-            ingress-no-tlv, then the contents of this object
-            are meaningless.";
-          reference
-            "12.14.7.5.3l, 20.41.2.7 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-ingress-port-id-subtype {
-          type lldp-types:port-id-subtype-type;
-          config false;
-          description
-            "Ingress Port ID. The format of this object is 
-            determined by the value of the 
-            ltr-ingress-port-id-subtype object. If the
-            ltr-ingress object contains the value 
-            ingress-no-tlv, then the contents of this object
-            are meaningless.";
-          reference
-            "12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-egress {
-          type cfm-types:egress-action-field-value;
-          config false;
-          description
-            "The value returned in the Egress Action Field of
-            the LTM. The value egress-no-tlv indicates that 
-            no Reply Egress TLV was returned in the LTM.";
-          reference
-            "12.14.7.5.3o, 20.41.2.10 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-egress-mac {
-          type ieee:mac-address;
-          config false;
-          description
-            "MAC address returned in the egress MAC address
-            field. If the ltr-egress object contains the value
-            egress-no-tlv, then the contents of this object are
-            meaningless.";
-          reference
-            "12.14.7.5.3p, 20.41.2.11 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-egress-port-id-subtype {
-          type lldp-types:port-id-subtype-type;
-          config false;
-          description
-            "Format of the egress Port ID. If the ltr-egress
-            object contains the value egress-no-tlv, then the
-            contents of this object are meaningless.";
-          reference
-            "12.14.7.5.3q, 20.41.2.12 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-egress-port-id {
-          type lldp-types:port-id-type;
-          config false;
-          description
-            "Egress Port ID. The format of this object is
-            determined by the value of the
-            ltr-egress-port-id-subtype object. If the 
-            ltr-egress object contains the value egress-no-tlv,
-            then the contents of this object are meaningless.";
-          reference
-            "12.14.7.5.3r, 20.41.2.13 of IEEE Std 802.1Q-2018";
-        }           
-        leaf ltr-organization-specific-tlv {
-          type string {
-            length "0 | 4..1500";
-          }
-          config false;
-          description
-            "All Organization specific TLVs returned in the 
-            LTR, if any. Includes all octets including and
-            following the TLV Length field of each TLV, 
-            concatenated together.";
-          reference
-            "12.14.7.5.3s, 21.5.2 of IEEE Std 802.1Q-2018";
-        }
-      } // linktrace-reply
-    } // cfm-operation
+            "12.14.7.7.2c of IEEE Std 802.1Q-2018";
+        } // mep-fault-alarm
+      } // mep
+    } // maintenance-group
   } // cfm
   
 } // ieee802-dot1q-cfm


### PR DESCRIPTION
Clean PYANG compilation and YANG Validation


ieee802-dot1q-cfm.yang
Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm
    +--rw cfm
       +--rw maintenance-domain* [md-id]
       |  +--rw md-id                        cfm-types:name-key-type
       |  +--rw (md-name)?
       |  |  +--:(none)
       |  |  |  +--rw none?                        empty
       |  |  +--:(dns-like-name)
       |  |  |  +--rw dns-like-name?               string
       |  |  +--:(mac-address-and-uint)
       |  |  |  +--rw mac-address-and-uint-type
       |  |  |     +--rw address    ieee:mac-address
       |  |  |     +--rw int        uint16
       |  |  +--:(char-string)
       |  |     +--rw char-string?                 string
       |  +--rw md-level?                    cfm-types:md-level-type
       |  +--rw mhf-creation?                cfm-types:mhf-creation-type
       |  +--rw id-permission?               cfm-types:sender-id-permission-type
       |  +--rw fault-alarm-address?         cfm-types:fault-alarm-address-type
       |  +--rw maintenance-association* [ma-id]
       |     +--rw ma-id                               cfm-types:name-key-type
       |     +--rw (ma-name)
       |     |  +--:(primary-vid)
       |     |  |  +--rw primary-vid?                        dot1q-types:vlanid
       |     |  +--:(char-string)
       |     |  |  +--rw char-string?                        string
       |     |  +--:(unsigned-int16)
       |     |  |  +--rw unsigned-int16?                     uint16
       |     |  +--:(rfc2865-vpn-id)
       |     |  |  +--rw vpn-id
       |     |  |     +--rw vpn-oui?    uint32
       |     |  |     +--rw vpn-idex?   uint32
       |     |  +--:(icc-format)
       |     |     +--rw icc-format?                         string
       |     +--rw ccm-interval?                       cfm-types:ccm-interval-type
       |     +--rw fault-alarm-address?                cfm-types:fault-alarm-address-type
       |     +--rw mhf-creation?                       cfm-types:mhf-creation-type
       |     +--rw id-permission?                      cfm-types:sender-id-permission-type
       |     +--rw maintenance-association-mep-list* [mep-id]
       |        +--rw mep-id    cfm-types:mep-id-type
       +--rw maintenance-group* [maintenance-group-id]
          +--rw maintenance-group-id    cfm-types:name-key-type
          +--rw md-id                   -> /cfm/maintenance-domain/md-id
          +--rw ma-id                   -> /cfm/maintenance-domain[md-id = current()/../md-id]/maintenance-association/ma-id
          +--rw mep* [mep-id]
             +--rw mep-id                -> /cfm/maintenance-domain[md-id = current()/../../md-id]/maintenance-association[ma-id = current()/../../ma-id]/maintenance-association-mep-list/mep-id
             +--rw direction             cfm-types:mp-direction-type
             +--rw primary-vid?          uint32
             +--rw admin-state?          boolean
             +--rw ccm-ltm-priority      dot1q-types:priority-type
             +--ro mac-address           ieee:mac-address
             +--ro mep-db* [rmep-id]
             |  +--ro rmep-id                     -> /cfm/maintenance-domain[md-id = current()/../../../md-id]/maintenance-association[ma-id = current()/../../../ma-id]/maintenance-association-mep-list/mep-id
             |  +--ro rmep-state                  cfm-types:remote-mep-state-type
             |  +--ro rmep-failed-ok-time         yang:zero-based-counter64
             |  +--ro mac-address                 ieee:mac-address
             |  +--ro rdi                         boolean
             |  +--ro port-status-tlv?            cfm-types:port-status-tlv-value-type
             |  +--ro interface-status-tlv?       cfm-types:interface-status-tlv-value-type
             |  +--ro chassis-id-subtype?         lldp-types:chassis-id-subtype-type
             |  +--ro chassis-id?                 lldp-types:chassis-id-type
             |  +--ro transport-service-domain
             |  |  +--ro (management-address-domain)?
             |  |     +--:(udp-ipv4)
             |  |     |  +--ro udp-ipv4-domain?      yang:object-identifier-128
             |  |     |  +--ro udp-ipv4-address      inet:ipv4-address
             |  |     |  +--ro udp-ipv4-port         inet:port-number
             |  |     +--:(udp-ipv6)
             |  |     |  +--ro udp-ipv6-domain?      yang:object-identifier-128
             |  |     |  +--ro udp-ipv6-address      inet:ipv6-address
             |  |     |  +--ro udp-ipv6-port         inet:port-number
             |  |     +--:(udp-ipv4z)
             |  |     |  +--ro udp-ipv4z-domain?     yang:object-identifier-128
             |  |     |  +--ro udp-ipv4z-address     inet:ipv4-address
             |  |     |  +--ro udp-ipv4z-index       uint32
             |  |     |  +--ro udp-ipv4z-port        inet:port-number
             |  |     +--:(udp-ipv6z)
             |  |     |  +--ro udp-ipv6z-domain?     yang:object-identifier-128
             |  |     |  +--ro udp-ipv6z-address     inet:ipv6-address
             |  |     |  +--ro udp-ipv6z-index       uint32
             |  |     |  +--ro udp-ipv6z-port        inet:port-number
             |  |     +--:(tcp-ipv4)
             |  |     |  +--ro tcp-ipv4-domain?      yang:object-identifier-128
             |  |     |  +--ro tcp-ipv4-address      inet:ipv4-address
             |  |     |  +--ro tcp-ipv4-port         inet:port-number
             |  |     +--:(tcp-ipv6)
             |  |     |  +--ro tcp-ipv6-domain?      yang:object-identifier-128
             |  |     |  +--ro tcp-ipv6-address      inet:ipv6-address
             |  |     |  +--ro tcp-ipv6-port         inet:port-number
             |  |     +--:(tcp-ipv4z)
             |  |     |  +--ro tcp-ipv4z-domain?     yang:object-identifier-128
             |  |     |  +--ro tcp-ipv4z-address     inet:ipv4-address
             |  |     |  +--ro tcp-ipv4z-index       uint32
             |  |     |  +--ro tcp-ipv4z-port        inet:port-number
             |  |     +--:(tcp-ipv6z)
             |  |     |  +--ro tcp-ipv6z-domain?     yang:object-identifier-128
             |  |     |  +--ro tcp-ipv6z-address     inet:ipv6-address
             |  |     |  +--ro tcp-ipv6z-index       uint32
             |  |     |  +--ro tcp-ipv6z-port        inet:port-number
             |  |     +--:(sctp-ipv4)
             |  |     |  +--ro sctp-ipv4-domain?     yang:object-identifier-128
             |  |     |  +--ro sctp-ipv4-address     inet:ipv4-address
             |  |     |  +--ro sctp-ipv4-port        inet:port-number
             |  |     +--:(sctp-ipv6)
             |  |     |  +--ro sctp-ipv6-domain?     yang:object-identifier-128
             |  |     |  +--ro sctp-ipv6-address     inet:ipv6-address
             |  |     |  +--ro sctp-ipv6-port        inet:port-number
             |  |     +--:(sctp-ipv4z)
             |  |     |  +--ro sctp-ipv4z-domain?    yang:object-identifier-128
             |  |     |  +--ro sctp-iv4z-address     inet:ipv4-address
             |  |     |  +--ro sctp-ipv4z-index      uint32
             |  |     |  +--ro sctp-ipv4z-port       inet:port-number
             |  |     +--:(sctp-ipv6z)
             |  |     |  +--ro sctp-ipv6z-domain?    yang:object-identifier-128
             |  |     |  +--ro sctp-ipv6z-address    inet:ipv6-address
             |  |     |  +--ro sctp-ipv6z-index      uint32
             |  |     |  +--ro sctp-ipv6z-port       inet:port-number
             |  |     +--:(local)
             |  |     |  +--ro local-domain?         yang:object-identifier-128
             |  |     |  +--ro local-address         string
             |  |     +--:(udp-dns)
             |  |     |  +--ro udp-dns-domain?       yang:object-identifier-128
             |  |     |  +--ro udp-dns-address       string
             |  |     +--:(tcp-dns)
             |  |     |  +--ro tcp-dns-domain?       yang:object-identifier-128
             |  |     |  +--ro tcp-dns-address       string
             |  |     +--:(sctp-dns)
             |  |        +--ro sctp-dns-domain?      yang:object-identifier-128
             |  |        +--ro sctp-dns-address      string
             |  +--ro rmep-is-active?             boolean
             +--rw continuity-check
             |  +--rw ccm-enabled?               boolean
             |  +--ro fng-state?                 cfm-types:fng-state-type
             |  +--rw fault-alarm-address?       cfm-types:fault-alarm-address-type
             |  +--rw lowest-priority-defect?    cfm-types:lowest-alarm-priority-type
             |  +--rw fng-alarm-time?            yang:zero-based-counter32
             |  +--rw fng-reset-time?            yang:zero-based-counter32
             |  +--ro highest-priority-defect    cfm-types:highest-defect-priority-type
             |  +--ro defects                    cfm-types:mep-defects-type
             |  +--ro error-ccm-last-failure?    binary
             |  +--ro xcon-ccm-last-failure?     binary
             +--ro stats
             |  +--ro mep-ccm-sequence-errors    yang:counter64
             |  +--ro mep-ccms-sent              yang:counter64
             |  +--ro mep-lbr-in                 yang:counter64
             |  +--ro mep-lbr-in-out-of-order    yang:counter64
             |  +--ro mep-lbr-bad-msdu           yang:counter64
             |  +--ro mep-unexpected-ltr-in      yang:counter64
             |  +--ro mep-lbr-out                yang:counter64
             +---x transmit-loopback
             |  +---w input
             |  |  +---w (destination)
             |  |  |  +--:(dest-ucast-mac-address)
             |  |  |  |  +---w lbm-dest-ucast-mac-address?          ieee:mac-address
             |  |  |  +--:(dest-mcast-class1-mac-address)
             |  |  |  |  +---w lbm-dest-mcast-class1-mac-address?   ieee:mac-address
             |  |  |  +--:(dest-mep-id)
             |  |  |     +---w lbm-dest-mep-id?                     cfm-types:mep-id-type
             |  |  +---w lbm-messages?                        uint32
             |  |  +---w lbm-priority                         dot1q-types:priority-type
             |  |  +---w lbm-drop-eligible?                   boolean
             |  |  +---w lbm-data-tlv?                        cfm-types:lbm-data-tlv-type
             |  +--ro output
             |     +--ro lbm-request-id    cfm-types:seq-number-type
             +---x transmit-linktrace
             |  +---w input
             |  |  +---w (target)
             |  |  |  +--:(target-ucast-mac-address)
             |  |  |  |  +---w ltm-target-mac-address?   ieee:mac-address
             |  |  |  +--:(target-mep-id)
             |  |  |     +---w ltm-target-mep-id?        cfm-types:mep-id-type
             |  |  +---w ltm-ttl?                  uint32
             |  |  +---w ltm-flags?                cfm-types:mep-tx-ltm-flags-type
             |  +--ro output
             |     +--ro ltm-transaction-id       cfm-types:seq-number-type
             |     +--ro ltm-egress-identifier    binary
             +--ro loopback-reply* [lbm-request-id]
             |  +--ro lbm-request-id                       cfm-types:seq-number-type
             |  +--ro (destination)
             |  |  +--:(dest-ucast-mac-address)
             |  |  |  +--ro lbm-dest-ucast-mac-address?          ieee:mac-address
             |  |  +--:(dest-mcast-class1-mac-address)
             |  |  |  +--ro lbm-dest-mcast-class1-mac-address?   ieee:mac-address
             |  |  +--:(dest-mep-id)
             |  |     +--ro lbm-dest-mep-id?                     cfm-types:mep-id-type
             |  +--ro lbm-messages?                        uint32
             |  +--ro lbm-priority                         dot1q-types:priority-type
             |  +--ro lbm-drop-eligible?                   boolean
             |  +--ro lbm-data-tlv?                        cfm-types:lbm-data-tlv-type
             |  +--ro responses* [lbr-receive-order]
             |     +--ro lbr-receive-order    uint32
             +--ro linktrace-reply* [ltr-transaction-id]
             |  +--ro ltr-transaction-id        cfm-types:seq-number-type
             |  +--ro (target)
             |  |  +--:(target-ucast-mac-address)
             |  |  |  +--ro ltm-target-mac-address?   ieee:mac-address
             |  |  +--:(target-mep-id)
             |  |     +--ro ltm-target-mep-id?        cfm-types:mep-id-type
             |  +--ro ltm-ttl?                  uint32
             |  +--ro ltm-flags?                cfm-types:mep-tx-ltm-flags-type
             |  +--ro responses* [ltr-receive-order]
             |     +--ro ltr-receive-order                uint32
             |     +--ro ltr-ttl                          uint32
             |     +--ro ltr-forwarded                    boolean
             |     +--ro ltr-terminal-mep                 boolean
             |     +--ro ltr-last-egress-identifier       binary
             |     +--ro ltr-next-egress-identifier       binary
             |     +--ro ltr-relay                        cfm-types:relay-action-field-value-type
             |     +--ro ltr-chassis-id-subtype?          lldp-types:chassis-id-subtype-type
             |     +--ro ltr-chassis-id?                  lldp-types:chassis-id-type
             |     +--ro ltr-transport-service-domain
             |     |  +--ro (management-address-domain)?
             |     |     +--:(udp-ipv4)
             |     |     |  +--ro udp-ipv4-domain?      yang:object-identifier-128
             |     |     |  +--ro udp-ipv4-address      inet:ipv4-address
             |     |     |  +--ro udp-ipv4-port         inet:port-number
             |     |     +--:(udp-ipv6)
             |     |     |  +--ro udp-ipv6-domain?      yang:object-identifier-128
             |     |     |  +--ro udp-ipv6-address      inet:ipv6-address
             |     |     |  +--ro udp-ipv6-port         inet:port-number
             |     |     +--:(udp-ipv4z)
             |     |     |  +--ro udp-ipv4z-domain?     yang:object-identifier-128
             |     |     |  +--ro udp-ipv4z-address     inet:ipv4-address
             |     |     |  +--ro udp-ipv4z-index       uint32
             |     |     |  +--ro udp-ipv4z-port        inet:port-number
             |     |     +--:(udp-ipv6z)
             |     |     |  +--ro udp-ipv6z-domain?     yang:object-identifier-128
             |     |     |  +--ro udp-ipv6z-address     inet:ipv6-address
             |     |     |  +--ro udp-ipv6z-index       uint32
             |     |     |  +--ro udp-ipv6z-port        inet:port-number
             |     |     +--:(tcp-ipv4)
             |     |     |  +--ro tcp-ipv4-domain?      yang:object-identifier-128
             |     |     |  +--ro tcp-ipv4-address      inet:ipv4-address
             |     |     |  +--ro tcp-ipv4-port         inet:port-number
             |     |     +--:(tcp-ipv6)
             |     |     |  +--ro tcp-ipv6-domain?      yang:object-identifier-128
             |     |     |  +--ro tcp-ipv6-address      inet:ipv6-address
             |     |     |  +--ro tcp-ipv6-port         inet:port-number
             |     |     +--:(tcp-ipv4z)
             |     |     |  +--ro tcp-ipv4z-domain?     yang:object-identifier-128
             |     |     |  +--ro tcp-ipv4z-address     inet:ipv4-address
             |     |     |  +--ro tcp-ipv4z-index       uint32
             |     |     |  +--ro tcp-ipv4z-port        inet:port-number
             |     |     +--:(tcp-ipv6z)
             |     |     |  +--ro tcp-ipv6z-domain?     yang:object-identifier-128
             |     |     |  +--ro tcp-ipv6z-address     inet:ipv6-address
             |     |     |  +--ro tcp-ipv6z-index       uint32
             |     |     |  +--ro tcp-ipv6z-port        inet:port-number
             |     |     +--:(sctp-ipv4)
             |     |     |  +--ro sctp-ipv4-domain?     yang:object-identifier-128
             |     |     |  +--ro sctp-ipv4-address     inet:ipv4-address
             |     |     |  +--ro sctp-ipv4-port        inet:port-number
             |     |     +--:(sctp-ipv6)
             |     |     |  +--ro sctp-ipv6-domain?     yang:object-identifier-128
             |     |     |  +--ro sctp-ipv6-address     inet:ipv6-address
             |     |     |  +--ro sctp-ipv6-port        inet:port-number
             |     |     +--:(sctp-ipv4z)
             |     |     |  +--ro sctp-ipv4z-domain?    yang:object-identifier-128
             |     |     |  +--ro sctp-iv4z-address     inet:ipv4-address
             |     |     |  +--ro sctp-ipv4z-index      uint32
             |     |     |  +--ro sctp-ipv4z-port       inet:port-number
             |     |     +--:(sctp-ipv6z)
             |     |     |  +--ro sctp-ipv6z-domain?    yang:object-identifier-128
             |     |     |  +--ro sctp-ipv6z-address    inet:ipv6-address
             |     |     |  +--ro sctp-ipv6z-index      uint32
             |     |     |  +--ro sctp-ipv6z-port       inet:port-number
             |     |     +--:(local)
             |     |     |  +--ro local-domain?         yang:object-identifier-128
             |     |     |  +--ro local-address         string
             |     |     +--:(udp-dns)
             |     |     |  +--ro udp-dns-domain?       yang:object-identifier-128
             |     |     |  +--ro udp-dns-address       string
             |     |     +--:(tcp-dns)
             |     |     |  +--ro tcp-dns-domain?       yang:object-identifier-128
             |     |     |  +--ro tcp-dns-address       string
             |     |     +--:(sctp-dns)
             |     |        +--ro sctp-dns-domain?      yang:object-identifier-128
             |     |        +--ro sctp-dns-address      string
             |     +--ro ltr-ingress?                     cfm-types:ingress-action-field-value-type
             |     +--ro ltr-ingress-mac?                 ieee:mac-address
             |     +--ro ltr-ingress-port-id-subtype?     lldp-types:port-id-subtype-type
             |     +--ro ltr-ingress-port-id?             lldp-types:port-id-type
             |     +--ro ltr-egress?                      cfm-types:egress-action-field-value-type
             |     +--ro ltr-egress-mac?                  ieee:mac-address
             |     +--ro ltr-egress-port-id-subtype?      lldp-types:port-id-subtype-type
             |     +--ro ltr-egress-port-id?              lldp-types:port-id-type
             |     +--ro ltr-organization-specific-tlv?   binary
             +---n mep-fault-alarm
                +---- mep-priority-defect    -> ../../continuity-check/highest-priority-defect
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

________________________________________
ieee802-dot1q-cfm-types.yang
Pyang Validation
ieee802-dot1q-cfm-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors

________________________________________
ieee802-dot1q-cfm-bridge.yang
Pyang Validation
ieee802-dot1q-cfm-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-bridge
  augment /dot1q-cfm:cfm:
    +--ro cfm-stack* [port md-level direction service-selector service-id]
    |  +--ro port                    port-ref
    |  +--ro md-level                cfm-types:md-level-type
    |  +--ro direction               cfm-types:mp-direction-type
    |  +--ro service-selector        cfm-types:service-selector-type
    |  +--ro service-id              cfm-types:service-selector-value-type
    |  +--ro maintenance-group-id?   -> /dot1q-cfm:cfm/maintenance-group/maintenance-group-id
    |  +--ro mep-id?                 -> /dot1q-cfm:cfm/maintenance-group[dot1q-cfm:maintenance-group-id = current()/../maintenance-group-id]/mep/mep-id
    |  +--ro mac-address             ieee:mac-address
    |  +--ro mp?                     cfm-types:mp-type
    +--rw default-md-level* [bridge-id component-id primary-service-id service-selector]
    |  +--rw bridge-id                 bridge-ref
    |  +--rw component-id              -> /dot1q:bridges/bridge[dot1q:name = current()/../bridge-id]/component/name
    |  +--rw service-selector          cfm-types:service-selector-type
    |  +--rw primary-service-id        cfm-types:service-selector-value-type
    |  +--rw associated-service-ids
    |  |  +--rw (service-id)?
    |  |     +--:(none)
    |  |     |  +--rw zero?         uint32
    |  |     +--:(vid)
    |  |     |  +--rw vid*          dot1q-types:vlanid
    |  |     +--:(isid)
    |  |     |  +--rw isid?         uint32
    |  |     +--:(tesid)
    |  |     |  +--rw tesid?        uint32
    |  |     +--:(segid)
    |  |     |  +--rw segid?        uint32
    |  |     +--:(path-tesid)
    |  |     |  +--rw path-tesid?   uint32
    |  |     +--:(group-isid)
    |  |        +--rw group-isid?   uint32
    |  +--ro md-status                 boolean
    |  +--rw md-level                  cfm-types:md-level-type
    |  +--rw mhf-creation?             cfm-types:mhf-creation-type
    |  +--rw id-permission?            cfm-types:sender-id-permission-type
    +--ro config-error* [port service-id service-selector]
       +--ro port                port-ref
       +--ro service-selector    cfm-types:service-selector-type
       +--ro service-id          cfm-types:service-selector-value-type
       +--ro error-type          cfm-types:config-error-type
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group:
    +--rw bridge-id?          bridge-ref
    +--rw component-name?     -> /dot1q:bridges/bridge[dot1q:name = current()/../cfm-bridge:bridge-id]/dot1q:component/name
    +--rw service-selector?   cfm-types:service-selector-type
    +--rw service-id?         cfm-types:service-selector-value-type
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group/dot1q-cfm:mep:
    +--rw port?   port-ref
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
