### PR TITLE
P802.1Qcx D1.1 Module revision

### DIFF
--- a/standard/ieee/draft/802.1/ieee802-dot1q-cfm-bridge.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1q-cfm-bridge.yang
@@ -35,9 +35,9 @@ module ieee802-dot1q-cfm-bridge {
     in Virtual Bridged Local Area Networks. This module binds
     the CFM modules to an IEEE 802.1Q Bridge.";
   
-  revision 2018-06-25 {
+  revision 2019-03-28 {
     description
-      "Creation for Task Group review.";
+      "Creation for Working Group review.";
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
@@ -65,31 +65,29 @@ module ieee802-dot1q-cfm-bridge {
   
   grouping service-id-grouping {
     description
-      "The list of VIDs, I-SID, or the TE-SID monitored by 
-      this MA, or 0, if the MA is not attached to a VID, or
-      I-SID, or TE-SID. In the case of a list of VIDs, the 
-      first VID in the list is the MAs Primary VID (default 
-      none). The specification of I-SID is allowed only in
-      the case of I- or B- components. The TE-SID is allowed
-      only in the case that PBB-TE is supported.";
+      "The list of VIDs, the I-SID, the TE-SID, or the SEG-ID
+      monitored by tehis MA, if present. In the case that a list
+      of VIDs is specified, the first VID in the list is the MA's
+      Primary VID (default none). The specificaiton of I-SID is 
+      allowed only in the case of I- or B-components. The TE-SID
+      is allowed only in the case that PBB-TE or SPBM is supported.
+      The SEG-ID is allowed only in the case that IPS is supported.";
     choice service-id {
-      default vid;
+      mandatory true;
       description
-        "The service identifiers types";
-      case none {
-        leaf zero {
-          type uint32 {
-            range "0";
+        "The type of service identifier.";
+      case vids {
+        list vid {
+          key "vlan-id";
+          description "A list of VIDs associated with any MHF on the
+            VID, always including that VID. The first VID is the 
+            MA's primary VID. List is empty if no primary VID 
+            specified";
+          leaf vlan-id {
+            type dot1q-types:vlanid;
+            description
+              "The 12-bit VLAN identifier.";
           }
-          description
-            "Represents no service identifier selected.";
-        }
-      }
-      case vid {
-        leaf-list vid {
-          type dot1q-types:vlanid;
-          description
-            "12-Bit identifier VLAN identifier.";
         }
       }
       case isid {
@@ -98,7 +96,7 @@ module ieee802-dot1q-cfm-bridge {
             range "1..16777215";
           }
           description
-            "24-Bit identifier I-SID identifier.";
+            "24-bit I-SID identifier.";
         }
       }
       case tesid {
@@ -127,7 +125,7 @@ module ieee802-dot1q-cfm-bridge {
             range "1..4294967295";
           }
           description
-            "The path-tesid is used as a service selector for SPBM 
+            "The path-tesid is used as a service selector for SPBM
             path MAs.";
         }
       }
@@ -137,7 +135,7 @@ module ieee802-dot1q-cfm-bridge {
             range "1..4294967295";
           }
           description
-            "The group-isid is used as a service selector for SPBM 
+            "The group-isid is used as a service selector for SPBM
             group MAs.";
         }
       }
@@ -153,16 +151,16 @@ module ieee802-dot1q-cfm-bridge {
   
   augment "/dot1q-cfm:cfm" {
     description
-      "Augment the base/common CFM model with CFM IEEE 802.1Qcp 
-      Bridge configuration specific attributes.";
+      "Augment the base/common CFM model with CFM Bridge 
+      specific attributes.";
     
     list cfm-stack {
-      key "port md-level direction service-selector service-id";
+      key "port service-selector service-id md-level direction";
       config false;
       description
         "The CFM Stack contains information about the Maintenance
         Points configured on a particular Bridge Port (or
-        aggregated port). It contains all CFM Stack specific related
+        Aggregation Port). It contains all CFM Stack specific related
         configuration and operational data.
         
         Upon a restart of the system, the system SHALL, if necessary,
@@ -177,7 +175,7 @@ module ieee802-dot1q-cfm-bridge {
         description
           "An interface on which maintenance points might be 
           configured. This object represents the Bridge Port or 
-          aggregated port on which MEPs or MHFs might be 
+          Aggregation Port on which MEPs or MHFs might be 
           configured.";
         reference
           "12.14.2.1.2a of IEEE Std 802.1Q-2018";
@@ -213,28 +211,77 @@ module ieee802-dot1q-cfm-bridge {
           "12.14.2.1.2d of IEEE Std 802.1Q-2018";
       }
       leaf maintenance-group-id {
+        when '../maintenance-point = "mep"' {
+          description
+            "This should only exist if the configured
+            maintenance point is a MEP (and not a MHF).";
+        }
         type leafref {
           path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-group'
-            + '/dot1q-cfm:maintenance-group-id';
+             + '/dot1q-cfm:maintenance-group-id';
         }
-        config false;
+        mandatory true;
         description
-          "The maintenance group to which the Maintenance Points
-          is associated with.";
+          "The maintenance group that the MEP is associated with. If
+          the Maintenance Point is a MHF created due to an entry in
+          the default-md-levels list, it has no associated 
+          maintenance group, and therefore this leaf is not present.";
       }
       leaf mep-id {
+        when '../maintenance-point = "mep"' {
+          description
+            "This should only exist if the configured
+            maintenance-point is a MEP.";
+        }
         type leafref {
           path '/dot1q-cfm:cfm'
-            + '/dot1q-cfm:maintenance-group'
-            + '[dot1q-cfm:maintenance-group-id = current()'
-            + '/../maintenance-group-id]'
-            + '/dot1q-cfm:mep/dot1q-cfm:mep-id';
+             + '/dot1q-cfm:maintenance-group'
+             + '[dot1q-cfm:maintenance-group-id = current()'
+             + '/../maintenance-group-id]'
+             + '/dot1q-cfm:mep/dot1q-cfm:mep-id';
         }
+        mandatory true;
         description
           "The MEP identifier if a MEP is configured. Does not exist
           if the maintenance point is a MHF.";
         reference
           "12.14.2.1.3d of IEEE Std 802.1Q-2018";
+      }
+      leaf md-id {
+        when '../maintenance-point != "mep"' {
+          description
+            "This should only exist if the configured
+            maintenance point is a MHF (and not a MEP).";
+        }
+        type leafref {
+          path '/dot1q-cfm:cfm/dot1q-cfm:maintenance-domain'
+            + '/dot1q-cfm:md-id';
+        }
+        description
+          "The maintenance domain that the MHF is 
+          associated with.  If the MHF is 
+          created due to an entry in the default-md-levels list, 
+          it has no associated maintenance domain, and therefore this
+          leaf is not present.";
+      }
+      leaf ma-id {
+        when '../maintenance-point != "mep"' {
+          description
+            "This should only exist if the configured maintenance
+            point is a MHF (and not a MEP), and it has a
+            Maintenance Domain.";
+        }
+        type leafref {
+          path '/dot1q-cfm:cfm'
+            +'/dot1q-cfm:maintenance-domain'
+            +'[dot1q-cfm:md-id = current()/../md-id]'
+            +'/dot1q-cfm:maintenance-association/dot1q-cfm:ma-id';
+        }
+        description
+          "The maintenance association that the MHF is associated
+          with.  If the MHF is created due to an entry in the 
+          default-md-levels list, it has no associated maintenance
+          association, and therefore this leaf is not present.";
       }
       leaf mac-address {
         type ieee:mac-address;
@@ -244,9 +291,9 @@ module ieee802-dot1q-cfm-bridge {
         reference
           "12.14.2.1.3e of IEEE Std 802.1Q-2018";
       }
-      leaf mp {
+      leaf maintenance-point {
         type cfm-types:mp-type;
-        config false;
+        mandatory true;
         description
           "Indicates the type of maintenance point. That is whether a
           MEP or MHF.";
@@ -256,7 +303,7 @@ module ieee802-dot1q-cfm-bridge {
     }  // cfm-stack
     
     list default-md-level {
-      key "bridge-id component-id primary-service-id service-selector";
+      key "bridge-id component-id service-selector primary-service-id";
       description
         "For each bridge component, the Default MD Level Managed 
         Object controls MHF creation for VIDs that are not attached
@@ -331,7 +378,7 @@ module ieee802-dot1q-cfm-bridge {
           "A Boolean value indicating whether this entry is in effect
           or has been overridden by the existence of a Maintenance
           Association managed object associated with the same VID or
-          I-SID of I- or Bcomponents and MD Level, and on which is
+          I-SID of I- or B-components and MD Level, and on which is
           configured an Up MEP. True if this Maintenance Domain
           managed object is in effect.";
         reference
@@ -376,14 +423,14 @@ module ieee802-dot1q-cfm-bridge {
         description
           "An enumerated value indicating what, if anything, is to be
           included in the Sender ID TLV transmitted by MPs configured
-          in the Default Maintenance Domain..";
+          in the Default Maintenance Domain.";
         reference
           "12.14.3.1.3e, 12.14.3.2.2a of IEEE Std 802.1Q-2018";
       }
     } // default-md-level
     
     list config-error {
-      key "port service-id service-selector";
+      key "port service-selector service-id";
       config false;
       description
         "The CFM Configuration Error List table provides a list of
@@ -428,10 +475,11 @@ module ieee802-dot1q-cfm-bridge {
   }
   
   augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-group" {
+    when "dot1q-cfm:maintenance-group-id";
     description
       "Augment the maintenance group list object with the
       maintenance association component identifier, since the 
-      maintenance association component is an IEEE 802.1Qcp bridge
+      maintenance association component is an Bridge
       specific attributes.";
     leaf bridge-id {
       type bridge-ref;
@@ -446,53 +494,61 @@ module ieee802-dot1q-cfm-bridge {
           + '[dot1q:name = current()/../cfm-bridge:bridge-id]'
           + '/dot1q:component/dot1q:name';
       }
-      //mandatory true;
+      mandatory true;
       description
         "A reference to the maintenance association component within
         the provided maintenance domain and maintenance association
         values.";
     }
-    leaf service-selector {
-      type cfm-types:service-selector-type;
+    container service-id {
       description
-        "The type of the service selector";
-    }
-    leaf service-id {
-      when "../service-selector";
-      type cfm-types:service-selector-value-type;
-      //mandatory true;
-      description
-        "A vid or isid in an I or B component.";
-      reference
-        "12.14.4.1.2a of IEEE Std 802.1Q-2018";
+        "The service identifier grouping.";
+      uses service-id-grouping;
     }
   }
   
   augment "/dot1q-cfm:cfm/dot1q-cfm:maintenance-group"
         + "/dot1q-cfm:mep" {
+    when "dot1q-cfm:mep-id";
     description
       "Augment the MEP object defined in the ieee802-dot1q-mep
-      (CFM MEP) YANG module with IEEE 802.1Qcp bridge specific
-      attributes.";
+      (CFM MEP) YANG module with Bridge specific attributes.";
     leaf port {
-      when "../../service-selector";
       type port-ref;
-      must '/dot1q-cfm:cfm'
+      must 'not(/dot1q-cfm:cfm'
+         + '/dot1q-cfm:maintenance-group'
+         + '/cfm-bridge:component-name)'
+         + ' or '
+         + '/dot1q-cfm:cfm'
          + '/dot1q-cfm:maintenance-group'
          + '/cfm-bridge:component-name = '
          + '/if:interfaces/if:interface[current() = ./if:name]'
          + '/dot1q:bridge-port/dot1q:component-name' {
         description
-          "The component of the port (Interface) reference must be
-          the same as the bridge and component references by the 
-          maintenance association group.";
+          "If there is a Bridge Component, then the component of the 
+          port (Interface) reference must be the same as the bridge 
+          and component references by the maintenance association
+          group.";
       }
-      //mandatory true;
+      mandatory true;
       description
         "The interface index of the interface (e.g., Bridge 
         Port) to which the MEP is attached.";
       reference
         "12.14.7.1.3b of IEEE Std 802.1Q-2018";
+    }
+    leaf primary-vid {
+      type leafref {
+        path '../../service-id/vid/vlan-id';
+      }
+      description
+        "An integer indicating the Primary VID of the MEP. It
+        is always one of the VIDs assigned to the MEPs MA. If not
+        present, then indicates that either the Primary VID is
+        that of the MEPs MA, or that the MEPs MA is 
+        associated with no VID.";
+      reference
+        "12.14.7.1.3d of IEEE Std 802.1Q-2018"; 
     }
   }
   

--- a/standard/ieee/draft/802.1/ieee802-dot1q-cfm-mip.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1q-cfm-mip.yang
@@ -28,7 +28,7 @@ module ieee802-dot1q-cfm-mip {
   description
     "TBD.";
   
-  revision 2018-06-25 {
+  revision 2019-03-28 {
     description
       "Creation for Task Group review.";
     reference

--- a/standard/ieee/draft/802.1/ieee802-dot1q-cfm-types.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1q-cfm-types.yang
@@ -25,9 +25,9 @@ module ieee802-dot1q-cfm-types {
   description
     "Common types used within ieee802-dot1q-cfm modules.";
   
-  revision 2018-06-25 {
+  revision 2019-03-28 {
     description
-      "Creation for Task Group review.";
+      "Creation for Working Group review.";
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
@@ -36,14 +36,33 @@ module ieee802-dot1q-cfm-types {
    * Type definitions used by 802.1Qcx YANG module.
    * ------------------------------------------------------
    */
+  typedef unicast-mac-address-type {
+    type string {
+      pattern "[0-9a-fA-F][02468aAcCeE](-[0-9a-fA-F]{2}){5}";
+    }
+    description
+      "A unicast destination MAC address. The I/G address bit is
+      used to identify the destination MAC address as an individual
+      MAC address or a group MAC address. If the I/G address bit is
+      0, it indicates that the MAC address field is an individual
+      MAC address. If this bit is 1, the MAC address is a group MAC
+      address that identifies one or more (or all) stations 
+      connected to the IEEE 802 network";
+  }
+    
+  typedef multicast-class1-mac-address-type {
+    type string {
+      pattern "(01-80-C2-00-00-3)[0-7]";
+    }
+    description
+      "The multicast class 1 MAC address must take the
+      form of 01-80-C2-00-00-3x, where x represents
+      the MEG level, with x being a value in the range
+      of 0..7.";
+  }
   
   typedef mp-type {
     type enumeration {
-      enum none {
-        value 0;
-        description
-          "No MP";
-      }
       enum mhf {
         value 1;
         description
@@ -58,6 +77,7 @@ module ieee802-dot1q-cfm-types {
     description
       "Indicates the type of Maintenance Point.";
   }
+  
   typedef mhf-creation-type {
     type enumeration {
       enum mhf-none {
@@ -79,7 +99,7 @@ module ieee802-dot1q-cfm-types {
         description
           "MHFs can be created for designated VID(s) or ISID only
           on Bridge Ports through which the VID(s) or ISID can pass, 
-          and onlyh if there is a MEP at the next lower active 
+          and only if there is a MEP at the next lower active 
           MD level on the port.";
       }
       enum mhf-defer {
@@ -111,7 +131,7 @@ module ieee802-dot1q-cfm-types {
     }
     description
       "Indicates the direction in which the Maintenance
-      association (MEP or MIP) faces on the Bridge Port.";
+      Point (MEP or MIP) faces on the Bridge Port.";
   }
   
   typedef mep-id-type {
@@ -124,7 +144,7 @@ module ieee802-dot1q-cfm-types {
   }
   
   typedef md-level-type {
-    type uint32 {
+    type uint8 {
       range "0..7";
     }
     description
@@ -159,7 +179,7 @@ module ieee802-dot1q-cfm-types {
       }
     }
     description
-      "An enumerated value from he Port Status TLV from the last CCM
+      "An enumerated value from the Port Status TLV from the last CCM
       received from the last MEP. It indicates the ability of the
       Bridge Port on which the transmitting MEP resides to pass
       ordinary data, regardless of the status of the MAC.";
@@ -187,7 +207,7 @@ module ieee802-dot1q-cfm-types {
       enum testing {
         value 3;
         description
-          "The interface is in same test mode.";
+          "The interface is in some test mode.";
       }
       enum unknown {
         value 4;
@@ -199,12 +219,12 @@ module ieee802-dot1q-cfm-types {
         value 5;
         description
           "The interface is not in a state to pass packets but is in
-          a pending state, waiting for some extrnal event.";
+          a pending state, waiting for some external event.";
       }
       enum not-present {
         value 6;
         description
-          "Some component of the interface is mssing.";
+          "Some component of the interface is missing.";
       }
       enum lower-layer-down {
         value 7;
@@ -240,8 +260,8 @@ module ieee802-dot1q-cfm-types {
         description
           "The last CCM received by this MEP from some remote MEP
           indicating that the transmitting MEP's associated MAC is
-          reporting an error status via the Port Status TLV or
-          Interface Status TLV is set.";
+          reporting its status via the Port Status TLV or Interface
+          Status TLV.";
       }
       enum def-remote-ccm {
         value 3;
@@ -266,7 +286,9 @@ module ieee802-dot1q-cfm-types {
       highestDefect (20.35.9 and Table 20-1), indicating the
       highest-priority defect that has been present since the MEP
       Fault Notification Generator State Machine was last in the
-      FNG_RESET state.";
+      FNG_RESET state. 
+      The integer value assigned to the enum value determines the
+      priority. The higher value corresponds to the higher priority.";
   }
   
   typedef lowest-alarm-priority-type {
@@ -274,14 +296,14 @@ module ieee802-dot1q-cfm-types {
       enum all-def {
         value 1;
         description
-          "Includes def-rid-ccm, def-mac-status, def-remote-ccm,
+          "Includes def-rdi-ccm, def-mac-status, def-remote-ccm,
           def-error-ccm, and def-xcon-ccm.";
       }
       enum mac-remote-error-xcon {
         value 2;
         description
-          "Only includes def-mac-status, def-remote-ccm, def-error-ccm,
-          and def-xcon-ccm.";
+          "Only includes def-mac-status, def-remote-ccm, 
+          def-error-ccm, and def-xcon-ccm.";
       }
       enum remote-error-xcon {
         value 3;
@@ -305,8 +327,9 @@ module ieee802-dot1q-cfm-types {
       }
     }
     description
-      "An integer value specifying the lowest priority defect
-      that is allowed to generate a Fault Alarm (20.9.5).";
+      "Specifies the lowest priority defect that is allowed to
+      generate a Fault Alarm (20.9.5). The to be reported defects
+      are identified per enum value.";
   }
   
   typedef sender-id-permission-type {
@@ -320,7 +343,7 @@ module ieee802-dot1q-cfm-types {
         value 2;
         description
           "The Chassis ID Length, Chassis ID Subtype, and Chassis ID
-          fields of te Sender ID TLV are to be sent.";
+          fields of the Sender ID TLV are to be sent.";
       }
       enum send-id-manage {
         value 3;
@@ -352,41 +375,41 @@ module ieee802-dot1q-cfm-types {
       enum 300hz {
         value 1;
         description
-          "CFM PDUs are sent every 3 1/3 milliseconds (300Hz).";
+          "CCM PDUs are sent every 3 1/3 milliseconds (300Hz).";
       }
       enum 10ms {
         value 2;
         description
-          "CFM PDUs are sent every 10 milliseconds.";
+          "CCM PDUs are sent every 10 milliseconds.";
       }
       enum 100ms {
         value 3;
         description
-          "CFM PDUs are sent every 100 milliseconds.";
+          "CCM PDUs are sent every 100 milliseconds.";
       }
       enum 1sec {
         value 4;
         description
-          "CFM PDUs are sent every second.";
+          "CCM PDUs are sent every second.";
       }
       enum 10sec {
         value 5;
         description
-          "CFm PDUs are sent every 10 seconds.";
+          "CCM PDUs are sent every 10 seconds.";
       }
       enum 1min {
         value 6;
         description
-          "CFM PDUs are sent every minute.";
+          "CCM PDUs are sent every minute.";
       }
       enum 10min {
         value 7;
         description
-          "CFM PDUs are sent every 10 minutes.";
+          "CCM PDUs are sent every 10 minutes.";
       }
     }
     description
-      "Indicates the interval at which CFM PDUs are sent by a MEP.";
+      "Indicates the interval at which CCM PDUs are sent by a MEP.";
   }
   
   typedef fng-state-type {
@@ -394,7 +417,7 @@ module ieee802-dot1q-cfm-types {
       enum fng-reset {
         value 1;
         description
-          "No defect has been present since the mep-fng-reset-time
+          "No defect has been present since the MEP's fng-reset-time
           timer expired, or since the state machine was last reset.";
       }
       enum fng-defect {
@@ -406,8 +429,9 @@ module ieee802-dot1q-cfm-types {
       enum fng-report-defect {
         value 3;
         description
-          "A momentary state during which the defect is reported by sending a
-          fault-alarm notification, if that action is enabled.";
+          "A momentary state during which the defect is reported by
+          sending a fault-alarm notification, if that action is 
+          enabled.";
       }
       enum fng-defect-reported {
         value 4;
@@ -417,7 +441,7 @@ module ieee802-dot1q-cfm-types {
       enum fng-defect-clearing {
         value 5;
         description
-          "No defect is present, but the mep-fng-reset-time timer
+          "No defect is present, but the MEP's fng-reset-time timer
           has not yet expired.";
       }
     }
@@ -501,13 +525,13 @@ module ieee802-dot1q-cfm-types {
           "The Egress Port can be identified, but the data frame would
           not pass through the Egress Port due to active topology 
           management (i.e., the Bridge Port is not in the 
-          Forwardin state.";
+          Forwarding state.";
       }
       enum egress-vid {
         value 4;
         description
-          "The Egress Port can be identified, but the Bridge Port is not
-          in the LTMs VIDs member set, so would be filtered by
+          "The Egress Port can be identified, but the Bridge Port is
+          not in the LTMs VIDs member set, so would be filtered by
           egress filtering.";
       }
     }
@@ -545,7 +569,7 @@ module ieee802-dot1q-cfm-types {
       state machine monitors the reception of valid CCMs from a
       remote MEP with a specific MEPID. It uses a timer that
       expires in 3.5 times the length of time indicated by the
-      ma-ccm-interval object.";
+      MA's ccm-interval object.";
   }
   
   typedef mep-defects-type {
@@ -565,7 +589,7 @@ module ieee802-dot1q-cfm-types {
       bit def-remote-ccm {
         position 2;
         description
-          "The MEP is not receiving valid VCMs from at least one of
+          "The MEP is not receiving valid CCMs from at least one of
           the remote MEPs.";
       }
       bit def-error-ccm {
@@ -578,7 +602,7 @@ module ieee802-dot1q-cfm-types {
         position 4;
         description
           "The MEP has received at last one CCM from either another 
-          MAID or a lower MD level whose CCm Interval has not yet 
+          MAID or a lower MD level whose CCM Interval has not yet 
           timed out.";
       }
     }
@@ -618,7 +642,7 @@ module ieee802-dot1q-cfm-types {
         description
           "A MEP is created for one VID at one MD Level, but a MEP is
           configured on another VID at that MD Level or higher,
-          exceeding the Bridges capabilities.";
+          exceeding the Bridge's capabilities.";
       }
     }
     description
@@ -629,11 +653,6 @@ module ieee802-dot1q-cfm-types {
   
   typedef mep-tx-ltm-flags-type {
     type bits {
-      bit no-flags {
-        position 0;
-        description
-          "No flags set";
-      }
       bit use-fdb-only {
         position 1;
         description
@@ -644,7 +663,7 @@ module ieee802-dot1q-cfm-types {
       "The flags field for LTMs transmitted by the MEP.";
   }
   
-  typedef fault-alarm-address-type {
+  typedef fault-alarm-type {
     type enumeration {
       enum address {
         value 1;
@@ -653,13 +672,13 @@ module ieee802-dot1q-cfm-types {
           are to be transmitted should be used.";
       }
       enum not-transmitted {
-        value 3;
+        value 2;
         description
           "Indicates that Fault alarms are not to be transmitted.";
       }
     }
     description
-      "The Fault Alarm address indicators.";
+      "The Fault Alarm indicators.";
   }
   
   typedef lbm-data-tlv-type {
@@ -676,16 +695,16 @@ module ieee802-dot1q-cfm-types {
       pattern '[0-9a-zA-Z\-_.]*';
     }
     description
-      "The maintenance domains and maintenance association list key type.";
+      "String type with at least 1 and up to 255 of the specified
+      characters.";
   }
-  
   
   typedef seq-number-type {
     type uint32 {
       range "0..4294967295";
     }
     description
-      "The transaction identifer or sequence number of the CFM PDU.";
+      "The transaction identifier or sequence number of the CFM PDU.";
   }
   
   typedef service-selector-type {
@@ -693,43 +712,42 @@ module ieee802-dot1q-cfm-types {
       enum ieee-reserved-0 {
         value 0;
         description
-        "Reserved for definition by IEEE 802.1 recommend to not
-        use zero unless absolutely needed.";
+          "Reserved for definition by IEEE 802.1.";
       }
       enum vlan-id {
         value 1;
         description
-        "12-bit identifier found in a VLAN tag.";
+          "12-bit identifier found in a VLAN tag.";
       }
       enum isid {
         value 2;
         description
-        "24-bit identifier found in an I-TAG.";
+          "24-bit identifier found in an I-TAG.";
       }
       enum tesid {
         value 3;
         description
-        "32-bit identifier";
+          "32-bit identifier";
       }
       enum segid {
         value 4;
         description
-        "32-bit identifier";
+          "32-bit identifier";
       }
       enum path-tesid {
         value 5;
         description
-        "32-bit identifier";
+          "32-bit identifier";
       }
       enum group-isid {
         value 6;
         description
-        "24 bit identifier";
+          "24 bit identifier";
       }
       enum ieee-reserved {
         value 7;
         description
-        "Reserved for definition by IEEE 802.1";
+          "Reserved for definition by IEEE 802.1";
       }
     }
     default "vlan-id";
@@ -738,50 +756,24 @@ module ieee802-dot1q-cfm-types {
       of a service-selector-value.";
     }
   
-    typedef service-selector-value-type {
-      type uint32 {
-        range "1..4294967295";
-      }
-      description
-        "An integer that uniquely identifies a generic MAC Service,
-        or none. Examples of service selectors are a VLAN-ID
-        (IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
-        An service-selector-value value is always interpreted
-        within the context of an service-selector-type value.
-        Every usage of the service-selector-value textual
-        convention is required to specify the
-        service-selector-type object that provides the context.
-        The value of an service-selector-value object must
-        always be consistent with the value of the associated
-        service-selector-type object. Attempts to set an
-        service-selector-value object to a value inconsistent
-        with the associated service-selector-type must fail
-        with an inconsistent-value error.";
+  typedef service-selector-value-type {
+    type uint32 {
+      range "1..4294967295";
     }
-    
-    typedef service-selector-value-or-none-type {
-      type uint32 {
-        range "0 | 1..4294967295";
-      }
-      description
-        "An integer that uniquely identifies a generic MAC Service,
-        or none. Examples of service selectors are a VLAN-ID
-        (IEEE 802.1Q) and an I-SID (IEEE 802.1ah).
-        An service-selector-value value is always interpreted
-        within the context of an service-selector-type value.
-        Every usage of the service-selector-value textual
-        convention is required to specify the
-        service-selector-type object that provides the context.
-        The value of an service-selector-value object must
-        always be consistent with the value of the associated
-        service-selector-type object. Attempts to set an
-        service-selector-value object to a value inconsistent
-        with the associated service-selector-type must fail
-        with an inconsistent-value error.
-        The special value of zero is used to indicate that no
-        service selector is present or used. This can be used in
-        any situation where an object or a table entry MUST either
-        refer to a specific service, or not make a selection.";
-    }
+    description
+      "An integer that uniquely identifies a generic MAC Service,
+      or none. Examples of service selectors are a VLAN-ID
+      and an I-SID. A service-selector-value value is always 
+      interpreted within the context of a service-selector-type
+      value. Every usage of the service-selector-value textual
+      convention is required to specify the
+      service-selector-type object that provides the context.
+      The value of a service-selector-value object must
+      always be consistent with the value of the associated
+      service-selector-type object. Attempts to set a
+      service-selector-value object to a value inconsistent
+      with the associated service-selector-type must fail
+      with an inconsistent-value error.";
+  }
   
 } // ieee802-dot1q-cfm-types

--- a/standard/ieee/draft/802.1/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1q-cfm.yang
@@ -34,12 +34,12 @@ module ieee802-dot1q-cfm {
     for detecting, verifying, and isolating connectivity failures
     in Virtual Bridged Local Area Networks. These capabilities
     can be used in networks operated by multiple independent
-    organizations, each wit restricted management access to each others
-    equipment.";
+    organizations, each with restricted management access to each 
+    other's equipment.";
   
-  revision 2018-06-25 {
+  revision 2019-03-28 {
     description
-      "Creation for Task Group review.";
+      "Creation for Working Group review.";
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
@@ -82,8 +82,9 @@ module ieee802-dot1q-cfm {
           type empty;
           description
             "No format specified, usually because there is not a
-            Maintenance Domain Name. In this case, a zero length OCTET
-            string for the Domain name field is acceptable.";
+            Maintenance Domain Name. The Maintenance Domain name
+            inserted in CFM protocol messages will be an zero 
+            length OCTET string.";
         }
       }
       case dns-like-name {
@@ -104,12 +105,13 @@ module ieee802-dot1q-cfm {
       case char-string {
         leaf char-string {
           type string {
-            length "0..43";
+            length "1..43";
+            pattern '[ -~]*';
           }
           default "DEFAULT";
           description
-            "RFC2579 DisplayString, except that the character codes 0-31
-            (decimal) are not used.";
+            "RFC2579 DisplayString, except that the character 
+            codes 0-31 (decimal) are not used.";
         }
       }
     }
@@ -133,17 +135,18 @@ module ieee802-dot1q-cfm {
         leaf char-string {
           type string {
             length "1..45";
+            pattern '[ -~]*';
           }
           description
-            "RFC2579 DisplayString, except that the character codes 0-31
-            (decimal) are not used.";
+            "RFC2579 DisplayString, except that the character codes
+            0-31 (decimal) are not used.";
         }
       }
       case unsigned-int16 {
         leaf unsigned-int16 {
           type uint16;
           description
-            "2-octet integer/big endian.";
+            "2-octet integer.";
         }
       }
       case rfc2865-vpn-id {
@@ -153,25 +156,20 @@ module ieee802-dot1q-cfm {
             Unique Identifier followed by 4 octet VPN index identifying
             VPN according to the OUI.";
           leaf vpn-oui {
-            type uint32;
+            type uint32 {
+              range "0..16777215";
+            }
+            mandatory true;
             description
               "3 octet VPN authority Organizationally Unique
               Identifier.";
           }
-          leaf vpn-idex {
+          leaf vpn-index {
             type uint32;
+            mandatory true;
             description
               "4 octet VPN index identifying VPN according to OUI.";
           }
-        }
-      }
-      case icc-format {
-        leaf icc-format {
-          type string {
-            length "1..13";
-          }
-          description
-            "ICC-based format as specified in ITU-T Y.1731.";
         }
       }
     }
@@ -182,536 +180,257 @@ module ieee802-dot1q-cfm {
       "Defines the Management Address.";
     reference
       "21.5.3.5 of IEEE Std 802.1Q-2018";
-  
-    choice management-address-domain {
+    
+    leaf domain {
+      type yang:object-identifier-128;
       description
-        "Selects the domain of the management address";
+        "The domain type.";
+    }
+  
+    choice management-address {
+      when "./domain";
+      description
+        "Selects the management address";
         
-      case udp-ipv4 {
+      case ip {
         description
-          "Represents an IPv4 UDP transport address consisting of an 
-           IPv4 address, and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv4";
+          "Represents an IP TCP, UDP, or SCTP transport 
+          address consisting of an IPv4/v6 address, and a port 
+          number, associated with the domain type defined by the 
+          domain leaf node.";
           
-        leaf udp-ipv4-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1";
-            }
-          default "1.3.6.1.2.1.100.1";
-          description
-            "The domain type transportDomainUdpIpv4 corresponding to
-            OID 1.3.6.1.2.1.100.1";
-        }
-        leaf udp-ipv4-address {
-          type inet:ipv4-address;
+        leaf ip-address {
+          type inet:ip-address;
           mandatory true;
           description
-            "UDP IPv4 address.";
+            "IPv4 or IPv6 address.";
         }
-        leaf udp-ipv4-port {
+        leaf ip-port {
           type inet:port-number;
           mandatory true;
           description
-            "UDP IPv4 port.";
+            "IP port.";
         }
       }
-      
-      case udp-ipv6 {
-        description
-          "Represents an IPv6 UDP transport address consisting of an 
-           IPv6 address and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv6";
-          
-        leaf udp-ipv6-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.2"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.2";
-            }
-          default "1.3.6.1.2.1.100.1.2";
-          description
-            "The domain type transportDomainUdpIpv6";
-        }
-        leaf udp-ipv6-address {
-          type inet:ipv6-address;
-          mandatory true;
-          description
-            "UDP IPv6 address.";
-        }        
-        leaf udp-ipv6-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "UDP IPv6 port.";
-        }
-      }
-      
-      case udp-ipv4z {
-        description
-          "Represents a UDP transport address consisting of an IPv4 
-           address, a zone index and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv4z";
-          
-        leaf udp-ipv4z-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.3"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.3";
-            }
-          default "1.3.6.1.2.1.100.1.3";
-          description
-            "The domain type transportDomainUdpIpv4z";
-        }
-        leaf udp-ipv4z-address {
-          type inet:ipv4-address;
-          mandatory true;
-          description
-            "UDP IPv4 address.";
-        }        
-        leaf udp-ipv4z-index {
-          type uint32;
-          mandatory true;
-          description
-            "UDP IPv4 zone index.";
-        }
-        leaf udp-ipv4z-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "UDP IPv4 port.";
-        }
-      }
-      
-      case udp-ipv6z {
-        description
-          "Represents a UDP transport address consisting of an IPv6 
-           address, a zone index and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpIpv6z";
-          
-        leaf udp-ipv6z-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.4"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.4";
-            }
-          default "1.3.6.1.2.1.100.1.4";
-          description
-            "The domain type transportDomainUdpIpv6z";
-        }
-        leaf udp-ipv6z-address {
-          type inet:ipv6-address;
-          mandatory true;
-          description
-            "UDP IPv6 address.";
-        }        
-        leaf udp-ipv6z-index {
-          type uint32;
-          mandatory true;
-          description
-            "UDP IPv6 zone index.";
-        }
-        leaf udp-ipv6z-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "UDP IPv6 port.";
-        }
-      }
-      
-      case tcp-ipv4 {
-        description
-          "Represents an IPv4 TCP transport address consisting of an 
-           IPv4 address and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv4";
-          
-        leaf tcp-ipv4-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.5"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.5";
-            }
-          default "1.3.6.1.2.1.100.1.5";
-          description
-            "The domain type transportDomainTcpIpv4";
-        }
-        leaf tcp-ipv4-address {
-          type inet:ipv4-address;
-          mandatory true;
-          description
-            "TCP IPv4 address.";
-        }        
-        leaf tcp-ipv4-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "TCP IPv4 port.";
-        }
-      }
-      
-      case tcp-ipv6 {
-        description
-          "Represents an IPv6 TCP transport address consisting of an 
-           IPv6 address and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv6";
-
-        leaf tcp-ipv6-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.6"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.6";
-            }
-          default "1.3.6.1.2.1.100.1.6";
-          description
-            "The domain type transportDomainTcpIpv6";
-        }
-        leaf tcp-ipv6-address {
-          type inet:ipv6-address;
-          mandatory true;
-          description
-            "TCP IPv6 address.";
-        }
-        leaf tcp-ipv6-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "TCP IPv6 port.";
-        }
-      }
-      
-      case tcp-ipv4z {
-        description
-          "Represents a TCP IPv4 transport address consisting of an 
-           IPv4 address, a zone index and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv4z";
-          
-        leaf tcp-ipv4z-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.7"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.7";
-            }
-          default "1.3.6.1.2.1.100.1.7";
-          description
-            "The domain type transportDomainTcpIpv4z";
-        }
-        leaf tcp-ipv4z-address {
-          type inet:ipv4-address;
-          mandatory true;
-          description
-            "TCP IPv4 address.";
-        }        
-        leaf tcp-ipv4z-index {
-          type uint32;
-          mandatory true;
-          description
-            "TCP IPv4 zone index.";
-        }
-        leaf tcp-ipv4z-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "TCP IPv4 port.";
-        }
-      }
-      
-      case tcp-ipv6z {
-        description
-          "Represents a TCP IPv6 transport address consisting of an 
-           IPv6 address, a zone index and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpIpv6z";
-          
-        leaf tcp-ipv6z-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.8"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.8";
-            }
-          default "1.3.6.1.2.1.100.1.8";
-          description
-            "The domain type transportDomainTcpIpv6z";
-        }
-        leaf tcp-ipv6z-address {
-            type inet:ipv6-address;
-            mandatory true;
-            description
-              "TCP IPv6 address.";
-        }          
-        leaf tcp-ipv6z-index {
-          type uint32;
-          mandatory true;
-          description
-            "TCP IPv6 zone index.";
-        }        
-        leaf tcp-ipv6z-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "TCP IPv6 port.";
-        }
-      }
-      
-      case sctp-ipv4 {
-        description
-          "Represents an IPv4 SCTP transport address consisting of 
-           an IPv4 address and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv4";
-          
-        leaf sctp-ipv4-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.9"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.9";
-            }
-          default "1.3.6.1.2.1.100.1.9";
-          description
-            "The domain type transportDomainSctpIpv4";
-        }
-        leaf sctp-ipv4-address {
-          type inet:ipv4-address;
-          mandatory true;
-          description
-            "SCTP IPv4 address.";
-        }        
-        leaf sctp-ipv4-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "SCTP IPv4 port.";
-        }
-      } 
-      
-      case sctp-ipv6 {
-        description
-          "Represents an IPv6 SCTP transport address consisting of 
-           an IPv6 address and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv6";
-          
-        leaf sctp-ipv6-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.10"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.10";
-            }
-          default "1.3.6.1.2.1.100.1.10";
-          description
-            "The domain type transportDomainSctpIpv6";
-        }
-        leaf sctp-ipv6-address {
-          type inet:ipv6-address;
-          mandatory true;
-          description
-            "SCTP IPv6 address.";
-        }        
-        leaf sctp-ipv6-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "SCTP IPv6 port.";
-        }
-      }
-      
-      case sctp-ipv4z {
-        description
-          "Represents an SCTP IPv4 transport address consisting of 
-           an IPv4 address, a zone index and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv4z";
-          
-        leaf sctp-ipv4z-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.11"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.11";
-            }
-          default "1.3.6.1.2.1.100.1.11";
-          description
-            "The domain type transportDomainSctpIpv4z";
-        }
-        leaf sctp-iv4z-address {
-          type inet:ipv4-address;
-          mandatory true;
-          description
-            "SCTP IPv4 address.";
-        }        
-        leaf sctp-ipv4z-index {
-          type uint32;
-          mandatory true;
-          description
-            "SCTP IPv4 zone index.";
-        }        
-        leaf sctp-ipv4z-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "SCTP IPv4 port.";
-        }
-      }
-      
-      case sctp-ipv6z {
-        description
-          "Represents an SCTP IPv6 transport address consisting of 
-           an IPv6 address, a zone index and a port number.";
-        reference
-          "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpIpv6z";
-          
-        leaf sctp-ipv6z-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.12"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.12";
-            }
-          default "1.3.6.1.2.1.100.1.12";
-          description
-            "The domain type transportDomainSctpIpv6z";
-        }
-        leaf sctp-ipv6z-address {
-          type inet:ipv6-address;
-          mandatory true;
-          description
-            "SCTP IPv6 address.";
-        }        
-        leaf sctp-ipv6z-index {
-          type uint32;
-          mandatory true;
-          description
-            "SCTP IPv6 zone index.";
-        }        
-        leaf sctp-ipv6z-port {
-          type inet:port-number;
-          mandatory true;
-          description
-            "SCTP IPv6 port.";
-        }
-      }
-      
+            
       case local {
-        leaf local-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.13"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.13";
-            }
-          default "1.3.6.1.2.1.100.1.13";
-          description
-            "The domain type";
-        }
         leaf local-address {
           type string {
             length '1..255';
           }
           mandatory true;
           description
-            "Represents a POSIX Local IPC transport address.";
+            "Represents a POSIX Local IPC transport address, 
+            associated with the domain type defined by the 
+            domain leaf node.";
         }
       }
       
-      case udp-dns {
-        leaf udp-dns-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.14"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.14";
-            }
-          default "1.3.6.1.2.1.100.1.14";
-          description
-            "The domain type";
-        }
-        leaf udp-dns-address {
+      case dns {
+        leaf dns-address {
           type string {
             length "1..255";
           }
           mandatory true;
           description
-            "The UDP transport domain using fully qualified domain 
-             names. Represents a DNS domain name followed by a colon 
-             ':' (ASCII character 0x3A) and a port number in ASCII. 
-             The name SHOULD be fully qualified whenever possible.";
-          reference
-            "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainUdpDns";
+            "The transport domain using fully qualified domain 
+            names, associated with the domain type defined by the 
+            domain leaf node. Represents a DNS domain name followed
+            by a colon ':' (ASCII character 0x3A) and a port number
+            in ASCII. The name SHOULD be fully qualified whenever
+            possible.";
         }
       }
       
-      case tcp-dns {
-        leaf tcp-dns-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.15"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.15";
-            }
-          default "1.3.6.1.2.1.100.1.15";
-          description
-            "The domain type";
-        }
-        leaf tcp-dns-address {
-          type string {
+      case other {
+        leaf unknown-address {
+          type binary {
             length "1..255";
           }
-          mandatory true;
           description
-            "The TCP transport domain using fully qualified domain 
-             names. Represents a DNS domain name followed by a colon 
-             ':' (ASCII character 0x3A) and a port number in ASCII. 
-             The name SHOULD be fully qualified whenever possible.";
-          reference
-            "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainTcpDns";
-        }
-      }
-      
-      case sctp-dns {
-        leaf sctp-dns-domain {
-          type yang:object-identifier-128;
-          must '. = "1.3.6.1.2.1.100.1.16"' {
-            description
-              "The value of the OID for this domain must be
-              1.3.6.1.2.1.100.1.16";
-            }
-          default "1.3.6.1.2.1.100.1.16";
-          description
-            "The domain type";
-        }
-        leaf sctp-dns-address {
-          type string {
-            length "1..255";
-          }
-          mandatory true;
-          description
-            "The SCTP transport domain using fully qualified domain 
-             names. Represents a DNS domain name followed by a colon 
-             ':' (ASCII character 0x3A) and a port number in ASCII. 
-             The name SHOULD be fully qualified whenever possible.";
-          reference
-            "RFC3419 TRANSPORT-ADDRESS-MIB.transportDomainSctpDns";
+            "This represents an undefined address, for the case when 
+            the domain type provided is an unrecognizable value.";
         }
       }
     }
   }
+
+  grouping loopback-input-grouping {
+    description
+      "Defines the group of loopback input parameters.";
+    choice lbm-destination {
+      mandatory true;
+      description
+        "Selects the destination type (which is
+        either MEP identifier or MAC address) used
+        for the Loopback transmissions.";
+      case dest-ucast-mac-address {
+        description
+          "The target unicast MAC Address field to be 
+          transmitted. A unicast destination MAC address.";
+        leaf lbm-dest-ucast-mac-address {
+          type cfm-types:unicast-mac-address-type;
+          description
+            "The target MAC Address field to be transmitted.
+            A unicast destination MAC address.";
+          reference
+            "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+        }
+      }
+      case dest-mcast-class1-mac-address {
+        description
+          "The target multicast Class 1 MAC address field to be
+          transmitted.";
+        leaf lbm-dest-mcast-class1-mac-address {
+          type cfm-types:multicast-class1-mac-address-type;
+          description
+            "The target multicast Class 1 MAC address field to
+            be transmitted";
+        }
+      }
+      case dest-mep-id {
+        description
+          "The identifier of a remote MEP in the same MA to
+          which the LBM is to be sent.";
+        leaf lbm-dest-mep-id {
+          type cfm-types:mep-id-type;
+          description
+            "The identifier of a remote MEP in the same MA to
+            which the LBM is to be sent.";
+          reference
+            "12.14.7.3.2b of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+    leaf lbm-messages {
+      type uint16 {
+        range "1..1024";
+      }
+      default 1;
+      description
+        "The number of Loopback messages to be transmitted.";
+      reference
+        "12.14.7.3.2c of IEEE Std 802.1Q-2018";
+    }
+    leaf lbm-priority {
+      type dot1q-types:priority-type;
+      default 7;
+      description
+        "Priority. 3 bit value to be used in the VLAN tag, if
+        present in the transmitted frame. The default value
+        should be the CCM priority (ccm-ltm-priority).";
+      reference
+        "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+    }
+    leaf lbm-drop-eligible {
+      type boolean;
+      default "false";
+      description
+        "Drop eligible bit value to be used in the VLAN tag, if 
+        present in the transmitted frame. A value 'true' means 
+        inserting value '1' in the DEI field, while a value 
+        'false' means inserting value '0' in the DEI field.";
+      reference
+        "12.14.7.3.2e of IEEE Std 802.1Q-2018";
+    }
+    leaf lbm-data-tlv {
+      type cfm-types:lbm-data-tlv-type;
+      description
+        "An arbitrary amount of data to be included in the
+        Data TLV, if the Data TLV is selected to be sent.";
+      reference
+        "12.14.7.3.2d of IEEE Std 802.1Q-2018";
+    }
+  }
+  
+  grouping linktrace-input-grouping {
+    description
+      "Defines the group of linktrace input parameters. By default,
+      the priority used is that of the CCMs (ccm-ltm-priority)
+      and the drop elibility is false. ";
+    choice ltr-target {
+      mandatory true;
+      description
+        "Selects the target address type (which is
+        either MEP identifier or MAC address) used
+        for the Linktrace transmissions.";
+      case target-ucast-mac-address {
+        description
+          "The target MAC address field to be transmitted. A
+          unicast MAC address.";
+        leaf ltm-target-mac-address {
+          type cfm-types:unicast-mac-address-type;
+          description
+            "The target MAC address field to be transmitted.
+            A unicast MAC address.";
+          reference
+            "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+        }
+      }
+      case target-mep-id {
+        description
+          "The target MAC address field to be transmitted. 
+          The MEP identifier of another MEP in the same MA.";
+        leaf ltm-target-mep-id {
+          type cfm-types:mep-id-type;
+          description
+            "The target MAC address field to be transmitted.
+            The MEP identifier of another MEP in the same MA.";
+          reference
+            "12.14.7.4.2c of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+    leaf ltm-ttl {
+      type uint8 {
+        range "0..255";
+      }
+      default 64;
+      description
+        "The LTM TTL field. Indicates the number of hops 
+        remaining to the LTM. Decremented by 1 by each
+        Linktrace Responder that handles the LTM. The value
+        returned in the LTR is one less than that received in
+        the LTM. If the LTM TTL is 0 or 1, the LTM is not
+        forwarded to the next hop, and if 0, no LTR is 
+        generated.";
+      reference
+        "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf ltm-flags {
+      type cfm-types:mep-tx-ltm-flags-type;
+      default '';
+      description
+        "The flags field for the LTMs transmitted by the MEP.";
+      reference
+        "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
+      
+    }
+  }
+  
+  grouping ltm-egress-identifier-grouping {
+    description
+      "The grouping used to identify the MEP Linktrace 
+      initiator that is originating the LTM. It defines
+      the MAC address and uint type definition.";
+    leaf int {
+      type uint16;
+      mandatory true;
+      description
+        "A value used to uniquely identify the MEP 
+        Linktrace Initiator or Linktrace Responder within
+        that system.";
+    }
+    leaf address {
+      type ieee:mac-address;
+      mandatory true;
+      description
+        "A 48-bit IEEE MAC address unique to the system in
+       which the MEP Linktrace Initiator or Linktrace 
+       Responder resides.";
+    }
+  }
+  
   
   /* ---------------------------------------------------
    * Configuration objects used by 802.1Qcx YANG module
@@ -749,6 +468,10 @@ module ieee802-dot1q-cfm {
       }
       leaf mhf-creation {
         type cfm-types:mhf-creation-type;
+        must '. != "mhf-defer"' {
+          description
+            "The value mhf-defer is not allowed";
+        }
         default mhf-none;
         description
           "Value indicating whether the management entity can
@@ -760,6 +483,10 @@ module ieee802-dot1q-cfm {
       }
       leaf id-permission {
         type cfm-types:sender-id-permission-type;
+        must '. != "send-id-defer"' {
+          description
+            "The value send-id-defer is not allowed";
+        }
         default send-id-none;
         description
           "Value indicating what, if anything, is to be included in
@@ -770,8 +497,8 @@ module ieee802-dot1q-cfm {
         reference
           "3.122, 12.14.5.1.3d of IEEE Std 802.1Q-2018";
       }
-      leaf fault-alarm-address {
-        type cfm-types:fault-alarm-address-type;
+      leaf fault-alarm-transmission {
+        type cfm-types:fault-alarm-type;
         default "not-transmitted";
         description
           "A value indicating whether Fault Alarms are to be 
@@ -805,8 +532,8 @@ module ieee802-dot1q-cfm {
           reference
             "12.14.6.1.3e of IEEE Std 802.1Q-2018";
         }
-        leaf fault-alarm-address {
-          type cfm-types:fault-alarm-address-type;
+        leaf fault-alarm-transmission {
+          type cfm-types:fault-alarm-type;
           description
             "A value indicating whether Fault Alarms are to be 
             transmitted or not. If this leaf node is not present
@@ -821,7 +548,7 @@ module ieee802-dot1q-cfm {
           description
             "Value indicating whether the management entity can
             create MHFs (MIP Half Function) for this Maintenance
-            Domain.";
+            Association.";
           reference
             "3.122, 12.14.5.1.3c of IEEE Std 802.1Q-2018";
         }
@@ -836,7 +563,7 @@ module ieee802-dot1q-cfm {
             "12.14.3.1.3d of IEEE Std 802.1Q-2018";
         }
         
-        list maintenance-association-mep-list {
+        list maintenance-association-mep {
           key mep-id;
           description
             "The list of all MEPs that belong to this Maintenance
@@ -882,9 +609,9 @@ module ieee802-dot1q-cfm {
         }
         mandatory true;
         description
-          "A reference to the maintenance association in the specified
-          maintenance domain, that this maintanance group is 
-          associated with.";
+          "A reference to the maintenance association in the 
+          specified maintenance domain, that this maintenance group
+          is associated with.";
       }
       
       list mep {
@@ -903,7 +630,7 @@ module ieee802-dot1q-cfm {
               + '[md-id = current()/../../md-id]'
               + '/maintenance-association'
               + '[ma-id = current()/../../ma-id]'
-              + '/maintenance-association-mep-list'
+              + '/maintenance-association-mep'
               + '/mep-id';
           }
           description
@@ -921,20 +648,6 @@ module ieee802-dot1q-cfm {
           reference
             "12.14.7.1.3c, 19.2 of IEEE Std 802.1Q-2018";
         }
-        leaf primary-vid {
-          type uint32 {
-            range "0..16777215";
-          }
-          default 0;
-          description
-            "An integer indicating the Primary VID of the MEP. It
-            is always one of the VIDs assigned to the MEPs MA. A
-            value of 0 indicates that either the Primary VID is
-            that of the MEPs MA, or that the MEPs MA is 
-            associated with no VID.";
-          reference
-            "12.14.7.1.3d of IEEE Std 802.1Q-2018"; 
-        }
         leaf admin-state {
           type boolean;
           default "false";
@@ -947,7 +660,7 @@ module ieee802-dot1q-cfm {
         }
         leaf ccm-ltm-priority {
           type dot1q-types:priority-type;
-          mandatory true;
+          default 7;
           description
             "The priority value for CCMs and LTMs transmitted by
             the MEP. The default value is the highest priority 
@@ -965,6 +678,32 @@ module ieee802-dot1q-cfm {
           reference
             "12.14.7.1.3i, 19.4 of IEEE Std 802.1Q-2018";
         }
+        list inactive-remote-mep {
+          key inactive-rmep-id;
+          description
+            "A list indicating which of the remote MEPs in the same
+            MA are inactive. The Remote MEP state machines (20.20)
+            are instantiated only for the remote MEPs which are
+            present in the maintenance-association-mep-list, but
+            not in this list. By default, all configured remote
+            MEPs in the same MA are active";
+          leaf inactive-rmep-id {
+            type leafref {
+              path '/cfm/maintenance-domain'
+                 + '[md-id = current()/../../../md-id]'
+                 + '/maintenance-association'
+                 + '[ma-id = current()/../../../ma-id]'
+                 + '/maintenance-association-mep'
+                 + '/mep-id';
+            }
+            description
+              "Maintenance association Endpoint Identifier of a
+              remote MEP for which the Remote MEP state machine
+              should not be instantiated.";
+            reference
+              "12.14.7.1.3ae of IEEE Std 802.1Q-2018";
+            }
+          } //inactive-remote-mep
         
         list mep-db {
           key rmep-id;
@@ -972,16 +711,9 @@ module ieee802-dot1q-cfm {
           description
             "The MEP CCM Database. A database, maintained by every 
             MEP, that maintains received information about other MEPs
-            in the Maintenance Domain.";
+            in the Maintenance Association.";
           leaf rmep-id {
-            type leafref {
-              path '/cfm/maintenance-domain'
-                + '[md-id = current()/../../../md-id]'
-                + '/maintenance-association'
-                + '[ma-id = current()/../../../ma-id]'
-                + '/maintenance-association-mep-list'
-                + '/mep-id';
-            }
+            type cfm-types:mep-id-type;
             description
               "Maintenance association Endpoint Identifier of a
               remote MEP whose information from the MEP Database
@@ -999,7 +731,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3b, 20.20 of IEEE Std 802.1Q-2018";
           }
           leaf rmep-failed-ok-time {
-            type yang:zero-based-counter64;
+            type yang:date-and-time;
             units milliseconds;
             mandatory true;
             description
@@ -1079,7 +811,7 @@ module ieee802-dot1q-cfm {
             type boolean;
             default "true";
             description
-              "A Boolean value statign if the remote MEP is 
+              "A Boolean value stating if the remote MEP is 
               active.";
             reference
               "12.14.7.1.3ae";
@@ -1108,13 +840,13 @@ module ieee802-dot1q-cfm {
             reference
               "12.14.7.1.3f, 20.35 of IEEE Std 802.1Q-2018";
           }
-          leaf fault-alarm-address {
-            type cfm-types:fault-alarm-address-type;
+          leaf fault-alarm-transmission {
+            type cfm-types:fault-alarm-type;
             description
               "A value indicating whether Fault Alarms are to be 
-              transmitted or not. The default is not specified, 
-              which implies that the disposition of the fault-alarm
-              used by the MD should be used.";
+              transmitted or not. If this leaf is not specified, 
+              the disposition of the fault-alarm used by the MD
+              should be used.";
             reference
               "3.122, 12.14.7.1.3j of IEEE Std 802.1Q-2018";
           }
@@ -1128,7 +860,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.1.3k, 20.9.5 of IEEE Std 802.1Q-2018";
           }
           leaf fng-alarm-time {
-            type yang:zero-based-counter32 {
+            type uint16 {
               range "2500..10000";
             }
             units milliseconds;
@@ -1140,7 +872,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.1.3l, 20.35.3 of IEEE Std 802.1Q-2018";
           }
           leaf fng-reset-time {
-            type yang:zero-based-counter32 {
+            type uint16 {
               range "2500..10000";
             }
             units milliseconds;
@@ -1157,7 +889,7 @@ module ieee802-dot1q-cfm {
             mandatory true;
             description
               "The highest priority defect that has been present
-              sicne the MEPs Fault Notification Generator state
+              since the MEPs Fault Notification Generator state
               machine was last in the FNG_RESET state.";
             reference
               "12.14.7.1.3n, 20.35.9 of IEEE Std 802.1Q-2018";
@@ -1170,7 +902,8 @@ module ieee802-dot1q-cfm {
               "Vector of boolean error conditions";
             reference
               "12.14.7.1.3o-s, 20.21.3,
-              20.23.3, 20.35.5, 20.35.6, 20.35.7 of IEEE Std 802.1Q-2018";
+              20.23.3, 20.35.5, 20.35.6, 20.35.7 of IEEE Std 
+              802.1Q-2018";
           }
           leaf error-ccm-last-failure {
             type binary {
@@ -1265,115 +998,21 @@ module ieee802-dot1q-cfm {
         
         action transmit-loopback {
           description
-            "To signal to the MEP to transmit some number of LBMs.";
+            "To signal to the MEP to transmit some number of LBMs.
+            Accepting the action means the device will transmit LBM
+            messages according the input leaf nodes. The outcome of
+            sending these LBM messages will be reported through the
+            list 'loopback-reply'.";
           input {
-            choice destination {
-              mandatory true;
-              description
-                "Selects the destination address type (which is
-                either MEP identifier or MAC address) used
-                for the Loopback transmissions.";
-              case dest-ucast-mac-address {
-                description
-                  "The target unicast MAC Address field to be 
-                  transmitted. A unicast destination MAC address.";
-                leaf lbm-dest-ucast-mac-address {
-                  type ieee:mac-address;
-                  description
-                    "The target MAC Address field to be transmitted.
-                    A unicast destination MAC address.";
-                  reference
-                    "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-                }
-              }
-              case dest-mcast-class1-mac-address {
-                description
-                  "The target multicast Class 1 MAC address field to be
-                  transmitted.";
-                leaf lbm-dest-mcast-class1-mac-address {
-                  type ieee:mac-address;
-                  must '. = "01-80-C2-00-00-30" or '+
-                       '. = "01-80-C2-00-00-31" or '+
-                       '. = "01-80-C2-00-00-32" or '+
-                       '. = "01-80-C2-00-00-33" or '+
-                       '. = "01-80-C2-00-00-34" or '+
-                       '. = "01-80-C2-00-00-35" or '+
-                       '. = "01-80-C2-00-00-36" or '+
-                       '. = "01-80-C2-00-00-37"' {
-                   description
-                     "The multicast class 1 MAC address must take the
-                     form of 01-80-C2-00-00-3x, where x represents
-                     the MEG level, with x being a value in the range
-                     of 0..7.";
-                 }
-                  description
-                    "The target multicast Class 1 MAC address field to
-                    be transmitted";
-                }
-              }
-              case dest-mep-id {
-                description
-                  "The identifier of a remote MEP in the same MA to
-                  which the LBM is to be sent.";
-                leaf lbm-dest-mep-id {
-                  type cfm-types:mep-id-type;
-                  description
-                    "The identifier of a remote MEP in the same MA to
-                    which the LBM is to be sent.";
-                  reference
-                    "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-                }
-              }
-            }
-            leaf lbm-messages {
-              type uint32 {
-                range "1..1024";
-              }
-              default 1;
-              description
-                "The number of Loopback messages to be transmitted.";
-              reference
-                "12.14.7.3.2c of IEEE Std 802.1Q-2018";
-            }
-            leaf lbm-priority {
-              type dot1q-types:priority-type;
-              mandatory true;
-              description
-                "Priority. 3 bit value to be used in the VLAN tag, if
-                present in the transmitted frame. The default value
-                should be the CCM priority.";
-              reference
-                "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-            }
-            leaf lbm-drop-eligible {
-              type boolean;
-              default "false";
-              description
-                "Drop eligible bit value to be used in the VLAN tag, if
-                present in the transmitted frame";
-              reference
-                "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-            }
-            leaf lbm-data-tlv {
-              type cfm-types:lbm-data-tlv-type;
-              description
-                "An arbitrary amount of data to be included in the
-                Data TLV, if the Data TLV is selected to be sent. The
-                intent is to be able to fill the frame carrying the
-                CFM PDU to its maximum length.";
-              reference
-                "12.14.7.3.2d of IEEE Std 802.1Q-2018";
-            }
+            uses loopback-input-grouping;
           } // input
           output {
             leaf lbm-request-id {
               type cfm-types:seq-number-type;
               mandatory true;
               description
-                "The Loopback transaction identifier
-                of the first LBM (to be) sent.
-                The value returned is undefined if an RPC
-                error is returned.";
+                "The Loopback transaction identifier of the first
+                LBM (to be) sent.";
               reference
                 "12.14.7.3.3b of IEEE Std 802.1Q-2018";
             }     
@@ -1382,67 +1021,14 @@ module ieee802-dot1q-cfm {
         
         action transmit-linktrace {
           description
-            "To signal to the MEP to transmit an LTM and to create an LTM
-            entry in the MEPs Linktrace Database.";
+            "To signal to the MEP to transmit an LTM and to create
+            an LTM entry in the MEPs Linktrace Database. Accepting
+            the action means the device will transmit LTM messages
+            according to the input leafs. The outcome of sending
+            these LTM messages will be reported through the list
+            'linktrace-reply'.";
           input {
-            choice target {
-              mandatory true;
-              description
-                "Selects the target address type (which is
-                either MEP identifier or MAC address) used
-                for the Linktrace transmissions.";
-              case target-ucast-mac-address {
-                description
-                  "The target MAC address field to be transmitted. A
-                  unicast MAC address.";
-                leaf ltm-target-mac-address {
-                  type ieee:mac-address;
-                  description
-                    "The target MAC address field to be transmitted. A
-                    unicast MAC address.";
-                  reference
-                    "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-                }
-              }
-              case target-mep-id {
-                description
-                  "The target MAC address field to be transmitted. The
-                  MEP identifier of another MEP in the same MA.";
-                leaf ltm-target-mep-id {
-                  type cfm-types:mep-id-type;
-                  description
-                    "The target MAC address field to be transmitted. The
-                    MEP identifier of another MEP in the same MA.";
-                  reference
-                    "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-                }
-              }
-            }
-            leaf ltm-ttl {
-              type uint32 {
-                range "0..255";
-              }
-              default 64;
-              description
-                "The LTM TTL field. Indicates the number of hops 
-                remaining to the LTM. Decremented by 1 by each
-                Linktrace Responder that handles the LTM. The value
-                returned in the LTR is one less than that received in
-                the LTM. If the LTM TTL is 0 or 1, the LTM is not
-                forwarded to the next hop, and if 0, no LTR is 
-                generated.";
-              reference
-                "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
-            }
-            leaf ltm-flags {
-              type cfm-types:mep-tx-ltm-flags-type;
-              default no-flags;
-              description
-                "The flags field for the LTMs transmitted by the MEP.";
-              reference
-                "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
-              
-            }
+            uses linktrace-input-grouping;
           } // input
           output {
             leaf ltm-transaction-id {
@@ -1455,20 +1041,17 @@ module ieee802-dot1q-cfm {
               reference
                 "12.14.7.4.3b of IEEE Std 802.1Q-2018";
             }
-            leaf ltm-egress-identifier {
-              type binary {
-                length "8";
-              }
-              mandatory true;
+            container ltm-egress-identifier {
+              uses ltm-egress-identifier-grouping;
               description
                 "Identifies the MEP Linktrace Initiator that is 
                 originating this LTM.
                 
                 The low-order six octets contain a 48-bit IEEE MAC
-                address unique to the system in which the MEP Linktrace
-                Initiator or Linktrace Responder resides. The 
-                high-order two octets contain a value sufficient to 
-                uniquely identify the MEP Linktrace Initiator or 
+                address unique to the system in which the MEP 
+                Linktrace Initiator or Linktrace Responder resides.
+                The high-order two octets contain a value sufficient
+                to uniquely identify the MEP Linktrace Initiator or 
                 Linktrace Responder within that system.
                 
                 For most Bridges, the address of any MAC attached to
@@ -1479,8 +1062,8 @@ module ieee802-dot1q-cfm {
                 high-order two octets can be used to differentiate
                 among the transmitting entities.
                 
-                The value returned is undefined if 
-                mep-transmit-ltm-result is FALSE.";
+                The value returned is undefined if the 
+                transmit-linktrace input action was not accepted.";
               reference
                 "12.14.7.4.3c of IEEE Std 802.1Q-2018";
             }
@@ -1491,140 +1074,56 @@ module ieee802-dot1q-cfm {
           key "lbm-request-id";
           config false;
           description 
-            "This table extends the MEP table and contains a list
-            of Loopback replies received by a specific MEP in
-            response to a loopback message.";
+            "This list extends the MEP table and reports on accepted
+            transmit-loopback actions. In case Loopback replies are
+            received it also reports with data from the received
+            Loopback reply messages.";
           leaf lbm-request-id {
             type cfm-types:seq-number-type;
             description
-              "The Loopback transaction identifier
-              of the first LBM (to be) sent.";
+              "The Loopback transaction identifier corresponding to
+              the transaction identifier in the received LBR.";
             reference
               "12.14.7.3.3b of IEEE Std 802.1Q-2018";
           }
-          choice destination {
-            mandatory true;
-            description
-              "Selects the destination address type (which is
-              either MEP identifier or MAC address) used
-              for the Loopback transmissions.";
-            case dest-ucast-mac-address {
-              description
-                "The target unicast MAC Address field to be 
-                transmitted. A unicast destination MAC address.";
-              leaf lbm-dest-ucast-mac-address {
-                type ieee:mac-address;
-                description
-                  "The target MAC Address field to be transmitted.
-                  A unicast destination MAC address.";
-                reference
-                  "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-              }
-            }
-            case dest-mcast-class1-mac-address {
-              description
-                "The target multicast Class 1 MAC address field to be
-                transmitted.";
-              leaf lbm-dest-mcast-class1-mac-address {
-                type ieee:mac-address;
-                must '. = "01-80-C2-00-00-30" or '+
-                     '. = "01-80-C2-00-00-31" or '+
-                     '. = "01-80-C2-00-00-32" or '+
-                     '. = "01-80-C2-00-00-33" or '+
-                     '. = "01-80-C2-00-00-34" or '+
-                     '. = "01-80-C2-00-00-35" or '+
-                     '. = "01-80-C2-00-00-36" or '+
-                     '. = "01-80-C2-00-00-37"' {
-                 description
-                   "The multicast class 1 MAC address must take the
-                   form of 01-80-C2-00-00-3x, where x represents
-                   the MEG level, with x being a value in the range
-                   of 0..7.";
-               }
-                description
-                  "The target multicast Class 1 MAC address field to
-                  be transmitted";
-              }
-            }
-            case dest-mep-id {
-              description
-                "The identifier of a remote MEP in the same MA to
-                which the LBM is to be sent.";
-              leaf lbm-dest-mep-id {
-                type cfm-types:mep-id-type;
-                description
-                  "The identifier of a remote MEP in the same MA to
-                  which the LBM is to be sent.";
-                reference
-                  "12.14.7.3.2b of IEEE Std 802.1Q-2018";
-              }
-            }
+          container loopback-input {
+            description 
+              "The loopback parameter input";
+            uses loopback-input-grouping;
           }
-          leaf lbm-messages {
-            type uint32 {
-              range "1..1024";
-            }
-            default 1;
-            description
-              "The number of Loopback messages to be transmitted.";
-            reference
-              "12.14.7.3.2c of IEEE Std 802.1Q-2018";
-          }
-          leaf lbm-priority {
-            type dot1q-types:priority-type;
-            mandatory true;
-            description
-              "Priority. 3 bit value to be used in the VLAN tag, if
-              present in the transmitted frame. The default value
-              should be the CCM priority.";
-            reference
-              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-          }
-          leaf lbm-drop-eligible {
-            type boolean;
-            default "false";
-            description
-              "Drop eligible bit value to be used in the VLAN tag, if
-              present in the transmitted frame";
-            reference
-              "12.14.7.3.2e of IEEE Std 802.1Q-2018";
-          }
-          leaf lbm-data-tlv {
-            type cfm-types:lbm-data-tlv-type;
-            description
-              "An arbitrary amount of data to be included in the
-              Data TLV, if the Data TLV is selected to be sent. The
-              intent is to be able to fill the frame carrying the
-              CFM PDU to its maximum length.";
-            reference
-              "12.14.7.3.2d of IEEE Std 802.1Q-2018";
-          }
-          list responses {
-            key "lbr-receive-order";
-            description
-              "The responses associated with the request.";
-            leaf lbr-receive-order {
-              type uint32 {
-                range "1..4294967295";
-              }
-              description
-                "An index to distinguish among multiple LBRs with
-                the same LBR Transaction Identifier field value. 
-                Assigned sequentially from 1, in the order that the 
-                Loopback Initiator received the LBRs. Also used to
-                distinguish between LBRs with different transaction
-                IDs in the same request.";
-            }
-          }
+          // -- The following list of responses is not specified
+          //    specified by 802.1Q-2018. However, it may be
+          //    useful to be defined by other standard 
+          //    organizaitons.
+          //
+          //list responses {
+          //  key "source-mac-address";
+          //  description
+          //    "The responses associated with the request.";
+          //  leaf source-mac-address {
+          //    type ieee:mac-address;
+          //    description
+          //      "The source MAC address field from the received 
+          //       loopback-reply message.";
+          //  }
+          //  leaf received-lbrs {
+          //    type uint16 {
+          //      range "0..1024";
+          //    }
+          //    description
+          //      "The number of received loopback reply messages.";
+          //  }
+          //}
         } // loopback-reply
         
         list linktrace-reply {
           key "ltr-transaction-id";
           config false;
           description
-            "This table extends the MEP table and contains a list
-            of Linktrace replies received by a specific MEP in
-            response to a linktrace message.";
+            "This list extends the MEP table and reports on accepted
+            transmit-linktrace actions. In case linktrace replies
+            are received it also reports with data from the received
+            Linktrace reply messages.";
           leaf ltr-transaction-id {
             type cfm-types:seq-number-type;
             description
@@ -1634,65 +1133,13 @@ module ieee802-dot1q-cfm {
             reference
               "12.14.7.5.2b of IEEE Std 802.1Q-2018";
           }
-          choice target {
-            mandatory true;
-            description
-              "Selects the target address type (which is
-              either MEP identifier or MAC address) used
-              for the Linktrace transmissions.";
-            case target-ucast-mac-address {
-              description
-                "The target MAC address field to be transmitted. A
-                unicast MAC address.";
-              leaf ltm-target-mac-address {
-                type ieee:mac-address;
-                description
-                  "The target MAC address field to be transmitted. A
-                  unicast MAC address.";
-                reference
-                  "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-              }
-            }
-            case target-mep-id {
-              description
-                "The target MAC address field to be transmitted. The
-                MEP identifier of another MEP in the same MA.";
-              leaf ltm-target-mep-id {
-                type cfm-types:mep-id-type;
-                description
-                  "The target MAC address field to be transmitted. The
-                  MEP identifier of another MEP in the same MA.";
-                reference
-                  "12.14.7.4.2c of IEEE Std 802.1Q-2018";
-              }
-            }
+          container linktrace-input {
+            description 
+              "The linktrace parameter input. By default, the 
+              priority used is that of the CCMs (ccm-ltm-priority)
+              and the drop elibility is false.";
+            uses linktrace-input-grouping;
           }
-          leaf ltm-ttl {
-            type uint32 {
-              range "1..255";
-            }
-            default 64;
-            description
-              "The LTM TTL field. Indicates the number of hops 
-              remaining to the LTM. Decremented by 1 by each
-              Linktrace Responder that handles the LTM. The value
-              returned in the LTR is one less than that received in
-              the LTM. If the LTM TTL is 0 or 1, the LTM is not
-              forwarded to the next hop, and if 0, no LTR is 
-              generated.";
-            reference
-              "12.14.7.4.2d, 21.8.4 of IEEE Std 802.1Q-2018";
-          }
-          leaf ltm-flags {
-            type cfm-types:mep-tx-ltm-flags-type;
-            default no-flags;
-            description
-              "The flags field for the LTMs transmitted by the MEP.";
-            reference
-              "12.14.7.4.2b, 20.42.1 of IEEE Std 802.1Q-2018";
-            
-          }
-          
           list responses {
             key "ltr-receive-order";
             description
@@ -1708,10 +1155,9 @@ module ieee802-dot1q-cfm {
                 Linktrace Initiator received the LTRs.";
             }
             leaf ltr-ttl {
-              type uint32 {
+              type uint8 {
                 range "0..255";
               }
-              config false;
               mandatory true;
               description
                 "TTL field value for a returned LTR.";
@@ -1720,7 +1166,6 @@ module ieee802-dot1q-cfm {
             }
             leaf ltr-forwarded {
               type boolean;
-              config false;
               mandatory true;
               description
                 "Indicates if a LTM was forwarded by the responding
@@ -1731,7 +1176,6 @@ module ieee802-dot1q-cfm {
             }           
             leaf ltr-terminal-mep {
               type boolean;
-              config false;
               mandatory true;
               description
                 "A Boolean value stating whether the forwarded LTM
@@ -1740,13 +1184,8 @@ module ieee802-dot1q-cfm {
               reference
                 "12.14.7.5.3d, 20.41.2.1 of IEEE Std 802.1Q-2018";
             }
-            leaf ltr-last-egress-identifier {
-              type binary {
-                length "8";
-              }
-              config false;
-              mandatory true;
-              description
+            container ltr-last-egress-identifier {
+              description 
                 "An octet field holding the Last Egress Identifier
                 returned in the LTR Egress Identifier TLV of the
                 LTR. The Last Egress Identifier identifies the MEP
@@ -1754,16 +1193,12 @@ module ieee802-dot1q-cfm {
                 Linktrace Responder that forwarded, the LTM to
                 which this LTR is the response. This is the same
                 value as the Egress Identifier TLV of that LTM.";
+              uses ltm-egress-identifier-grouping;
               reference
                 "12.14.7.5.3e, 20.41.2.3 of IEEE Std 802.1Q-2018";
             }
-            leaf ltr-next-egress-identifier {
-              type binary {
-                length "8";
-              }
-              config false;
-              mandatory true;
-              description
+            container ltr-next-egress-identifier {
+              description 
                 "An octet field holding the Next Egress Identifier
                 returned in the LTR Egress Identifier TLV of the 
                 LTR. The Next Egress Identifier Identifies the
@@ -1774,12 +1209,12 @@ module ieee802-dot1q-cfm {
                 Flags field is false, the contents of this field
                 are undefined, i.e., any value can be transmitted,
                 and the field is ignored by the receiver.";
+              uses ltm-egress-identifier-grouping;
               reference
                 "12.14.7.5.3f, 20.41.2.4 of IEEE Std 802.1Q-2018";
             }
             leaf ltr-relay {
               type cfm-types:relay-action-field-value-type;
-              config false;
               mandatory true;
               description
                 "Value returned in the Relay Action field.";
@@ -1788,30 +1223,36 @@ module ieee802-dot1q-cfm {
             }           
             leaf ltr-chassis-id-subtype {
               type lldp-types:chassis-id-subtype-type;
-              config false;
               description
                 "Specifies the format of the Chassis ID returned
-                in the Sender ID TLV of the LTR, if any. This value
-                is meaningless if the ltr-chassis-id has a length
-                of 0.";
+                in the Sender ID TLV of the LTR, if any. This leaf
+                is not present if the LTR did not contain a Sender 
+                ID TLV or if the Sender ID TLV did not contain a
+                Chassis ID.";
               reference
                 "12.14.7.5.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
             }           
             leaf ltr-chassis-id {
+              when "../ltr-chassis-id-subtype";
               type lldp-types:chassis-id-type;
-              config false;
+              mandatory true;
               description
                 "The Chassis ID returned in the Sender ID TLV of 
                 the LTR, if any. The format of this object is
                 determined by the value of the 
-                ltr-chassis-id-subtype object.";
+                ltr-chassis-id-subtype object. This leaf is not 
+                present if the LTR did not contain a Sender ID TLV
+                or if the Sender ID TLV did not contain a Chassis 
+                ID.";
               reference
                 "12.14.7.5.3i, 21.5.3.2 of IEEE Std 802.1Q-2018";
             }
             container ltr-transport-service-domain {
-              config false;
               description
-                "The transport management domain and address.";
+                "The transport management domain and address. This 
+                container is empty if the LTR did not contain a 
+                Sender ID TLV or if the Sender ID TLV did not 
+                contain a Management Address.";
               uses management-address-grouping;
               reference
                 "12.14.7.5.3j, 21.5.3.5, 21.5.3.7,
@@ -1819,7 +1260,6 @@ module ieee802-dot1q-cfm {
             }
             leaf ltr-ingress {
               type cfm-types:ingress-action-field-value-type;
-              config false;
               description
                 "The value returned in the Ingress Action Field of
                 the LTM. This leaf is not present if no
@@ -1828,42 +1268,42 @@ module ieee802-dot1q-cfm {
                 "12.14.7.5.3k, 20.41.2.6 of IEEE Std 802.1Q-2018";
             }           
             leaf ltr-ingress-mac {
+              when "../ltr-ingress";
               type ieee:mac-address;
-              config false;
+              mandatory true;
               description
                 "MAC address returned in the ingress MAC address
-                field. If the ltr-ingress object is not present,
-                then the contents of this object are meaningless.";
+                field. This leaf is not present if the ltr-ingress
+                leaf is not present.";
               reference
                 "12.14.7.5.3l, 20.41.2.7 of IEEE Std 802.1Q-2018";
-            }           
+            }
             leaf ltr-ingress-port-id-subtype {
+              when "../ltr-ingress";
               type lldp-types:port-id-subtype-type;
-              config false;
               description
-                "Ingress Port ID. The format of this object is 
-                determined by the value of the 
-                ltr-ingress-port-id-subtype object. If the
-                ltr-ingress object is not present, then the contents
-                of this object are meaningless.";
+                "Format of the ingress Port ID. This leaf is not 
+                present if the ltr-ingress leaf is not present, or if
+                the Reply Ingress TLV did not contain a Port ID.";
               reference
-                "12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
+                "12.14.7.5.3m, 20.41.2.8 of IEEE Std 802.1Q-2018";
             }
             leaf ltr-ingress-port-id {
+              when '../ltr-ingress and '+
+                   '../ltr-ingress-port-id-subtype';
               type lldp-types:port-id-type;
-              config false;
+              mandatory true;
               description
-                "Ingress Port ID. The format of this object is
+                "Ingress Port ID. The format of this object is 
                 determined by the value of the
-                ltr-ingress-port-id-subtype object. If the
-                ltr-igress object is not present, then the contents of
-                this object are meaningless.";
+                ltr-ingress-port-id-subtype object. This leaf is 
+                not present if the ltr-ingress leaf or the 
+                ltr-ingress-port-id-subtype leaf are not present.";
               reference
                 "12.14.7.5.3n, 20.41.2.9 of IEEE Std 802.1Q-2018";
             }
             leaf ltr-egress {
               type cfm-types:egress-action-field-value-type;
-              config false;
               description
                 "The value returned in the Egress Action Field of
                 the LTM. The node is not present if
@@ -1872,35 +1312,37 @@ module ieee802-dot1q-cfm {
                 "12.14.7.5.3o, 20.41.2.10 of IEEE Std 802.1Q-2018";
             }           
             leaf ltr-egress-mac {
+              when '../ltr-egress';
               type ieee:mac-address;
-              config false;
+              mandatory true;
               description
                 "MAC address returned in the egress MAC address
-                field. If the ltr-egress object is not present,
-                then the contents of this object are
-                meaningless.";
+                field. This leaf is not present if the ltr-egress 
+                leaf is not present.";
               reference
                 "12.14.7.5.3p, 20.41.2.11 of IEEE Std 802.1Q-2018";
             }           
             leaf ltr-egress-port-id-subtype {
+              when '../ltr-egress';
               type lldp-types:port-id-subtype-type;
-              config false;
               description
-                "Format of the egress Port ID. If the ltr-egress
-                object is not present, then the
-                contents of this object are meaningless.";
+                "Format of the egress Port ID. This leaf is not 
+                present if the ltr-egress leaf is not present, or if
+                the Reply Egress TLV did not contain a Port ID.";
               reference
                 "12.14.7.5.3q, 20.41.2.12 of IEEE Std 802.1Q-2018";
             }           
             leaf ltr-egress-port-id {
+              when '../ltr-egress and '+
+                   '../ltr-egress-port-id-subtype';
               type lldp-types:port-id-type;
-              config false;
+              mandatory true;
               description
                 "Egress Port ID. The format of this object is
                 determined by the value of the
-                ltr-egress-port-id-subtype object. If the 
-                ltr-egress object is not present, 
-                then the contents of this object are meaningless.";
+                ltr-egress-port-id-subtype object. This leaf is not 
+                present if the ltr-egress leaf or the 
+                ltr-egress-port-id-subtype leaf are not present.";
               reference
                 "12.14.7.5.3r, 20.41.2.13 of IEEE Std 802.1Q-2018";
             }           
@@ -1908,7 +1350,6 @@ module ieee802-dot1q-cfm {
               type binary {
                 length "0 | 4..1500";
               }
-              config false;
               description
                 "All Organization specific TLVs returned in the 
                 LTR, if any. Includes all octets including and


### PR DESCRIPTION
**Clean YANG Validation**

ieee802-dot1q-cfm.yang
Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm
  +--rw cfm
     +--rw maintenance-domain* [md-id]
     |  +--rw md-id                              cfm-types:name-key-type
     |  +--rw (md-name)?
     |  |  +--:(none)
     |  |  |  +--rw none?                        empty
     |  |  +--:(dns-like-name)
     |  |  |  +--rw dns-like-name?               string
     |  |  +--:(mac-address-and-uint)
     |  |  |  +--rw mac-address-and-uint-type
     |  |  |     +--rw address    ieee:mac-address
     |  |  |     +--rw int        uint16
     |  |  +--:(char-string)
     |  |     +--rw char-string?                 string
     |  +--rw md-level?                          cfm-types:md-level-type
     |  +--rw mhf-creation?                      cfm-types:mhf-creation-type
     |  +--rw id-permission?                     cfm-types:sender-id-permission-type
     |  +--rw fault-alarm-transmission?          cfm-types:fault-alarm-type
     |  +--rw maintenance-association* [ma-id]
     |     +--rw ma-id                          cfm-types:name-key-type
     |     +--rw (ma-name)
     |     |  +--:(primary-vid)
     |     |  |  +--rw primary-vid?             dot1q-types:vlanid
     |     |  +--:(char-string)
     |     |  |  +--rw char-string?             string
     |     |  +--:(unsigned-int16)
     |     |  |  +--rw unsigned-int16?          uint16
     |     |  +--:(rfc2865-vpn-id)
     |     |     +--rw vpn-id
     |     |        +--rw vpn-oui      uint32
     |     |        +--rw vpn-index    uint32
     |     +--rw ccm-interval?                  cfm-types:ccm-interval-type
     |     +--rw fault-alarm-transmission?      cfm-types:fault-alarm-type
     |     +--rw mhf-creation?                  cfm-types:mhf-creation-type
     |     +--rw id-permission?                 cfm-types:sender-id-permission-type
     |     +--rw maintenance-association-mep* [mep-id]
     |        +--rw mep-id    cfm-types:mep-id-type
     +--rw maintenance-group* [maintenance-group-id]
        +--rw maintenance-group-id    cfm-types:name-key-type
        +--rw md-id                   -> /cfm/maintenance-domain/md-id
        +--rw ma-id                   -> /cfm/maintenance-domain[md-id = current()/../md-id]/maintenance-association/ma-id
        +--rw mep* [mep-id]
           +--rw mep-id                 -> /cfm/maintenance-domain[md-id = current()/../../md-id]/maintenance-association[ma-id = current()/../../ma-id]/maintenance-association-mep/mep-id
           +--rw direction              cfm-types:mp-direction-type
           +--rw admin-state?           boolean
           +--rw ccm-ltm-priority?      dot1q-types:priority-type
           +--ro mac-address            ieee:mac-address
           +--rw inactive-remote-mep* [inactive-rmep-id]
           |  +--rw inactive-rmep-id    -> /cfm/maintenance-domain[md-id = current()/../../../md-id]/maintenance-association[ma-id = current()/../../../ma-id]/maintenance-association-mep/mep-id
           +--ro mep-db* [rmep-id]
           |  +--ro rmep-id                     cfm-types:mep-id-type
           |  +--ro rmep-state                  cfm-types:remote-mep-state-type
           |  +--ro rmep-failed-ok-time         yang:date-and-time
           |  +--ro mac-address                 ieee:mac-address
           |  +--ro rdi                         boolean
           |  +--ro port-status-tlv?            cfm-types:port-status-tlv-value-type
           |  +--ro interface-status-tlv?       cfm-types:interface-status-tlv-value-type
           |  +--ro chassis-id-subtype?         lldp-types:chassis-id-subtype-type
           |  +--ro chassis-id?                 lldp-types:chassis-id-type
           |  +--ro transport-service-domain
           |  |  +--ro domain?                  yang:object-identifier-128
           |  |  +--ro (management-address)?
           |  |     +--:(ip)
           |  |     |  +--ro ip-address         inet:ip-address
           |  |     |  +--ro ip-port            inet:port-number
           |  |     +--:(local)
           |  |     |  +--ro local-address      string
           |  |     +--:(dns)
           |  |     |  +--ro dns-address        string
           |  |     +--:(other)
           |  |        +--ro unknown-address?   binary
           |  +--ro rmep-is-active?             boolean
           +--rw continuity-check
           |  +--rw ccm-enabled?                boolean
           |  +--ro fng-state?                  cfm-types:fng-state-type
           |  +--rw fault-alarm-transmission?   cfm-types:fault-alarm-type
           |  +--rw lowest-priority-defect?     cfm-types:lowest-alarm-priority-type
           |  +--rw fng-alarm-time?             uint16
           |  +--rw fng-reset-time?             uint16
           |  +--ro highest-priority-defect     cfm-types:highest-defect-priority-type
           |  +--ro defects                     cfm-types:mep-defects-type
           |  +--ro error-ccm-last-failure?     binary
           |  +--ro xcon-ccm-last-failure?      binary
           +--ro stats
           |  +--ro mep-ccm-sequence-errors    yang:counter64
           |  +--ro mep-ccms-sent              yang:counter64
           |  +--ro mep-lbr-in                 yang:counter64
           |  +--ro mep-lbr-in-out-of-order    yang:counter64
           |  +--ro mep-lbr-bad-msdu           yang:counter64
           |  +--ro mep-unexpected-ltr-in      yang:counter64
           |  +--ro mep-lbr-out                yang:counter64
           +---x transmit-loopback
           |  +---w input
           |  |  +---w (lbm-destination)
           |  |  |  +--:(dest-ucast-mac-address)
           |  |  |  |  +---w lbm-dest-ucast-mac-address?          cfm-types:unicast-mac-address-type
           |  |  |  +--:(dest-mcast-class1-mac-address)
           |  |  |  |  +---w lbm-dest-mcast-class1-mac-address?   cfm-types:multicast-class1-mac-address-type
           |  |  |  +--:(dest-mep-id)
           |  |  |     +---w lbm-dest-mep-id?                     cfm-types:mep-id-type
           |  |  +---w lbm-messages?                              uint16
           |  |  +---w lbm-priority?                              dot1q-types:priority-type
           |  |  +---w lbm-drop-eligible?                         boolean
           |  |  +---w lbm-data-tlv?                              cfm-types:lbm-data-tlv-type
           |  +--ro output
           |     +--ro lbm-request-id    cfm-types:seq-number-type
           +---x transmit-linktrace
           |  +---w input
           |  |  +---w (ltr-target)
           |  |  |  +--:(target-ucast-mac-address)
           |  |  |  |  +---w ltm-target-mac-address?   cfm-types:unicast-mac-address-type
           |  |  |  +--:(target-mep-id)
           |  |  |     +---w ltm-target-mep-id?        cfm-types:mep-id-type
           |  |  +---w ltm-ttl?                        uint8
           |  |  +---w ltm-flags?                      cfm-types:mep-tx-ltm-flags-type
           |  +--ro output
           |     +--ro ltm-transaction-id       cfm-types:seq-number-type
           |     +--ro ltm-egress-identifier
           |        +--ro int        uint16
           |        +--ro address    ieee:mac-address
           +--ro loopback-reply* [lbm-request-id]
           |  +--ro lbm-request-id    cfm-types:seq-number-type
           |  +--ro loopback-input
           |     +--ro (lbm-destination)
           |     |  +--:(dest-ucast-mac-address)
           |     |  |  +--ro lbm-dest-ucast-mac-address?          cfm-types:unicast-mac-address-type
           |     |  +--:(dest-mcast-class1-mac-address)
           |     |  |  +--ro lbm-dest-mcast-class1-mac-address?   cfm-types:multicast-class1-mac-address-type
           |     |  +--:(dest-mep-id)
           |     |     +--ro lbm-dest-mep-id?                     cfm-types:mep-id-type
           |     +--ro lbm-messages?                              uint16
           |     +--ro lbm-priority?                              dot1q-types:priority-type
           |     +--ro lbm-drop-eligible?                         boolean
           |     +--ro lbm-data-tlv?                              cfm-types:lbm-data-tlv-type
           +--ro linktrace-reply* [ltr-transaction-id]
           |  +--ro ltr-transaction-id    cfm-types:seq-number-type
           |  +--ro linktrace-input
           |  |  +--ro (ltr-target)
           |  |  |  +--:(target-ucast-mac-address)
           |  |  |  |  +--ro ltm-target-mac-address?   cfm-types:unicast-mac-address-type
           |  |  |  +--:(target-mep-id)
           |  |  |     +--ro ltm-target-mep-id?        cfm-types:mep-id-type
           |  |  +--ro ltm-ttl?                        uint8
           |  |  +--ro ltm-flags?                      cfm-types:mep-tx-ltm-flags-type
           |  +--ro responses* [ltr-receive-order]
           |     +--ro ltr-receive-order                uint32
           |     +--ro ltr-ttl                          uint8
           |     +--ro ltr-forwarded                    boolean
           |     +--ro ltr-terminal-mep                 boolean
           |     +--ro ltr-last-egress-identifier
           |     |  +--ro int        uint16
           |     |  +--ro address    ieee:mac-address
           |     +--ro ltr-next-egress-identifier
           |     |  +--ro int        uint16
           |     |  +--ro address    ieee:mac-address
           |     +--ro ltr-relay                        cfm-types:relay-action-field-value-type
           |     +--ro ltr-chassis-id-subtype?          lldp-types:chassis-id-subtype-type
           |     +--ro ltr-chassis-id                   lldp-types:chassis-id-type
           |     +--ro ltr-transport-service-domain
           |     |  +--ro domain?                  yang:object-identifier-128
           |     |  +--ro (management-address)?
           |     |     +--:(ip)
           |     |     |  +--ro ip-address         inet:ip-address
           |     |     |  +--ro ip-port            inet:port-number
           |     |     +--:(local)
           |     |     |  +--ro local-address      string
           |     |     +--:(dns)
           |     |     |  +--ro dns-address        string
           |     |     +--:(other)
           |     |        +--ro unknown-address?   binary
           |     +--ro ltr-ingress?                     cfm-types:ingress-action-field-value-type
           |     +--ro ltr-ingress-mac                  ieee:mac-address
           |     +--ro ltr-ingress-port-id-subtype?     lldp-types:port-id-subtype-type
           |     +--ro ltr-ingress-port-id              lldp-types:port-id-type
           |     +--ro ltr-egress?                      cfm-types:egress-action-field-value-type
           |     +--ro ltr-egress-mac                   ieee:mac-address
           |     +--ro ltr-egress-port-id-subtype?      lldp-types:port-id-subtype-type
           |     +--ro ltr-egress-port-id               lldp-types:port-id-type
           |     +--ro ltr-organization-specific-tlv?   binary
           +---n mep-fault-alarm
              +-- mep-priority-defect    -> ../../continuity-check/highest-priority-defect
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors


ieee802-dot1q-cfm-mip.yang
Pyang Validation
ieee802-dot1q-cfm-mip.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-mip
  augment /dot1q-cfm:cfm:
    +--rw mips
       +--rw mip* [mip-id]
          +--rw mip-id           cfm-types:name-key-type
          +--rw md-level?        cfm-types:md-level-type
          +--rw id-permission?   cfm-types:sender-id-permission-type
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors


ieee802-dot1q-cfm-types.yang
Pyang Validation
ieee802-dot1q-cfm-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors


ieee802-dot1q-cfm-bridge.yang
Pyang Validation
ieee802-dot1q-cfm-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-bridge
  augment /dot1q-cfm:cfm:
    +--ro cfm-stack* [port service-selector service-id md-level direction]
    |  +--ro port                    port-ref
    |  +--ro md-level                cfm-types:md-level-type
    |  +--ro direction               cfm-types:mp-direction-type
    |  +--ro service-selector        cfm-types:service-selector-type
    |  +--ro service-id              cfm-types:service-selector-value-type
    |  +--ro maintenance-group-id    -> /dot1q-cfm:cfm/maintenance-group/maintenance-group-id
    |  +--ro mep-id                  -> /dot1q-cfm:cfm/maintenance-group[dot1q-cfm:maintenance-group-id = current()/../maintenance-group-id]/mep/mep-id
    |  +--ro md-id?                  -> /dot1q-cfm:cfm/maintenance-domain/md-id
    |  +--ro ma-id?                  -> /dot1q-cfm:cfm/maintenance-domain[dot1q-cfm:md-id = current()/../md-id]/maintenance-association/ma-id
    |  +--ro mac-address             ieee:mac-address
    |  +--ro maintenance-point       cfm-types:mp-type
    +--rw default-md-level* [bridge-id component-id service-selector primary-service-id]
    |  +--rw bridge-id                 bridge-ref
    |  +--rw component-id              -> /dot1q:bridges/bridge[dot1q:name = current()/../bridge-id]/component/name
    |  +--rw service-selector          cfm-types:service-selector-type
    |  +--rw primary-service-id        cfm-types:service-selector-value-type
    |  +--rw associated-service-ids
    |  |  +--rw (service-id)
    |  |     +--:(vids)
    |  |     |  +--rw vid* [vlan-id]
    |  |     |     +--rw vlan-id    dot1q-types:vlanid
    |  |     +--:(isid)
    |  |     |  +--rw isid?         uint32
    |  |     +--:(tesid)
    |  |     |  +--rw tesid?        uint32
    |  |     +--:(segid)
    |  |     |  +--rw segid?        uint32
    |  |     +--:(path-tesid)
    |  |     |  +--rw path-tesid?   uint32
    |  |     +--:(group-isid)
    |  |        +--rw group-isid?   uint32
    |  +--ro md-status                 boolean
    |  +--rw md-level                  cfm-types:md-level-type
    |  +--rw mhf-creation?             cfm-types:mhf-creation-type
    |  +--rw id-permission?            cfm-types:sender-id-permission-type
    +--ro config-error* [port service-selector service-id]
       +--ro port                port-ref
       +--ro service-selector    cfm-types:service-selector-type
       +--ro service-id          cfm-types:service-selector-value-type
       +--ro error-type          cfm-types:config-error-type
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group:
    +--rw bridge-id?        bridge-ref
    +--rw component-name    -> /dot1q:bridges/bridge[dot1q:name = current()/../cfm-bridge:bridge-id]/dot1q:component/name
    +--rw service-id
       +--rw (service-id)
          +--:(vids)
          |  +--rw vid* [vlan-id]
          |     +--rw vlan-id    dot1q-types:vlanid
          +--:(isid)
          |  +--rw isid?         uint32
          +--:(tesid)
          |  +--rw tesid?        uint32
          +--:(segid)
          |  +--rw segid?        uint32
          +--:(path-tesid)
          |  +--rw path-tesid?   uint32
          +--:(group-isid)
             +--rw group-isid?   uint32
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group/dot1q-cfm:mep:
    +--rw port           port-ref
    +--rw primary-vid?   -> ../../service-id/vid/vlan-id
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors