### PR TITLE
Create iana-routing-types.yang symlink

### DIFF
--- a/standard/ietf/RFC/iana-routing-types.yang
+++ b/standard/ietf/RFC/iana-routing-types.yang
@@ -1,0 +1,1 @@
+iana-routing-types@2018-10-29.yang

--- a/standard/ietf/RFC/iana-routing-types@2018-10-29.yang
+++ b/standard/ietf/RFC/iana-routing-types@2018-10-29.yang
@@ -1,0 +1,498 @@
+module iana-routing-types {
+  namespace "urn:ietf:params:xml:ns:yang:iana-routing-types";
+  prefix iana-rt-types;
+
+  organization
+    "IANA";
+  contact
+    "Internet Assigned Numbers Authority
+
+     Postal: ICANN
+             12025 Waterfront Drive, Suite 300
+             Los Angeles, CA  90094-2536
+             United States of America
+     Tel:    +1 310 301 5800
+     <mailto:iana&iana.org>";
+
+  description
+    "This module contains a collection of YANG data types
+     considered defined by IANA and used for routing
+     protocols.
+
+     Copyright (c) 2017 IETF Trust and the persons
+     identified as authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8294; see
+     the RFC itself for full legal notices.";
+
+   revision 2018-10-29 {
+     description "Added SAFI value 74.";
+  }
+
+   revision 2017-12-04 {
+     description "Initial revision.";
+     reference
+       "RFC 8294: Common YANG Data Types for the Routing Area.
+        Section 4.";
+  }
+
+
+
+
+  /*** Collection of IANA types related to routing ***/
+  /*** IANA Address Family enumeration ***/
+
+  typedef address-family {
+    type enumeration {
+      enum ipv4 {
+        value 1;
+        description
+          "IPv4 Address Family.";
+      }
+
+      enum ipv6 {
+        value 2;
+        description
+          "IPv6 Address Family.";
+      }
+
+      enum nsap {
+        value 3;
+        description
+          "OSI Network Service Access Point (NSAP) Address Family.";
+      }
+
+      enum hdlc {
+        value 4;
+        description
+          "High-Level Data Link Control (HDLC) Address Family.";
+      }
+
+      enum bbn1822 {
+        value 5;
+        description
+          "Bolt, Beranek, and Newman Report 1822 (BBN 1822)
+           Address Family.";
+      }
+
+      enum ieee802 {
+        value 6;
+        description
+          "IEEE 802 Committee Address Family
+           (aka Media Access Control (MAC) address).";
+      }
+
+      enum e163 {
+        value 7;
+        description
+          "ITU-T E.163 Address Family.";
+      }
+      enum e164 {
+        value 8;
+        description
+          "ITU-T E.164 (Switched Multimegabit Data Service (SMDS),
+           Frame Relay, ATM) Address Family.";
+      }
+
+      enum f69 {
+        value 9;
+        description
+          "ITU-T F.69 (Telex) Address Family.";
+      }
+
+      enum x121 {
+        value 10;
+        description
+          "ITU-T X.121 (X.25, Frame Relay) Address Family.";
+      }
+
+      enum ipx {
+        value 11;
+        description
+          "Novell Internetwork Packet Exchange (IPX)
+           Address Family.";
+      }
+
+      enum appletalk {
+        value 12;
+        description
+          "Apple AppleTalk Address Family.";
+      }
+
+      enum decnet-iv {
+        value 13;
+        description
+          "Digital Equipment DECnet Phase IV Address Family.";
+      }
+
+      enum vines {
+        value 14;
+        description
+          "Banyan Vines Address Family.";
+      }
+
+
+
+
+
+      enum e164-nsap {
+        value 15;
+        description
+          "ITU-T E.164 with NSAP sub-address Address Family.";
+      }
+
+      enum dns {
+        value 16;
+        description
+          "Domain Name System (DNS) Address Family.";
+      }
+
+      enum distinguished-name {
+        value 17;
+        description
+          "Distinguished Name Address Family.";
+      }
+
+      enum as-num {
+        value 18;
+        description
+          "Autonomous System (AS) Number Address Family.";
+      }
+
+      enum xtp-v4 {
+        value 19;
+        description
+          "Xpress Transport Protocol (XTP) over IPv4
+           Address Family.";
+      }
+
+      enum xtp-v6 {
+        value 20;
+        description
+          "XTP over IPv6 Address Family.";
+      }
+
+      enum xtp-native {
+        value 21;
+        description
+          "XTP native mode Address Family.";
+      }
+
+      enum fc-port {
+        value 22;
+        description
+          "Fibre Channel (FC) World-Wide Port Name Address Family.";
+      }
+      enum fc-node {
+        value 23;
+        description
+          "FC World-Wide Node Name Address Family.";
+      }
+
+      enum gwid {
+        value 24;
+        description
+          "ATM Gateway Identifier (GWID) Number Address Family.";
+      }
+
+      enum l2vpn {
+        value 25;
+        description
+          "Layer 2 VPN (L2VPN) Address Family.";
+      }
+
+      enum mpls-tp-section-eid {
+        value 26;
+        description
+          "MPLS Transport Profile (MPLS-TP) Section Endpoint
+           Identifier Address Family.";
+      }
+
+      enum mpls-tp-lsp-eid {
+        value 27;
+        description
+          "MPLS-TP Label Switched Path (LSP) Endpoint Identifier
+           Address Family.";
+      }
+
+      enum mpls-tp-pwe-eid {
+        value 28;
+        description
+          "MPLS-TP Pseudowire Endpoint Identifier Address Family.";
+      }
+
+      enum mt-v4 {
+        value 29;
+        description
+          "Multi-Topology IPv4 Address Family.";
+      }
+
+
+
+
+
+      enum mt-v6 {
+        value 30;
+        description
+          "Multi-Topology IPv6 Address Family.";
+      }
+
+      enum eigrp-common-sf {
+        value 16384;
+        description
+          "Enhanced Interior Gateway Routing Protocol (EIGRP)
+           Common Service Family Address Family.";
+      }
+
+      enum eigrp-v4-sf {
+        value 16385;
+        description
+          "EIGRP IPv4 Service Family Address Family.";
+      }
+
+      enum eigrp-v6-sf {
+        value 16386;
+        description
+          "EIGRP IPv6 Service Family Address Family.";
+      }
+
+      enum lcaf {
+        value 16387;
+        description
+          "Locator/ID Separation Protocol (LISP)
+           Canonical Address Format (LCAF) Address Family.";
+      }
+
+      enum bgp-ls {
+        value 16388;
+        description
+          "Border Gateway Protocol - Link State (BGP-LS)
+           Address Family.";
+      }
+
+      enum mac-48 {
+        value 16389;
+        description
+          "IEEE 48-bit MAC Address Family.";
+      }
+
+
+
+
+      enum mac-64 {
+        value 16390;
+        description
+          "IEEE 64-bit MAC Address Family.";
+      }
+
+      enum trill-oui {
+        value 16391;
+        description
+          "Transparent Interconnection of Lots of Links (TRILL)
+           IEEE Organizationally Unique Identifier (OUI)
+           Address Family.";
+      }
+
+      enum trill-mac-24 {
+        value 16392;
+        description
+          "TRILL final 3 octets of 48-bit MAC Address Family.";
+      }
+
+      enum trill-mac-40 {
+        value 16393;
+        description
+          "TRILL final 5 octets of 64-bit MAC Address Family.";
+      }
+
+      enum ipv6-64 {
+        value 16394;
+        description
+          "First 8 octets (64 bits) of IPv6 address
+           Address Family.";
+      }
+
+      enum trill-rbridge-port-id {
+        value 16395;
+        description
+          "TRILL Routing Bridge (RBridge) Port ID Address Family.";
+      }
+
+      enum trill-nickname {
+        value 16396;
+        description
+          "TRILL Nickname Address Family.";
+      }
+    }
+
+
+
+    description
+      "Enumeration containing all the IANA-defined
+       Address Families.";
+
+  }
+
+  /*** Subsequent Address Family Identifiers (SAFIs) ***/
+  /*** for multiprotocol BGP enumeration ***/
+
+  typedef bgp-safi {
+    type enumeration {
+      enum unicast-safi {
+        value 1;
+        description
+          "Unicast SAFI.";
+      }
+
+      enum multicast-safi {
+        value 2;
+        description
+          "Multicast SAFI.";
+      }
+
+      enum labeled-unicast-safi {
+        value 4;
+        description
+          "Labeled Unicast SAFI.";
+      }
+
+      enum multicast-vpn-safi {
+        value 5;
+        description
+          "Multicast VPN SAFI.";
+      }
+
+      enum pseudowire-safi {
+        value 6;
+        description
+          "Multi-segment Pseudowire VPN SAFI.";
+      }
+
+      enum tunnel-encap-safi {
+        value 7;
+        description
+          "Tunnel Encap SAFI.";
+      }
+
+
+      enum mcast-vpls-safi {
+        value 8;
+        description
+          "Multicast Virtual Private LAN Service (VPLS) SAFI.";
+      }
+
+      enum tunnel-safi {
+        value 64;
+        description
+          "Tunnel SAFI.";
+      }
+
+      enum vpls-safi {
+        value 65;
+        description
+          "VPLS SAFI.";
+      }
+
+      enum mdt-safi {
+        value 66;
+        description
+          "Multicast Distribution Tree (MDT) SAFI.";
+      }
+
+      enum v4-over-v6-safi {
+        value 67;
+        description
+          "IPv4 over IPv6 SAFI.";
+      }
+
+      enum v6-over-v4-safi {
+        value 68;
+        description
+          "IPv6 over IPv4 SAFI.";
+      }
+
+      enum l1-vpn-auto-discovery-safi {
+        value 69;
+        description
+          "Layer 1 VPN Auto-Discovery SAFI.";
+      }
+
+      enum evpn-safi {
+        value 70;
+        description
+          "Ethernet VPN (EVPN) SAFI.";
+      }
+
+      enum bgp-ls-safi {
+        value 71;
+        description
+          "BGP-LS SAFI.";
+      }
+
+      enum bgp-ls-vpn-safi {
+        value 72;
+        description
+          "BGP-LS VPN SAFI.";
+      }
+
+      enum sr-te-safi {
+        value 73;
+        description
+          "Segment Routing - Traffic Engineering (SR-TE) SAFI.";
+      }
+
+      enum sd-wan-capabilities-safi {
+        value 74;
+        description
+          "SD-WAN Capabilities SAFI.";
+      }
+
+      enum labeled-vpn-safi {
+        value 128;
+        description
+          "MPLS Labeled VPN SAFI.";
+      }
+
+      enum multicast-mpls-vpn-safi {
+        value 129;
+        description
+          "Multicast for BGP/MPLS IP VPN SAFI.";
+      }
+
+      enum route-target-safi {
+        value 132;
+        description
+          "Route Target SAFI.";
+      }
+
+      enum ipv4-flow-spec-safi {
+        value 133;
+        description
+          "IPv4 Flow Specification SAFI.";
+      }
+
+      enum vpnv4-flow-spec-safi {
+        value 134;
+        description
+          "IPv4 VPN Flow Specification SAFI.";
+      }
+
+      enum vpn-auto-discovery-safi {
+        value 140;
+        description
+          "VPN Auto-Discovery SAFI.";
+      }
+    }
+    description
+      "Enumeration for BGP SAFI.";
+    reference
+      "RFC 4760: Multiprotocol Extensions for BGP-4.";
+  }
+}


### PR DESCRIPTION
The latest version of iana-routing-types.yang was added and a symlink
pointing to it was created.