### PR TITLE
CFM YANG Modules for P802.1Qcx D1.2

### DIFF
--- a/standard/ieee/draft/802.1/ieee802-dot1q-cfm-bridge.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1q-cfm-bridge.yang
@@ -66,14 +66,13 @@ module ieee802-dot1q-cfm-bridge {
   grouping service-id-grouping {
     description
       "The list of VIDs, the I-SID, the TE-SID, or the SEG-ID
-      monitored by tehis MA, if present. In the case that a list
+      monitored by this MA, if present. In the case that a list
       of VIDs is specified, the first VID in the list is the MA's
-      Primary VID (default none). The specificaiton of I-SID is 
+      Primary VID (default none). The specification of I-SID is 
       allowed only in the case of I- or B-components. The TE-SID
       is allowed only in the case that PBB-TE or SPBM is supported.
       The SEG-ID is allowed only in the case that IPS is supported.";
     choice service-id {
-      mandatory true;
       description
         "The type of service identifier.";
       case vids {

--- a/standard/ieee/draft/802.1/ieee802-dot1q-cfm-types.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1q-cfm-types.yang
@@ -135,7 +135,7 @@ module ieee802-dot1q-cfm-types {
   }
   
   typedef mep-id-type {
-    type uint32 {
+    type uint16 {
       range "1..8191";
     }
     description
@@ -174,7 +174,7 @@ module ieee802-dot1q-cfm-types {
       enum up {
         value 2;
         description
-          "Ordinaty data can pass freely through the port on which
+          "Ordinary data can pass freely through the port on which
           the remote MEP resides.";
       }
     }

--- a/standard/ieee/draft/802.1/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1q-cfm.yang
@@ -83,7 +83,7 @@ module ieee802-dot1q-cfm {
           description
             "No format specified, usually because there is not a
             Maintenance Domain Name. The Maintenance Domain name
-            inserted in CFM protocol messages will be an zero 
+            inserted in CFM protocol messages will be a zero 
             length OCTET string.";
         }
       }
@@ -189,6 +189,7 @@ module ieee802-dot1q-cfm {
   
     choice management-address {
       when "./domain";
+      mandatory true;
       description
         "Selects the management address";
         
@@ -317,8 +318,9 @@ module ieee802-dot1q-cfm {
       default 7;
       description
         "Priority. 3 bit value to be used in the VLAN tag, if
-        present in the transmitted frame. The default value
-        should be the CCM priority (ccm-ltm-priority).";
+        present in the transmitted frame. The default value should
+        be priority 7, which is the default CCM priority
+        (ccm-ltm-priority).";
       reference
         "12.14.7.3.2e of IEEE Std 802.1Q-2018";
     }
@@ -347,7 +349,7 @@ module ieee802-dot1q-cfm {
     description
       "Defines the group of linktrace input parameters. By default,
       the priority used is that of the CCMs (ccm-ltm-priority)
-      and the drop elibility is false. ";
+      and the drop eligibility is false. ";
     choice ltr-target {
       mandatory true;
       description
@@ -369,13 +371,11 @@ module ieee802-dot1q-cfm {
       }
       case target-mep-id {
         description
-          "The target MAC address field to be transmitted. 
-          The MEP identifier of another MEP in the same MA.";
+          "The MEP identifier of another MEP in the same MA.";
         leaf ltm-target-mep-id {
           type cfm-types:mep-id-type;
           description
-            "The target MAC address field to be transmitted.
-            The MEP identifier of another MEP in the same MA.";
+            "The MEP identifier of another MEP in the same MA.";
           reference
             "12.14.7.4.2c of IEEE Std 802.1Q-2018";
         }
@@ -725,7 +725,7 @@ module ieee802-dot1q-cfm {
             type cfm-types:remote-mep-state-type;
             mandatory true;
             description 
-              "The operational state of the remote MEP  state
+              "The operational state of the remote MEP state
               machine";
             reference
               "12.14.7.6.3b, 20.20 of IEEE Std 802.1Q-2018";
@@ -1070,52 +1070,6 @@ module ieee802-dot1q-cfm {
           } // output
         } // transmit-linktrace
         
-        list loopback-reply {
-          key "lbm-request-id";
-          config false;
-          description 
-            "This list extends the MEP table and reports on accepted
-            transmit-loopback actions. In case Loopback replies are
-            received it also reports with data from the received
-            Loopback reply messages.";
-          leaf lbm-request-id {
-            type cfm-types:seq-number-type;
-            description
-              "The Loopback transaction identifier corresponding to
-              the transaction identifier in the received LBR.";
-            reference
-              "12.14.7.3.3b of IEEE Std 802.1Q-2018";
-          }
-          container loopback-input {
-            description 
-              "The loopback parameter input";
-            uses loopback-input-grouping;
-          }
-          // -- The following list of responses is not specified
-          //    specified by 802.1Q-2018. However, it may be
-          //    useful to be defined by other standard 
-          //    organizaitons.
-          //
-          //list responses {
-          //  key "source-mac-address";
-          //  description
-          //    "The responses associated with the request.";
-          //  leaf source-mac-address {
-          //    type ieee:mac-address;
-          //    description
-          //      "The source MAC address field from the received 
-          //       loopback-reply message.";
-          //  }
-          //  leaf received-lbrs {
-          //    type uint16 {
-          //      range "0..1024";
-          //    }
-          //    description
-          //      "The number of received loopback reply messages.";
-          //  }
-          //}
-        } // loopback-reply
-        
         list linktrace-reply {
           key "ltr-transaction-id";
           config false;
@@ -1168,7 +1122,7 @@ module ieee802-dot1q-cfm {
               type boolean;
               mandatory true;
               description
-                "Indicates if a LTM was forwarded by the responding
+                "Indicates if an LTM was forwarded by the responding
                 MP, as returned in the FwdYes flag of the flags 
                 field.";
               reference

--- a/standard/ieee/draft/802.1/ieee802-dot1x-types.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1x-types.yang
@@ -1,0 +1,243 @@
+module ieee802-dot1x-types {
+
+  namespace "urn:ieee:std:802.1X:yang:ieee802-dot1x-types";
+  prefix "dot1x-types";
+
+  organization
+    "Institute of Electrical and Electronics Engineers";
+
+  contact
+  	"WG-URL: http://grouper.ieee.org/groups/802/1/
+    WG-EMail: stds-802-1@ieee.org
+
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08855-1331
+            USA
+ 	
+    E-mail: STDS-802-1-L@LISTSERV.IEEE.ORG";
+
+  description
+    "Port-based network access control allows a network administrator
+    to restrict the use of IEEE 802 LAN service access points (ports)
+    to secure communication between authenticated and authorized
+    devices. IEEE Std 802.1X specifies an architecture, functional
+    elements, and protocols that support mutual authentication
+    between the clients of ports attached to the same LAN and secure
+    communication between the ports. The following control allows a
+    port to be reinitialized, terminating (and potentially
+    restarting) authentication exchanges and MKA operation, based on
+    a data model described in a set of YANG modules.";
+  
+  revision 2019-05-28 {
+    description
+      "Updates based upon comment resolution on draft
+      D1.0 of P802.1X-Rev.";
+    reference
+      "IEEE Std 802.1X-2020, Port-Based Network Access Control.";
+  }
+
+  /* ----------------------------------------------
+   * Type definitions used by dot1X YANG module
+   * ----------------------------------------------
+   */
+
+  typedef pae-nid {
+    type string {
+      length "0..100";
+    }
+    description
+      "Network Identity, which is a UTF-8 string identifying a
+      network or network service.";
+    reference
+      "IEEE 802.1X-2020 Clause 3, Clause 10.1, Clause 12.6";
+  }
+
+  typedef pae-session-user-name {
+    type string {
+      length "0..253";
+    }
+    description
+      "Session user name, which is a UTF-8 string, representing the
+      identity of the peer Supplicant.";
+    reference
+      "IEEE 802.1X-2020 Clause 12.5.1";
+  }
+
+  typedef pae-session-id {
+    type string {
+      length "3..253";
+    }
+    description
+      "Session Identifier, which is a UTF-8 string, uniquely
+      identifying the session within the context of the PAE's
+      system.";
+    reference
+      "IEEE 802.1X-2020 Clause 12.5.1";
+  }
+
+  typedef pae-nid-capabilities {
+    type bits {
+      bit eap {
+        position 0;
+        description
+          "EAP";
+      }
+      bit eapMka {
+        position 1;
+        description
+          "EAP + MKA";
+      }
+      bit eapMkaMacSec {
+        position 2;
+        description
+          "EAP + MKA + MACsec";
+      }
+      bit mka {
+        position 3;
+        description
+          "MKA";
+      }
+      bit mkaMacSec {
+        position 4;
+        description
+          "MKA + MACsec";
+      }
+      bit higherLayer {
+        position 5;
+        description
+          "Higher Layer (WebAuth)";
+      }
+      bit higherLayerFallback {
+        position 6;
+        description
+          "Higher Layer Fallback (WebAuth)";
+      }
+      bit vendorSpecific {
+        position 7;
+        description
+          "Vendor specific authentication mechanisms";
+      }
+    }
+    description
+      "Authentication and protection capabilities supported for the
+      NID. Indicates the combinations of authentication and
+      protection capabilities supported for the NID. Any set of these
+      combinations can be supported.";
+    reference
+      "IEEE 802.1X-2020 Clause 10.1, Clause 11.12.3";
+  }
+
+  typedef pae-access-status {
+    type enumeration {
+      enum no-access {
+        description
+          "Other than to authentication services, and to services
+          announced as available in the absence of authentication
+          (unauthenticated).";
+      }
+      enum remedial-access {
+        description
+          "The access granted is severely limited, possibly to
+          remedial services.";
+      }
+      enum restricted-access {
+        description
+          "The Controlled Port is operational, but restrictions have
+          been applied by the network that can limit access to some
+          resources.";
+      }
+      enum expected-access {
+        description
+          "The Controlled Port is operational, and access provided is
+          as expected for successful authentication and authorization
+          for the NID.";
+      }
+    }
+    description
+      "Indicates the transmitter's Controlled Port operational status
+      and current level of access resulting from authentication and
+      the consequent authorization controls applied by that port's
+      clients.";
+    reference
+      "IEEE 802.1X-2020 Clause 10.4, Clause 12.5";
+  }
+
+  typedef mka-kn {
+    type uint32;
+    description
+      "Indicates a Key Number (KN) used in MKA. It is assigned by
+      the Key Server (sequentially beginning with 1).";
+    reference
+      "IEEE 802.1X-2020 Clause 9.8, Clause 9.16";
+  }
+
+  typedef mka-an {
+    type uint32;
+    description
+      "A number that is concatenated with a MACsec Secure Channel
+      Identifier to identify a Secure Association. Indicates an
+      Association Number (AN) assigned by the Key Server for use with
+      the key number for transmission.";
+    reference
+      "IEEE 802.1X-2020 Clause 9.8, Clause 9.16";
+  }
+
+  typedef pae-ckn {
+    type string {
+      length "1..32";
+    }
+    description
+      "Indicates the CAK name to identify the Connectivity
+      Association Key (CAK) which is the root key in the MACsec Key
+      Agreement key hierarchy. All potential members of the CA use
+      the same CKN.";
+    reference
+      "IEEE 802.1X-2020 Clause 9.3.1, Clause 6.2";
+  }
+
+  typedef pae-kmd {
+    type string {
+      length "0..253";
+    }
+    description
+      "A Key Management Domain (KMD). A string of up to 253 UTF-8
+      characters that names the transmitting authenticator's key
+      management domain.";
+    reference
+      "IEEE Clause 12.6";
+  }
+
+  typedef pae-auth-data {
+    type string;
+    description
+      "Authorization data associated with the CAK.";
+    reference
+      "IEEE 802.1X-2020 Clause 9.16";
+  }
+
+  typedef sci-list-entry {
+    type string {
+      length "8";
+    }
+    description
+      "8 octet string, where the first 6 octets represents the MAC
+      Address (in canonical format), and the next 2 octets represents
+      the Port Identifier.";
+    reference
+      "IEEE 802.1AE Clause 7.1.2, Clause 10.7.1";
+  }
+  
+  typedef pae-if-index {
+  	type int32 {
+      range "1..2147483647";
+    }
+  	description
+  		"The interface index value represented by this interface.";  	
+  }
+
+} // ieee802-dot1x-types

--- a/standard/ieee/draft/802.1/ieee802-dot1x.yang
+++ b/standard/ieee/draft/802.1/ieee802-dot1x.yang
@@ -8,6 +8,7 @@ module ieee802-dot1x {
   import ietf-interfaces { prefix "if"; }
   import ietf-system { prefix "sys"; }
   import iana-if-type { prefix "ianaift"; }
+  import ieee802-dot1x-types { prefix "dot1x-types"; }
 
   organization
     "Institute of Electrical and Electronics Engineers";
@@ -41,284 +42,15 @@ module ieee802-dot1x {
   
   revision 2017-10-15 {
     description
-      "Updates based upon comment resolution on draft
-      D1.1 of P802.1Xck.";
+      "Updates based on comment resolution of the WG ballot of 
+	  P802.1X-Rev/D1.0.";
     reference
-      "IEEE 802.1X-2010, Port-Based Network Access Control.";
-  }
-
-  /* ------------------------------------------
-   * List of features that may be optionally
-   * implemented/supported
-   * ------------------------------------------
-   */
-  feature pacp-eap-supplicant {
-    description
-      "This feature indicates that the device supports a PACP EAP
-      Supplicant.";
-    reference
-      "IEEE 802.1X-2010 Clause 12.9.2";
-  }
-  feature pacp-eap-authenticator {
-    description
-      "This feature indicates that the device supports a PACP EAP
-      Authenticator.";
-    reference
-      "IEEE 802.1X-2010 Clause 12.9.2";
-  }
-  feature mka {
-    description
-      "This feature indicates that the device supports MKA";
-    reference
-      "IEEE 802.1X-2010 Clause 12.9.2";
-  }
-  feature macsec {
-    description
-      "This feature indicates that the device supports MACsec on the
-      Controlled Port.";
-    reference
-      "IEEE 802.1X-2010 Clause 12.9.2";
-  }
-  feature announcements {
-    description
-      "This feature indicates that the device supports the ability to
-      send EAPOL announcements.";
-    reference
-      "IEEE 802.1X-2010 Clause 12.9.2";
-  }
-  feature listener {
-    description
-      "This feature indicates that the device supports the ability to
-      use receive EAPOL announcements.";
-    reference
-      "IEEE 802.1X-2010 Clause 12.9.2";
-  }
-  feature virtual-ports {
-    description
-      "This feature indicates that the device supports the virtual
-      ports for a real port.";
-    reference
-      "IEEE 802.1X-2010 Clause 12.9.2";
-  }
-  feature in-service-upgrades {
-    description
-      "This feature indicates that the device supports MKA in-service
-      upgrades.";
-    reference
-      "IEEE 802.1Xbx-2014 Clause 12.9.2";
-  }
-
-  /* ----------------------------------------------
-   * Type definitions used by dot1X YANG module
-   * ----------------------------------------------
-   */
-
-  typedef pae-system-ref {
-    type leafref {
-      path "/sys:system/dot1x:pae-system/dot1x:name";
-    }
-    description
-      "This type is used by data models that need to reference
-      configured PAE systems.";
-  }
-
-  typedef pae-nid {
-    type string {
-      length "0..100";
-    }
-    description
-      "Network Identify, which is a UTF-8 string identifying a
-      network or network service.";
-    reference
-      "IEEE 802.1X-2010 Clause 3, Clause 10.1, Clause 12.6";
-  }
-
-  typedef pae-session-user-name {
-    type string {
-      length "0..253";
-    }
-    description
-      "Session user name, which is a utf8 string, representing the
-      identify of the peer Supplicant.";
-    reference
-      "IEEE 802.1X-2010 Clause 12.5.1";
-  }
-
-  typedef pae-session-id {
-    type string {
-      length "3..253";
-    }
-    description
-      "Session Identifier, which is a utf8 string, uniquely
-      identifying the session within the context of the PAEs
-      system.";
-    reference
-      "IEEE 802.1X-2010 Clause 12.5.1";
-  }
-
-  typedef pae-nid-capabilities {
-    type bits {
-      bit eap {
-        position 0;
-        description
-          "EAP";
-      }
-      bit eapMka {
-        position 1;
-        description
-          "EAP + MKA";
-      }
-      bit eapMkaMacSec {
-        position 2;
-        description
-          "EAP + MKA + MACsec";
-      }
-      bit mka {
-        position 3;
-        description
-          "MKA";
-      }
-      bit mkaMacSec {
-        position 4;
-        description
-          "MKA + MACsec";
-      }
-      bit higherLayer {
-        position 5;
-        description
-          "Higher Layer (WebAuth)";
-      }
-      bit higherLayerFallback {
-        position 6;
-        description
-          "Higher Layer Fallback (WebAuth)";
-      }
-      bit vendorSpecific {
-        position 7;
-        description
-          "Vendor specific authentication mechanisms";
-      }
-    }
-    description
-      "Authentication and protection capabilities supported for the
-      NID. Indicates the combinations of authentication and
-      protection capabilities supported for a NID. Any set of these
-      combinations can be supported.";
-    reference
-      "IEEE 802.1X-2010 Clause 10.1, Clause 11.12.3";
-  }
-
-  typedef pae-access-status {
-    type enumeration {
-      enum no-access {
-        description
-          "Other than to authentication services, and to services
-          announced as available in the absence of authentication
-          (unauthenticated).";
-      }
-      enum remedial-access {
-        description
-          "The access granted is severely limited, possibly to
-          remedial services.";
-      }
-      enum restricted-access {
-        description
-          "The Controlled Port is operational, but restrictions have
-          been applied by the network that can limit access to some
-          resources.";
-      }
-      enum expected-access {
-        description
-          "The Controlled Port is operational, and access provided is
-          as expected for successful authentication and authorization
-          for the NID.";
-      }
-    }
-    description
-      "Indicates the transmitters Controlled Port operational status
-      and current level of access resulting from authentication and
-      the consequent authorization controls applied by that ports
-      clients.";
-    reference
-      "IEEE 802.1X-2010 Clause 10.4, Clause 12.5";
-  }
-
-  typedef mak-kn {
-    type uint32;
-    description
-      "Indicates a Key Number (KN) used in MKA. It is assigned by
-      the Key Server (sequentially beginning with 1).";
-    reference
-      "IEEE 802.1X-2010 Clause 9.8, Clause 9.16";
-  }
-
-  typedef mak-an {
-    type uint32;
-    description
-      "A number that is concatenated with a MACsec Secure Channel
-      Identifier to identify a Secure Association. Indicates an
-      Association Number (AN) assigned by the Key Server for use with
-      the key number for transmission.";
-    reference
-      "IEEE 802.1X-2010 Clause 9.8, Clause 9.16";
-  }
-
-  typedef pae-ckn {
-    type string {
-      length "1..32";
-    }
-    description
-      "Indicates the CAK name to identify the Connectivity
-      Association Key (CAK) which is the root key in the MACsec Key
-      Agreement key hierarchy. All potential members of the CA use
-      the same CKN.";
-    reference
-      "IEEE 802.1X-2010 Clause 9.3.1, Clause 6.2";
-  }
-
-  typedef pae-kmd {
-    type string {
-      length "0..253";
-    }
-    description
-      "A Key Management Domain (KMD). A string of up to 253 UTF-8
-      characters that names the transmitting authenticators key
-      management domain.";
-    reference
-      "IEEE Clause 12.6";
-  }
-
-  typedef pae-auth-data {
-    type string;
-    description
-      "Authorization data associated with the CAK.";
-    reference
-      "IEEE 802.1X-2010 Clause 9.16";
-  }
-
-  typedef sci-list-entry {
-    type string {
-      length "8";
-    }
-    description
-      "8 octet string, where the first 6 octets represents the MAC
-      Address (in canonical format), and the next 2 octets represents
-      the Port Identifier.";
-    reference
-      "IEEE 802.1AE Clause 7.1.2, Clause 10.7.1";
+      "IEEE Std 802.1X-2020, Port-Based Network Access Control.";
   }
   
-  typedef pae-if-index {
-  	type int32 {
-      range "1..2147483647";
-    }
-  	description
-  		"The interface index value represented by this interface.";  	
-  }
-
   grouping nid-group {
     description
-      "The PAE NID Group configuration and operational inforamtion.";
+      "The PAE NID Group configuration and operational information.";
     list pae-nid-group {
       key "nid";
       description
@@ -326,11 +58,11 @@ module ieee802-dot1x {
       	nodes for the network announcement information for the
       	Logon Process.";
       leaf nid {
-        type pae-nid;
+        type dot1x-types:pae-nid;
         description
           "Identification of the network or network service.";
         reference
-          "IEEE 802.1X-2010 Clause 12.5";
+          "IEEE 802.1X-2020 Clause 12.5";
       }
       leaf use-eap {
         type enumeration {
@@ -355,7 +87,7 @@ module ieee802-dot1x {
           the Supplicant and or Authenticator are enabled, and takes
           one of the above values.";
         reference
-          "IEEE 802.1X-2010 Clause 12.5";
+          "IEEE 802.1X-2020 Clause 12.5";
       }
       leaf unauth-allowed {
         type enumeration {
@@ -382,7 +114,7 @@ module ieee802-dot1x {
           machine to provide unauthenticated connectivity, and takes
           one of the above values.";
         reference
-          "IEEE 802.1X-2010 Clause 12.5";
+          "IEEE 802.1X-2020 Clause 12.5";
       }
       leaf unsecure-allowed {
         type enumeration {
@@ -410,7 +142,7 @@ module ieee802-dot1x {
           machine to provide authenticated but unsecured
           connectivity, takes one of the above values.";
         reference
-          "IEEE 802.1X-2010 Clause 12.5";
+          "IEEE 802.1X-2020 Clause 12.5";
       }
       leaf unauthenticated-access {
         type enumeration {
@@ -438,24 +170,24 @@ module ieee802-dot1x {
         description
           "Unauthenticated access capabilities provided by the NID.";
         reference
-          "IEEE 802.1X-2010 Clause 10.1";
+          "IEEE 802.1X-2020 Clause 10.1";
       }
       leaf access-capabilities {
-        type pae-nid-capabilities;
+        type dot1x-types:pae-nid-capabilities;
         description
           "Authentication and protection capabilities supported for
           the NID.";
         reference
-          "IEEE 802.1X-2010 Clause 10.1";
+          "IEEE 802.1X-2020 Clause 10.1";
       }
       
       leaf kmd {
-        type pae-kmd;
+        type dot1x-types:pae-kmd;
         config false;
         description
           "The Key Management Domain for the NID.";
         reference
-          "IEEE 802.1X-2010 Clause 10.4";
+          "IEEE 802.1X-2020 Clause 10.4";
       }
     }
   }
@@ -468,28 +200,28 @@ module ieee802-dot1x {
       description
         "Indicates if PACP EAP Supplicant is supported.";
       reference
-        "IEEE 802.1X-2010 Clause 12.9.2";
+        "IEEE 802.1X-2020 Clause 12.9.2";
     }
     leaf auth {
       type boolean;
       description
         "Indicates if PACP EAP Authenticator is supported.";
       reference
-        "IEEE 802.1X-2010 Clause 12.9.2";
+        "IEEE 802.1X-2020 Clause 12.9.2";
     }
     leaf mka {
       type boolean;
       description
         "Indicates if MKA is supported.";
       reference
-        "IEEE 802.1X-2010 Clause 12.9.2";
+        "IEEE 802.1X-2020 Clause 12.9.2";
     }
     leaf macsec {
       type boolean;
       description
         "Indicates if MACsec on the Controlled port is supported.";
       reference
-        "IEEE 802.1X-2010 Clause 12.9.2";
+        "IEEE 802.1X-2020 Clause 12.9.2";
     }
     leaf announcements {
       type boolean;
@@ -497,7 +229,7 @@ module ieee802-dot1x {
         "Indicates if the ability to send EAPOL announcements is
         supported.";
       reference
-        "IEEE 802.1X-2010 Clause 12.9.2";
+        "IEEE 802.1X-2020 Clause 12.9.2";
     }
     leaf listener {
       type boolean;
@@ -505,21 +237,21 @@ module ieee802-dot1x {
         "Indicates if the ability to use received EAPOL
         announcements is supported.";
       reference
-        "IEEE 802.1X-2010 Clause 12.9.2";
+        "IEEE 802.1X-2020 Clause 12.9.2";
     }
     leaf virtual-ports {
       type boolean;
       description
         "Indicates if virtual ports for a real port is supported.";
       reference
-        "IEEE 802.1X-2010 Clause 12.9.2";
+        "IEEE 802.1X-2020 Clause 12.9.2";
     }
     leaf in-service-upgrades {
       type boolean;
       description
         "Indicates if MKA in-service upgrades is supported.";
       reference
-        "IEEE 802.1Xbx-2014 Clause 12.9.2";
+        "IEEE 802.1X-2020 Clause 12.9.2";
     }
   }
 
@@ -536,7 +268,9 @@ module ieee802-dot1x {
         "Contains all 802.1X PAE System specific related
         configuration and operational data.";
       leaf name {
-        type string;
+        type string {
+		  length "1..255";
+		}
         description
           "The name which uniquely identifies the PAE System.";
       }
@@ -571,14 +305,14 @@ module ieee802-dot1x {
           real port PAE are unaffected, and will be used once
           systemAccessControl is set to enabled.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.1";
+          "IEEE 802.1X-2020 Clause 12.9.1";
       }
       leaf system-announcements {
         type enumeration {
           enum disabled {
             description
               "Causes each PAE to behave as if enabled were clear
-              for the PAEs Announcement functionality.";
+              for the PAE's Announcement functionality.";
           }
           enum enabled {
             description
@@ -591,23 +325,23 @@ module ieee802-dot1x {
           functionality. The independent controls for each PAE apply
           if systemAnnouncements is Enabled.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.1";
+          "IEEE 802.1X-2020 Clause 12.9.1";
       }
       leaf eapol-protocol-version {
-        type uint32;
+        type uint8;
         config false;
         description
           "The EAPOL protocol version for this system.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.1, Clause 11.3";
+          "IEEE 802.1X-2020 Clause 12.9.1, Clause 11.3";
       }
       leaf mka-version {
-        type uint32;
+        type uint8;
         config false;
         description
           "The MKA protocol version for this system.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.1, Clause 11.3";
+          "IEEE 802.1X-2020 Clause 12.9.1, Clause 11.3";
       }
       leaf-list pae {
         type if:interface-ref;
@@ -634,13 +368,15 @@ module ieee802-dot1x {
       "Augment interface model with PAE configuration and
     	operational nodes.";
     reference
-      "IEEE 802.1AE Clause 11.7 and IEEE 802.1X-2010 Clause 6.5 and
+      "IEEE 802.1AE Clause 11.7 and IEEE 802.1X-2020 Clause 6.5 and
       Clause 13.3.2";
     container pae {
       description
         "Contains PAE configuration and operational related nodes.";
       leaf pae-system {
-        type dot1x:pae-system-ref;
+        type leafref {
+          path "/sys:system/dot1x:pae-system/dot1x:name";
+        }
         description
           "The PAE system that this PAE is a member of.";
       }
@@ -654,11 +390,11 @@ module ieee802-dot1x {
         type boolean;
         default "false";
         description
-          "A real ports PAE may be configured to create virtual
+          "A real port's PAE may be configured to create virtual
           ports to support multi-access LANs provided that MKA and
           MACsec operation is enabled for that port.";
         reference
-          "IEEE 802.1X-2010 Clause 12.7";
+          "IEEE 802.1X-2020 Clause 12.7";
       }
       container port-capabilities {
         description
@@ -673,7 +409,7 @@ module ieee802-dot1x {
           "Each PAE is uniquely identified by a port name.";
         }
       leaf port-number {
-        type pae-if-index;
+        type dot1x-types:pae-if-index;
         config false;
         description
           "Each PAE is uniquely identified by a port number. The
@@ -688,7 +424,7 @@ module ieee802-dot1x {
           this portNumber is the commonPortNumber for the associated
           PAC or SecY.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
+          "IEEE 802.1X-2020 Clause 12.9.2";
         }
       leaf controlled-port-name {
         type if:interface-ref;
@@ -697,13 +433,13 @@ module ieee802-dot1x {
           "Each PAE is uniquely identified by a port name.";
       }
       leaf controlled-port-number {
-        type pae-if-index;
+        type dot1x-types:pae-if-index;
         config false;
         description
           "The port for the associated PAC or SecYs Controlled
           Port.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
+          "IEEE 802.1X-2020 Clause 12.9.2";
       }
       leaf uncontrolled-port-name {
         type if:interface-ref;
@@ -712,13 +448,13 @@ module ieee802-dot1x {
           "The uncontrolled port name reference.";
       }
       leaf uncontrolled-port-number {
-        type pae-if-index;
+        type dot1x-types:pae-if-index;
         config false;
         description
           "The port for the associated PAC or SecYs Uncontrolled
           Port.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
+          "IEEE 802.1X-2020 Clause 12.9.2";
       }
       leaf common-port-name {
         type if:interface-ref;
@@ -727,14 +463,14 @@ module ieee802-dot1x {
           "The common port name reference.";
       }
       leaf common-port-number {
-        type pae-if-index;
+        type dot1x-types:pae-if-index;
         config false;
         description
           "The port for the associated PAC or SecYs Common Port. All
           the virtual ports created for a given real port share the
           same Common Port and commonPortNumber.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
+          "IEEE 802.1X-2020 Clause 12.9.2";
       }
       leaf port-type {
         type enumeration {
@@ -751,7 +487,7 @@ module ieee802-dot1x {
         description
           "The port type of the PAE.";
         reference
-          "IEEE 802.1X-2010 Clause 12.9.2";
+          "IEEE 802.1X-2020 Clause 12.9.2";
       }
       container virtual-port {
         when "../port-capabilities/virtual-ports = 'true'" {
@@ -771,7 +507,7 @@ module ieee802-dot1x {
           description
             "The guaranteed maximum number of virtual ports.";
           reference
-            "IEEE 802.1X-2010 Clause 12.9.2";
+            "IEEE 802.1X-2020 Clause 12.9.2";
         }
         leaf current {
           when "../../port-type = 'real-port'" {
@@ -782,19 +518,19 @@ module ieee802-dot1x {
           description
             "The current number of virtual ports.";
           reference
-            "IEEE 802.1X-2010 Clause 12.9.2";
+            "IEEE 802.1X-2020 Clause 12.9.2";
         }
         leaf start {
           when "../../port-type = 'virtual-port'" {
             description
               "Applies when Port is a Virtual Port.";
           }
-          type uint32;
+          type boolean;
           description
             "Set if the virtual port was created by receipt of an
             EAPOL-Start frame.";
           reference
-            "IEEE 802.1X-2010 Clause 12.9.7";
+            "IEEE 802.1X-2020 Clause 12.9.7";
         }
         leaf peer-address {
           when "../../port-type = 'virtual-port'" {
@@ -806,18 +542,16 @@ module ieee802-dot1x {
             "The source MAC Address of the EAPOL-Start (if vpStart is
             set).";
           reference
-            "IEEE 802.1X-2010 Clause 12.9.7";
+            "IEEE 802.1X-2020 Clause 12.9.7";
         }
       }
 
       container supplicant {
         when "../port-type = 'real-port' and
-              ../port-capabilities/supp = 'true' and
-              ../port-capabilities/auth = 'false'" {
+              ../port-capabilities/supp = 'true'" {
           description
-            "Applies to Real Ports and when the Authenticator is
-            disabled and supplicant port capabilities are
-            supported.";
+            "Applies to Real Port when supplicant port capabilities
+			are supported.";
         }
         description
           "Contains the configuration nodes for the Supplicant PAE
@@ -831,17 +565,17 @@ module ieee802-dot1x {
             period after a failed authentication attempt, before
             another attempt is permitted.";
           reference
-            "IEEE 802.1X-2010 Clause 8.6";
+            "IEEE 802.1X-2020 Clause 8.6";
         }
         leaf retry-max {
-          type uint8;
+          type uint32;
           default "2";
           description
             "Specifies the maximum number of re-authentication
             attempts on an authenticator port before port is
             unauthorized.";
           reference
-            "IEEE 802.1X-2010 Clause 8.7";
+            "IEEE 802.1X-2020 Clause 8.7";
         }
         
         leaf enabled {
@@ -855,7 +589,7 @@ module ieee802-dot1x {
             management, e.g. because the application scenario
             authenticates a user and there is no user logged on.";
           reference
-            "IEEE 802.1X-2010 Clause 8.4";
+            "IEEE 802.1X-2020 Clause 8.4";
         }
         leaf authenticate {
           type boolean;
@@ -866,7 +600,7 @@ module ieee802-dot1x {
             to revoke authentication. To enable authentication the
             client also needs to clear failed (if set).";
           reference
-            "IEEE 802.1X-2010 Clause 8.4";
+            "IEEE 802.1X-2020 Clause 8.4";
         }
         leaf authenticated {
           type boolean;
@@ -875,7 +609,7 @@ module ieee802-dot1x {
             "Set by PACP if the PAE is currently authenticated, and
             cleared if the authentication fails or is revoked.";
           reference
-            "IEEE 802.1X-2010 Clause 8.4";
+            "IEEE 802.1X-2020 Clause 8.4";
         }
         leaf failed {
           type boolean;
@@ -892,16 +626,14 @@ module ieee802-dot1x {
             machines) if enable becomes FALSE and enabled will be
             cleared, but failed will not be set.";
           reference
-            "IEEE 802.1X-2010 Clause 8.4";
+            "IEEE 802.1X-2020 Clause 8.4";
         }
       }
 
       container authenticator {
-        when "../port-capabilities/supp = 'false' and
-              ../port-capabilities/auth = 'true'" {
+        when "../port-capabilities/auth = 'true'" {
           description
-            "Applies when the Supplicant is disabled and
-            Authenticator is supported.";
+            "Applies when the Authenticator is supported.";
         }
         description
           "Contains configuration nodes for the Authenticator PAE
@@ -911,21 +643,21 @@ module ieee802-dot1x {
           units seconds;
           default "60";
           description
-            "Number of seconds that the switch remains in the quiet
+            "Number of seconds that the authenticator remains in the quiet
             state following a failed authentication exchange with the
-            client.";
+            supplicant.";
           reference
-            "IEEE 802.1X-2010 Clause 8.6, Figure 12-3";
+            "IEEE 802.1X-2020 Clause 8.6, Figure 12-3";
         }
         leaf reauth-period {
-          type uint16;
+          type uint32;
           units seconds;
           default "3600";
           description
             "This object indicates the time period of the
             reauthentication to the supplicant.";
           reference
-            "IEEE 802.1X-2010 Clause 8.6, Figure 12-3";
+            "IEEE 802.1X-2020 Clause 8.6, Figure 12-3";
         }
         leaf reauth-enable {
           type boolean;
@@ -933,17 +665,17 @@ module ieee802-dot1x {
           description
             "Re-authentication is enabled or not.";
           reference
-            "IEEE 802.1X Clasue 5.8c and 8.9";
+            "IEEE 802.1X-2020 Clause 5.8 and 8.9";
         }
         leaf retry-max {
-          type uint8;
+          type uint32;
           default "2";
           description
             "Specifies the maximum number of re-authentication
             attempts on an authenticator port before port is
             unauthorized.";
           reference
-            "IEEE 802.1X-2010 Clause 8.9";
+            "IEEE 802.1X-2020 Clause 8.9";
         }
         
         leaf enabled {
@@ -957,7 +689,7 @@ module ieee802-dot1x {
             management, e.g. because the application scenario
             authenticates a user and there is no user logged on.";
           reference
-            "IEEE 802.1X-2010 Clause 8.4";
+            "IEEE 802.1X-2020 Clause 8.4";
         }
         leaf authenticate {
           type boolean;
@@ -968,7 +700,7 @@ module ieee802-dot1x {
             to revoke authentication. To enable authentication the
             client also needs to clear failed (if set).";
           reference
-            "IEEE 802.1X-2010 Clause 8.4";
+            "IEEE 802.1X-2020 Clause 8.4";
         }
         leaf authenticated {
           type boolean;
@@ -977,7 +709,7 @@ module ieee802-dot1x {
             "Set by PACP if the PAE is currently authenticated, and
             cleared if the authentication fails or is revoked.";
           reference
-            "IEEE 802.1X-2010 Clause 8.4";
+            "IEEE 802.1X-2020 Clause 8.4";
         }
         leaf failed {
           type boolean;
@@ -994,7 +726,7 @@ module ieee802-dot1x {
             machines) if enable becomes FALSE and enabled will be
             cleared, but failed will not be set.";
           reference
-            "IEEE 802.1X-2010 Clause 8.4";
+            "IEEE 802.1X-2020 Clause 8.4";
         }
       }
 
@@ -1013,7 +745,7 @@ module ieee802-dot1x {
             "Set by management to enable (clear to disable) the use
             of MKA.";
           reference
-            "IEEE 802.1X-2010 Clause 9.16";
+            "IEEE 802.1X-2020 Clause 9.16";
         }
         container actor {
           description
@@ -1024,16 +756,16 @@ module ieee802-dot1x {
             description
               "The Key Server Priority for all the ports actors.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf sci {
-            type sci-list-entry;
+            type dot1x-types:sci-list-entry;
             config false;
             description
               "The SCI assigned by the system to the port (applies
               to all the ports actors).";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
         }
         container key-server {
@@ -1048,10 +780,10 @@ module ieee802-dot1x {
               principal actor. Matches the actorPriority if the
               actor is the Key Server";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf sci {
-            type sci-list-entry;
+            type dot1x-types:sci-list-entry;
             config false;
             description
               "The SCI for Key Server for the principal actor. Null
@@ -1059,7 +791,7 @@ module ieee802-dot1x {
               live peers. Matches the actorSCI if the actor is the
               Key Server.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
         }
         container group {
@@ -1073,7 +805,7 @@ module ieee802-dot1x {
               "Set if the KaY will accept Group CAKs distributed by
               MKA.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf form {
             type boolean;
@@ -1083,7 +815,7 @@ module ieee802-dot1x {
               to distribute a Group CAK, if its principal actor is
               the Key Server for all the point-to-point CAs.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf new {
             type boolean;
@@ -1094,7 +826,7 @@ module ieee802-dot1x {
               for all point-to-point CAs. Cleared by the KaY when
               distribution is complete.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
         }
         
@@ -1113,7 +845,7 @@ module ieee802-dot1x {
               "Set for the port and applicable to all actors, by
               management.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf desired {
             type boolean;
@@ -1122,7 +854,7 @@ module ieee802-dot1x {
               "Set for the port and applicable to all actors, by
               management.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           
           leaf protect {
@@ -1131,7 +863,7 @@ module ieee802-dot1x {
             description
               "As used by the CP state machine, see 12.4.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf validate {
             type boolean;
@@ -1139,7 +871,7 @@ module ieee802-dot1x {
             description
               "As used by the CP state machine, see 12.4.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf replay-protect {
             type boolean;
@@ -1147,7 +879,7 @@ module ieee802-dot1x {
             description
               "As used by the CP state machine, see 12.4.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
         }
         leaf suspend-on-request {
@@ -1168,7 +900,7 @@ module ieee802-dot1x {
             actor is the Key Server) or to request a suspension
             (otherwise).";
           reference
-            "IEEE 802.1X-2010 Clause 9.18";
+            "IEEE 802.1X-2020 Clause 9.18";
         }
         
         leaf suspended-while {
@@ -1179,7 +911,7 @@ module ieee802-dot1x {
             progress and (when available) to discover the remaining
             duration of that suspension";
           reference
-            "IEEE 802.1X-2010 Clause 9.18";
+            "IEEE 802.1X-2020 Clause 9.18";
         }
         leaf active {
           type boolean;
@@ -1188,7 +920,7 @@ module ieee802-dot1x {
             "Set if there is at least one active actor, transmitting
             MKPDUs.";
           reference
-            "IEEE 802.1X-2010 Clause 9.16";
+            "IEEE 802.1X-2020 Clause 9.16";
         }
         leaf authenticated {
           type boolean;
@@ -1199,7 +931,7 @@ module ieee802-dot1x {
             peers, has determined that Controlled Port communication
             should proceed without MACsec.";
           reference
-            "IEEE 802.1X-2010 Clause 9.16";
+            "IEEE 802.1X-2020 Clause 9.16";
         }
         leaf secured {
           type boolean;
@@ -1208,7 +940,7 @@ module ieee802-dot1x {
             "Set if the principal actor has determined that
             communication should use MACsec.";
           reference
-            "IEEE 802.1X-2010 Clause 9.16";
+            "IEEE 802.1X-2020 Clause 9.16";
         }
         leaf failed {
           type boolean;
@@ -1218,23 +950,23 @@ module ieee802-dot1x {
             the latter are clear and MKA Life Time has elapsed since
             an MKA participant was last created.";
           reference
-            "IEEE 802.1X-2010 Clause 9.16";
+            "IEEE 802.1X-2020 Clause 9.16";
         }
         container key-number {
         	config false;
           description
             "Contains operation state nodes for Key Numbers.";
           leaf tx {
-            type mak-kn;
+            type dot1x-types:mka-kn;
             description
               "The Key Number assigned by the Key Server to the SAK
               currently being used for transmission. Null if MACsec
               is not being used.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf rx {
-            type mak-kn;
+            type dot1x-types:mka-kn;
             description
               "The Key Number assigned by the Key Server to the
               oldest SAK currently being used for reception. The same
@@ -1242,7 +974,7 @@ module ieee802-dot1x {
               most often be the case). Null if MACsec is not being
               used.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
         }
         container association-number {
@@ -1251,21 +983,21 @@ module ieee802-dot1x {
             "Contains operation state nodes for Association
             Numbers.";
           leaf tx {
-            type mak-an;
+            type dot1x-types:mka-an;
             description
               "The Association Number assigned by the Key Server for
               use with txKN. Zero if MACsec is not in use.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf rx {
-            type mak-an;
+            type dot1x-types:mka-an;
             description
               "The Association Number assigned by the Key Server for
               use with rxKN. The same as txAN if a single SAK is
               currently in use. Zero if MACsec is not in use.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
         }
 
@@ -1294,7 +1026,7 @@ module ieee802-dot1x {
               "Set if the participant is active, i.e., is currently
               transmitting periodic MKPDUs.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf retain {
             type boolean;
@@ -1304,7 +1036,7 @@ module ieee802-dot1x {
               cache, even if the KaY would normally remove it (due to
               lack of use for example).";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf activate {
             type enumeration {
@@ -1352,7 +1084,7 @@ module ieee802-dot1x {
               of twice MKA Life Time will not cause the participant
               to become active once more.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           
           container peers {
@@ -1361,55 +1093,55 @@ module ieee802-dot1x {
               "Contains operational state nodes associated with the
               Peers.";
             leaf-list live {
-              type sci-list-entry;
+              type dot1x-types:sci-list-entry;
                 description
                   "A list of the SCIs of the participants live
                   peers.";
                 reference
-                  "IEEE 802.1X-2010 Clause 9.16";
+                  "IEEE 802.1X-2020 Clause 9.16";
             }
             leaf-list potential {
-              type sci-list-entry;
+              type dot1x-types:sci-list-entry;
               description
                 "A list of the SCIs of the participants potential
                 peers.";
               reference
-                "IEEE 802.1X-2010 Clause 9.16";
+                "IEEE 802.1X-2020 Clause 9.16";
             }
           }
           leaf ckn {
-            type pae-ckn;
+            type dot1x-types:pae-ckn;
             config false;
             description
               "The secure Connectivity Association Key Name for the
               participant.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf kmd {
-            type pae-kmd;
+            type dot1x-types:pae-kmd;
             config false;
             description
               "The Key Management Domain for the participant.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf nid {
-            type pae-nid;
+            type dot1x-types:pae-nid;
             config false;
             description
               "The NID for the participant.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf auth-data {
-            type pae-auth-data;
+            type dot1x-types:pae-auth-data;
             config false;
             description
               "Authorization data associated with the secure
               Connectivity Association Key.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf principal {
             type boolean;
@@ -1418,17 +1150,17 @@ module ieee802-dot1x {
               "Set if the participant is currently the principal
               actor.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
           leaf dist-ckn {
-            type pae-ckn;
+            type dot1x-types:pae-ckn;
             config false;
             description
               "The CKN for the last CAK distributed (either by the
               actor or one of its partners). Null if this participant
               has not been used to distribute a CAK.";
             reference
-              "IEEE 802.1X-2010 Clause 9.16";
+              "IEEE 802.1X-2020 Clause 9.16";
           }
         }
       }
@@ -1441,35 +1173,35 @@ module ieee802-dot1x {
         	authentication credentials, cached CAKs, and 
         	announcements.";
         leaf selected {
-          type pae-nid;
+          type dot1x-types:pae-nid;
           description
             "The NID currently configured for use by an access
             controlled port when transmitting EAPOL-Start frames.
             Defaults to the null NID.";
           reference
-            "IEEE 802.1X-2010 Clause 12.5";
+            "IEEE 802.1X-2020 Clause 12.5";
         }
         uses nid-group;
         
         leaf connected {
-          type pae-nid;
+          type dot1x-types:pae-nid;
           config false;
           description
             "The NID associated with the current connectivity
             (possibly unauthenticated) provided by the operation of
             the CP state machine.";
           reference
-            "IEEE 802.1X-2010 Clause 12.5";
+            "IEEE 802.1X-2020 Clause 12.5";
         }
         leaf requested {
-          type pae-nid;
+          type dot1x-types:pae-nid;
           config false;
           description
             "The NID marked as Access requested in announcements, as
             determined from EAPOL-Start frames. Defaults to the
             selectedNID.";
           reference
-            "IEEE 802.1X-2010 Clause 12.5";
+            "IEEE 802.1X-2020 Clause 12.5";
         }
       }
 
@@ -1489,7 +1221,7 @@ module ieee802-dot1x {
             "A boolean indicating if the announcer is enabled or
             not.";
           reference
-            "IEEE 802.1X-2010 Clause 10.4";
+            "IEEE 802.1X-2020 Clause 10.4";
         }
         list announce {
           key "announces";
@@ -1505,23 +1237,23 @@ module ieee802-dot1x {
           uses nid-group;
           
           leaf nid {
-            type pae-nid;
+            type dot1x-types:pae-nid;
             config false;
             description
               "The NID information to identify a received network
               announcement for the PAE.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
           }
           leaf access-status {
-            type pae-access-status;
+            type dot1x-types:pae-access-status;
             config false;
             description
               "Access Status reflects connectivity as a result of
               authentication attempts, and might be set directly by
               the system or configured by AAA protocols.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4, Clause 12.5";
+              "IEEE 802.1X-2020 Clause 10.4, Clause 12.5";
           }
         }
       }
@@ -1542,7 +1274,7 @@ module ieee802-dot1x {
             "A boolean indicating if the listener is enabled or
             not.";
           reference
-            "IEEE 802.1X-2010 Clause 10.4";
+            "IEEE 802.1X-2020 Clause 10.4";
         }
         
         list announcement {
@@ -1558,20 +1290,20 @@ module ieee802-dot1x {
               "The key into the list of Announce nodes.";
           }
           leaf nid {
-            type pae-nid;
+            type dot1x-types:pae-nid;
             description
               "The NID information to identify a received network
               announcement for the PAE.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
           }
           leaf kmd {
-            type pae-kmd;
+            type dot1x-types:pae-kmd;
             description
               "The KMD information for this received network
               announcement of the PAE.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
           }
           leaf specific {
             type boolean;
@@ -1580,16 +1312,16 @@ module ieee802-dot1x {
               information was specific to the receiving PAE, not
               generic for all systems attached to the LAN.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
           }
           leaf access-status {
-            type pae-access-status;
+            type dot1x-types:pae-access-status;
             description
               "The object information reflects connectivity as a
               result of authentication attempts for this received
               network announcement of the PAE.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
           }
           leaf requested-nid {
             type boolean;
@@ -1597,24 +1329,24 @@ module ieee802-dot1x {
               "The authenticated access has been requested for this
               particular NID or not.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
           }
           leaf unauthenticated-access {
-            type pae-access-status;
+            type dot1x-types:pae-access-status;
             description
               "The access capability of the ports clients without
               authentication in this received network announcement of
               the PAE";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
           }
           leaf access-capabilities {
-            type pae-nid-capabilities;
+            type dot1x-types:pae-nid-capabilities;
             description
               "The authentication and protection capabilities
               supported for the NID.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
           }
           list cipher-suites {
             key "index";
@@ -1623,7 +1355,7 @@ module ieee802-dot1x {
               the Listeners receive in the network announcement of
               the PAE system.";
             reference
-              "IEEE 802.1X-2010 Clause 10.4";
+              "IEEE 802.1X-2020 Clause 10.4";
             leaf index {
               type uint16;
               description
@@ -1646,7 +1378,7 @@ module ieee802-dot1x {
       container eapol-statistics {
       	config false;
         description
-          "Contains operational EAPOL statics.";
+          "Contains operational EAPOL statistics.";
         leaf invalid-eapol-frame-rx {
           when "../../port-type = 'real-port'" {
             description
@@ -1657,9 +1389,9 @@ module ieee802-dot1x {
             "The number of invalid EAPOL frames of any type that
             have been received by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
-        leaf eap-length-error-frames {
+        leaf eap-length-error-frames-rx {
           when "../../port-type = 'real-port'" {
             description
               "Applies when port is Real Port.";
@@ -1670,7 +1402,7 @@ module ieee802-dot1x {
             does not match a Packet Body that is contained within the
             octets of the received EAPOL MPDU in this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf eapol-announcements-rx {
           when "../../port-type = 'real-port'" {
@@ -1682,7 +1414,7 @@ module ieee802-dot1x {
             "The number of EAPOL-Announcement frames that have been
             received by this PAE";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf eapol-announce-reqs-rx {
           when "../../port-type = 'real-port'" {
@@ -1694,7 +1426,7 @@ module ieee802-dot1x {
             "The number of EAPOL-Announcement-Req frames that have
             been received by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf eapol-port-unavailable {
           when "../../port-type = 'real-port' and
@@ -1712,7 +1444,7 @@ module ieee802-dot1x {
             currently exists. If virtual port is not supported, this
             object should be always 0.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf eapol-start-frames-rx {
           type yang:counter32;
@@ -1720,7 +1452,7 @@ module ieee802-dot1x {
             "The number of EAPOL-Start frames that have been received
             by this PAE";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf eapol-eap-frames-rx {
           type yang:counter32;
@@ -1728,7 +1460,7 @@ module ieee802-dot1x {
             "The number of EAPOL-EAP frames that have been received
             by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf eapol-logoff-frames-rx {
           type yang:counter32;
@@ -1736,7 +1468,7 @@ module ieee802-dot1x {
             "The number of EAPOL-Logoff frames that have been
             received by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf eapol-mk-no-cfn {
           type yang:counter32;
@@ -1744,7 +1476,7 @@ module ieee802-dot1x {
             "The number of MKPDUs received with MKA not enabled or
             CKN not recognized in this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf eapol-mk-invalid-frames-rx {
           type yang:counter32;
@@ -1752,7 +1484,7 @@ module ieee802-dot1x {
             "The number of MKPDUs failing in message authentication
             on receipt process in this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.1";
+            "IEEE 802.1X-2020 Clause 12.8.1";
         }
         leaf last-eapol-frame-source {
           when "../../port-type = 'real-port'" {
@@ -1764,14 +1496,14 @@ module ieee802-dot1x {
             "The source MAC address of last received EAPOL frame by
             this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.2";
+            "IEEE 802.1X-2020 Clause 12.8.2";
         }
         leaf last-eapol-frame-version {
-          type yang:counter32;
+          type uint8;
           description
             "The version of last received EAPOL frame by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.2";
+            "IEEE 802.1X-2020 Clause 12.8.2";
         }
         leaf eapol-supp-eap-frames-tx {
           when "../../port-type = 'real-port'" {
@@ -1783,7 +1515,7 @@ module ieee802-dot1x {
             "The number of EAPOL-EAP frames that have been
             transmitted by the supplicant of this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.3";
+            "IEEE 802.1X-2020 Clause 12.8.3";
         }
         leaf eapol-logoff-frames-tx {
           when "../../port-type = 'real-port'" {
@@ -1795,7 +1527,7 @@ module ieee802-dot1x {
             "The number of EAPOL-Logoff frames that have been
             transmitted by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.3";
+            "IEEE 802.1X-2020 Clause 12.8.3";
         }
         leaf eapol-announcements-tx {
           when "../../port-type = 'real-port'" {
@@ -1807,7 +1539,7 @@ module ieee802-dot1x {
             "The number of EAPOL-Announcement frames that have been
             transmitted by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.3";
+            "IEEE 802.1X-2020 Clause 12.8.3";
         }
         leaf eapol-announce-reqs-tx {
           when "../../port-type = 'real-port'" {
@@ -1819,15 +1551,15 @@ module ieee802-dot1x {
             "The number of EAPOL-Announcement-Req frames that have
             been transmitted by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.3";
+            "IEEE 802.1X-2020 Clause 12.8.3";
         }
         leaf eapol-start-frames-tx {
           type yang:counter32;
           description
             "The number of EAPOL-Start frames that have been
-            received by this PAE.";
+            transmitted by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.3";
+            "IEEE 802.1X-2020 Clause 12.8.3";
         }
         leaf eapol-auth-eap-frames-tx {
           type yang:counter32;
@@ -1835,7 +1567,7 @@ module ieee802-dot1x {
             "The number of EAPOL-EAP frames that have been
             transmitted by the authenticator of this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.3";
+            "IEEE 802.1X-2020 Clause 12.8.3";
         }
         leaf eapol-mka-frames-tx {
           type yang:counter32;
@@ -1843,7 +1575,7 @@ module ieee802-dot1x {
             "The number of EAPOL-MKA frames with no CKN information
             that have been transmitted by this PAE.";
           reference
-            "IEEE 802.1X-2010 Clause 12.8.3";
+            "IEEE 802.1X-2020 Clause 12.8.3";
         }
       }
 
@@ -1859,7 +1591,7 @@ module ieee802-dot1x {
             "A boolean indicating if the logon-process is enabled or
             not.";
           reference
-            "IEEE 802.1X-2010 Clause 12.5";
+            "IEEE 802.1X-2020 Clause 12.5";
         }
         
         leaf connect {
@@ -1876,8 +1608,8 @@ module ieee802-dot1x {
             }
             enum authenticated {
               description
-                "Provide unsecured connectivity, setting
-                controlledPortEnabled.";
+                "Provide unsecured connectivity with authorization 
+				data, setting controlledPortEnabled.";
             }
             enum secure {
               description
@@ -1887,19 +1619,13 @@ module ieee802-dot1x {
                 and in use, as specified in detail by the CP state
                 machine.";
             }
-            enum authorization-data {
-              description
-                "Authorization data to be made available to the
-                client of the Controlled Port if connect is
-                Authenticated.";
-            }
           }
           config false;
           description
             "The Logon Process sets this variable to one of the
             above values.";
           reference
-            "IEEE 802.1X-2010 Clause 12.3";
+            "IEEE 802.1X-2020 Clause 12.3";
         }
         leaf port-valid {
           type boolean;
@@ -1908,7 +1634,7 @@ module ieee802-dot1x {
             "Set if Controlled Port communication is secured as
             specified by the MACsec control macsecProtect.";
           reference
-            "IEEE 802.1X-2010 Clause 12.3";
+            "IEEE 802.1X-2020 Clause 12.3";
         }
         list session-statistics {
           key "session-id";
@@ -1917,18 +1643,18 @@ module ieee802-dot1x {
             "Contains operational state nodes associated with the
             session statistics.";
           leaf session-id {
-            type pae-session-id;
+            type dot1x-types:pae-session-id;
             description
               "Key into list of session statistics.";
             reference
-              "IEEE 802.1X-2010 Clause 12.5.1";
+              "IEEE 802.1X-2020 Clause 12.5.1";
           }
           leaf user-name {
-            type pae-session-user-name;
+            type dot1x-types:pae-session-user-name;
             description
               "User name of the session.";
             reference
-              "IEEE 802.1X-2010 Clause 12.5.1";
+              "IEEE 802.1X-2020 Clause 12.5.1";
           }
           leaf octets-rx {
             type yang:counter64;
@@ -1936,7 +1662,7 @@ module ieee802-dot1x {
               "The number of octets received in this session of this
               PAE.";
             reference
-              "IEEE 802.1X-2010 Clause 12.5.1";
+              "IEEE 802.1X-2020 Clause 12.5.1";
           }
           leaf octets-tx {
             type yang:counter64;
@@ -1944,7 +1670,7 @@ module ieee802-dot1x {
               "The number of octets transmitted in this session of
               this PAE.";
             reference
-              "IEEE 802.1X-2010 Clause 12.5.1";
+              "IEEE 802.1X-2020 Clause 12.5.1";
           }
           leaf frames-rx {
             type yang:counter64;
@@ -1952,7 +1678,7 @@ module ieee802-dot1x {
               "The number of packets received in this session of
               this PAE.";
             reference
-              "IEEE 802.1X-2010 Clause 12.5.1";
+              "IEEE 802.1X-2020 Clause 12.5.1";
           }
           leaf frames-tx {
             type yang:counter64;
@@ -1960,7 +1686,7 @@ module ieee802-dot1x {
               "The number of packets transmitted in this session of
               this PAE.";
             reference
-              "IEEE 802.1X-2010 Clause 12.5.1";
+              "IEEE 802.1X-2020 Clause 12.5.1";
           }
           leaf time {
             type yang:timeticks;
@@ -1968,11 +1694,11 @@ module ieee802-dot1x {
               "Session Time. The duration of the session in
               seconds.";
             reference
-              "IEEE 802.1X-2010 Clause 12.5.1";
+              "IEEE 802.1X-2020 Clause 12.5.1";
           }
           leaf terminate-cause {
             type enumeration {
-              enum common_port_MAC_operatonal_false {
+              enum common_port_MAC_operational_false {
                 description
                   "Common Port for this PAE is not operational.";
               }
@@ -1990,7 +1716,7 @@ module ieee802-dot1x {
                 description
                   "EAP reauthentication has failed.";
               }
-              enum mak-failure_termination {
+              enum mka-failure_termination {
                 description
                   "MKA failure or other MKA termination.";
               }
@@ -2006,7 +1732,7 @@ module ieee802-dot1x {
             description
               "The reason for the session termination.";
             reference
-              "IEEE 802.1X-2010 Clause 12.5.1";
+              "IEEE 802.1X-2020 Clause 12.5.1";
           }
         }
       }


### PR DESCRIPTION
**Clean YANG Validation**

ieee802-dot1q-types.yang
Pyang Validation
ieee802-dot1q-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ieee802-dot1q-cfm.yang
Pyang Validation
ieee802-dot1q-cfm.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm
  +--rw cfm
     +--rw maintenance-domain* [md-id]
     |  +--rw md-id                              cfm-types:name-key-type
     |  +--rw (md-name)?
     |  |  +--:(none)
     |  |  |  +--rw none?                        empty
     |  |  +--:(dns-like-name)
     |  |  |  +--rw dns-like-name?               string
     |  |  +--:(mac-address-and-uint)
     |  |  |  +--rw mac-address-and-uint-type
     |  |  |     +--rw address    ieee:mac-address
     |  |  |     +--rw int        uint16
     |  |  +--:(char-string)
     |  |     +--rw char-string?                 string
     |  +--rw md-level?                          cfm-types:md-level-type
     |  +--rw mhf-creation?                      cfm-types:mhf-creation-type
     |  +--rw id-permission?                     cfm-types:sender-id-permission-type
     |  +--rw fault-alarm-transmission?          cfm-types:fault-alarm-type
     |  +--rw maintenance-association* [ma-id]
     |     +--rw ma-id                          cfm-types:name-key-type
     |     +--rw (ma-name)
     |     |  +--:(primary-vid)
     |     |  |  +--rw primary-vid?             dot1q-types:vlanid
     |     |  +--:(char-string)
     |     |  |  +--rw char-string?             string
     |     |  +--:(unsigned-int16)
     |     |  |  +--rw unsigned-int16?          uint16
     |     |  +--:(rfc2865-vpn-id)
     |     |     +--rw vpn-id
     |     |        +--rw vpn-oui      uint32
     |     |        +--rw vpn-index    uint32
     |     +--rw ccm-interval?                  cfm-types:ccm-interval-type
     |     +--rw fault-alarm-transmission?      cfm-types:fault-alarm-type
     |     +--rw mhf-creation?                  cfm-types:mhf-creation-type
     |     +--rw id-permission?                 cfm-types:sender-id-permission-type
     |     +--rw maintenance-association-mep* [mep-id]
     |        +--rw mep-id    cfm-types:mep-id-type
     +--rw maintenance-group* [maintenance-group-id]
        +--rw maintenance-group-id    cfm-types:name-key-type
        +--rw md-id                   -> /cfm/maintenance-domain/md-id
        +--rw ma-id                   -> /cfm/maintenance-domain[md-id = current()/../md-id]/maintenance-association/ma-id
        +--rw mep* [mep-id]
           +--rw mep-id                 -> /cfm/maintenance-domain[md-id = current()/../../md-id]/maintenance-association[ma-id = current()/../../ma-id]/maintenance-association-mep/mep-id
           +--rw direction              cfm-types:mp-direction-type
           +--rw admin-state?           boolean
           +--rw ccm-ltm-priority?      dot1q-types:priority-type
           +--ro mac-address            ieee:mac-address
           +--rw inactive-remote-mep* [inactive-rmep-id]
           |  +--rw inactive-rmep-id    -> /cfm/maintenance-domain[md-id = current()/../../../md-id]/maintenance-association[ma-id = current()/../../../ma-id]/maintenance-association-mep/mep-id
           +--ro mep-db* [rmep-id]
           |  +--ro rmep-id                     cfm-types:mep-id-type
           |  +--ro rmep-state                  cfm-types:remote-mep-state-type
           |  +--ro rmep-failed-ok-time         yang:date-and-time
           |  +--ro mac-address                 ieee:mac-address
           |  +--ro rdi                         boolean
           |  +--ro port-status-tlv?            cfm-types:port-status-tlv-value-type
           |  +--ro interface-status-tlv?       cfm-types:interface-status-tlv-value-type
           |  +--ro chassis-id-subtype?         lldp-types:chassis-id-subtype-type
           |  +--ro chassis-id?                 lldp-types:chassis-id-type
           |  +--ro transport-service-domain
           |  |  +--ro domain?                  yang:object-identifier-128
           |  |  +--ro (management-address)
           |  |     +--:(ip)
           |  |     |  +--ro ip-address         inet:ip-address
           |  |     |  +--ro ip-port            inet:port-number
           |  |     +--:(local)
           |  |     |  +--ro local-address      string
           |  |     +--:(dns)
           |  |     |  +--ro dns-address        string
           |  |     +--:(other)
           |  |        +--ro unknown-address?   binary
           |  +--ro rmep-is-active?             boolean
           +--rw continuity-check
           |  +--rw ccm-enabled?                boolean
           |  +--ro fng-state?                  cfm-types:fng-state-type
           |  +--rw fault-alarm-transmission?   cfm-types:fault-alarm-type
           |  +--rw lowest-priority-defect?     cfm-types:lowest-alarm-priority-type
           |  +--rw fng-alarm-time?             uint16
           |  +--rw fng-reset-time?             uint16
           |  +--ro highest-priority-defect     cfm-types:highest-defect-priority-type
           |  +--ro defects                     cfm-types:mep-defects-type
           |  +--ro error-ccm-last-failure?     binary
           |  +--ro xcon-ccm-last-failure?      binary
           +--ro stats
           |  +--ro mep-ccm-sequence-errors    yang:counter64
           |  +--ro mep-ccms-sent              yang:counter64
           |  +--ro mep-lbr-in                 yang:counter64
           |  +--ro mep-lbr-in-out-of-order    yang:counter64
           |  +--ro mep-lbr-bad-msdu           yang:counter64
           |  +--ro mep-unexpected-ltr-in      yang:counter64
           |  +--ro mep-lbr-out                yang:counter64
           +---x transmit-loopback
           |  +---w input
           |  |  +---w (lbm-destination)
           |  |  |  +--:(dest-ucast-mac-address)
           |  |  |  |  +---w lbm-dest-ucast-mac-address?          cfm-types:unicast-mac-address-type
           |  |  |  +--:(dest-mcast-class1-mac-address)
           |  |  |  |  +---w lbm-dest-mcast-class1-mac-address?   cfm-types:multicast-class1-mac-address-type
           |  |  |  +--:(dest-mep-id)
           |  |  |     +---w lbm-dest-mep-id?                     cfm-types:mep-id-type
           |  |  +---w lbm-messages?                              uint16
           |  |  +---w lbm-priority?                              dot1q-types:priority-type
           |  |  +---w lbm-drop-eligible?                         boolean
           |  |  +---w lbm-data-tlv?                              cfm-types:lbm-data-tlv-type
           |  +--ro output
           |     +--ro lbm-request-id    cfm-types:seq-number-type
           +---x transmit-linktrace
           |  +---w input
           |  |  +---w (ltr-target)
           |  |  |  +--:(target-ucast-mac-address)
           |  |  |  |  +---w ltm-target-mac-address?   cfm-types:unicast-mac-address-type
           |  |  |  +--:(target-mep-id)
           |  |  |     +---w ltm-target-mep-id?        cfm-types:mep-id-type
           |  |  +---w ltm-ttl?                        uint8
           |  |  +---w ltm-flags?                      cfm-types:mep-tx-ltm-flags-type
           |  +--ro output
           |     +--ro ltm-transaction-id       cfm-types:seq-number-type
           |     +--ro ltm-egress-identifier
           |        +--ro int        uint16
           |        +--ro address    ieee:mac-address
           +--ro linktrace-reply* [ltr-transaction-id]
           |  +--ro ltr-transaction-id    cfm-types:seq-number-type
           |  +--ro linktrace-input
           |  |  +--ro (ltr-target)
           |  |  |  +--:(target-ucast-mac-address)
           |  |  |  |  +--ro ltm-target-mac-address?   cfm-types:unicast-mac-address-type
           |  |  |  +--:(target-mep-id)
           |  |  |     +--ro ltm-target-mep-id?        cfm-types:mep-id-type
           |  |  +--ro ltm-ttl?                        uint8
           |  |  +--ro ltm-flags?                      cfm-types:mep-tx-ltm-flags-type
           |  +--ro responses* [ltr-receive-order]
           |     +--ro ltr-receive-order                uint32
           |     +--ro ltr-ttl                          uint8
           |     +--ro ltr-forwarded                    boolean
           |     +--ro ltr-terminal-mep                 boolean
           |     +--ro ltr-last-egress-identifier
           |     |  +--ro int        uint16
           |     |  +--ro address    ieee:mac-address
           |     +--ro ltr-next-egress-identifier
           |     |  +--ro int        uint16
           |     |  +--ro address    ieee:mac-address
           |     +--ro ltr-relay                        cfm-types:relay-action-field-value-type
           |     +--ro ltr-chassis-id-subtype?          lldp-types:chassis-id-subtype-type
           |     +--ro ltr-chassis-id                   lldp-types:chassis-id-type
           |     +--ro ltr-transport-service-domain
           |     |  +--ro domain?                  yang:object-identifier-128
           |     |  +--ro (management-address)
           |     |     +--:(ip)
           |     |     |  +--ro ip-address         inet:ip-address
           |     |     |  +--ro ip-port            inet:port-number
           |     |     +--:(local)
           |     |     |  +--ro local-address      string
           |     |     +--:(dns)
           |     |     |  +--ro dns-address        string
           |     |     +--:(other)
           |     |        +--ro unknown-address?   binary
           |     +--ro ltr-ingress?                     cfm-types:ingress-action-field-value-type
           |     +--ro ltr-ingress-mac                  ieee:mac-address
           |     +--ro ltr-ingress-port-id-subtype?     lldp-types:port-id-subtype-type
           |     +--ro ltr-ingress-port-id              lldp-types:port-id-type
           |     +--ro ltr-egress?                      cfm-types:egress-action-field-value-type
           |     +--ro ltr-egress-mac                   ieee:mac-address
           |     +--ro ltr-egress-port-id-subtype?      lldp-types:port-id-subtype-type
           |     +--ro ltr-egress-port-id               lldp-types:port-id-type
           |     +--ro ltr-organization-specific-tlv?   binary
           +---n mep-fault-alarm
              +-- mep-priority-defect    -> ../../continuity-check/highest-priority-defect
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ieee802-dot1ab-types.yang
Pyang Validation
ieee802-dot1ab-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ieee802-dot1q-cfm-mip.yang
Pyang Validation
ieee802-dot1q-cfm-mip.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-mip
  augment /dot1q-cfm:cfm:
    +--rw mips
       +--rw mip* [mip-id]
          +--rw mip-id           cfm-types:name-key-type
          +--rw md-level?        cfm-types:md-level-type
          +--rw id-permission?   cfm-types:sender-id-permission-type
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ieee802-dot1q-bridge.yang
Pyang Validation
ieee802-dot1q-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-bridge
  +--rw bridges
     +--rw bridge* [name]
        +--rw name           dot1qtypes:name-type
        +--rw address        ieee:mac-address
        +--rw bridge-type    identityref
        +--ro ports?         uint16
        +--ro up-time?       yang:zero-based-counter32
        +--ro components?    uint32
        +--rw component* [name]
           +--rw name                     string
           +--rw id?                      uint32
           +--rw type                     identityref
           +--rw address?                 ieee:mac-address
           +--rw traffic-class-enabled?   boolean
           +--ro ports?                   uint16
           +--ro bridge-port*             if:interface-ref
           +--ro capabilities
           |  +--ro extended-filtering?             boolean
           |  +--ro traffic-classes?                boolean
           |  +--ro static-entry-individual-port?   boolean
           |  +--ro ivl-capable?                    boolean
           |  +--ro svl-capable?                    boolean
           |  +--ro hybrid-capable?                 boolean
           |  +--ro configurable-pvid-tagging?      boolean
           |  +--ro local-vlan-capable?             boolean
           +--rw filtering-database
           |  +--rw aging-time?                          uint32
           |  +--ro size?                                yang:gauge32
           |  +--ro static-entries?                      yang:gauge32
           |  +--ro dynamic-entries?                     yang:gauge32
           |  +--ro static-vlan-registration-entries?    yang:gauge32
           |  +--ro dynamic-vlan-registration-entries?   yang:gauge32
           |  +--ro mac-address-registration-entries?    yang:gauge32 {extended-filtering-services}?
           |  +--rw filtering-entry* [database-id vids address]
           |  |  +--rw database-id    uint32
           |  |  +--rw address        ieee:mac-address
           |  |  +--rw vids           dot1qtypes:vid-range-type
           |  |  +--rw entry-type?    enumeration
           |  |  +--rw port-map* [port-ref]
           |  |  |  +--rw port-ref                                   port-number-type
           |  |  |  +--rw (map-type)?
           |  |  |     +--:(static-filtering-entries)
           |  |  |     |  +--rw static-filtering-entries
           |  |  |     |     +--rw control-element?         enumeration
           |  |  |     |     +--rw connection-identifier?   port-number-type
           |  |  |     +--:(static-vlan-registration-entries)
           |  |  |     |  +--rw static-vlan-registration-entries
           |  |  |     |     +--rw registrar-admin-control?   enumeration
           |  |  |     |     +--rw vlan-transmitted?          enumeration
           |  |  |     +--:(mac-address-registration-entries)
           |  |  |     |  +--rw mac-address-registration-entries
           |  |  |     |     +--rw control-element?   enumeration
           |  |  |     +--:(dynamic-vlan-registration-entries)
           |  |  |     |  +--rw dynamic-vlan-registration-entries
           |  |  |     |     +--rw control-element?   enumeration
           |  |  |     +--:(dynamic-reservation-entries)
           |  |  |     |  +--rw dynamic-reservation-entries
           |  |  |     |     +--rw control-element?   enumeration
           |  |  |     +--:(dynamic-filtering-entries)
           |  |  |        +--rw dynamic-filtering-entries
           |  |  |           +--rw control-element?   enumeration
           |  |  +--ro status?        enumeration
           |  +--rw vlan-registration-entry* [database-id vids]
           |     +--rw database-id    uint32
           |     +--rw vids           dot1qtypes:vid-range-type
           |     +--rw entry-type?    enumeration
           |     +--rw port-map* [port-ref]
           |        +--rw port-ref                                   port-number-type
           |        +--rw (map-type)?
           |           +--:(static-filtering-entries)
           |           |  +--rw static-filtering-entries
           |           |     +--rw control-element?         enumeration
           |           |     +--rw connection-identifier?   port-number-type
           |           +--:(static-vlan-registration-entries)
           |           |  +--rw static-vlan-registration-entries
           |           |     +--rw registrar-admin-control?   enumeration
           |           |     +--rw vlan-transmitted?          enumeration
           |           +--:(mac-address-registration-entries)
           |           |  +--rw mac-address-registration-entries
           |           |     +--rw control-element?   enumeration
           |           +--:(dynamic-vlan-registration-entries)
           |           |  +--rw dynamic-vlan-registration-entries
           |           |     +--rw control-element?   enumeration
           |           +--:(dynamic-reservation-entries)
           |           |  +--rw dynamic-reservation-entries
           |           |     +--rw control-element?   enumeration
           |           +--:(dynamic-filtering-entries)
           |              +--rw dynamic-filtering-entries
           |                 +--rw control-element?   enumeration
           +--rw permanent-database
           |  +--ro size?                               yang:gauge32
           |  +--ro static-entries?                     yang:gauge32
           |  +--ro static-vlan-registration-entries?   yang:gauge32
           |  +--rw filtering-entry* [database-id vids address]
           |     +--rw database-id    uint32
           |     +--rw address        ieee:mac-address
           |     +--rw vids           dot1qtypes:vid-range-type
           |     +--ro status?        enumeration
           |     +--rw port-map* [port-ref]
           |        +--rw port-ref                                   port-number-type
           |        +--rw (map-type)?
           |           +--:(static-filtering-entries)
           |           |  +--rw static-filtering-entries
           |           |     +--rw control-element?         enumeration
           |           |     +--rw connection-identifier?   port-number-type
           |           +--:(static-vlan-registration-entries)
           |           |  +--rw static-vlan-registration-entries
           |           |     +--rw registrar-admin-control?   enumeration
           |           |     +--rw vlan-transmitted?          enumeration
           |           +--:(mac-address-registration-entries)
           |           |  +--rw mac-address-registration-entries
           |           |     +--rw control-element?   enumeration
           |           +--:(dynamic-vlan-registration-entries)
           |           |  +--rw dynamic-vlan-registration-entries
           |           |     +--rw control-element?   enumeration
           |           +--:(dynamic-reservation-entries)
           |           |  +--rw dynamic-reservation-entries
           |           |     +--rw control-element?   enumeration
           |           +--:(dynamic-filtering-entries)
           |              +--rw dynamic-filtering-entries
           |                 +--rw control-element?   enumeration
           +--rw bridge-vlan
           |  +--ro version?                   uint16
           |  +--ro max-vids?                  uint16
           |  +--ro override-default-pvid?     boolean
           |  +--ro protocol-template?         dot1qtypes:protocol-frame-format-type {port-and-protocol-based-vlan}?
           |  +--ro max-msti?                  uint16
           |  +--rw vlan* [vid]
           |  |  +--rw vid               dot1qtypes:vlan-index-type
           |  |  +--rw name?             dot1qtypes:name-type
           |  |  +--ro untagged-ports*   if:interface-ref
           |  |  +--ro egress-ports*     if:interface-ref
           |  +--rw protocol-group-database* [db-index] {port-and-protocol-based-vlan}?
           |  |  +--rw db-index                 uint16
           |  |  +--rw frame-format-type?       dot1qtypes:protocol-frame-format-type
           |  |  +--rw (frame-format)?
           |  |  |  +--:(ethernet-rfc1042-snap8021H)
           |  |  |  |  +--rw ethertype?         dot1qtypes:ethertype-type
           |  |  |  +--:(snap-other)
           |  |  |  |  +--rw protocol-id?       string
           |  |  |  +--:(llc-other)
           |  |  |     +--rw dsap-ssap-pairs
           |  |  |        +--rw llc-address?   string
           |  |  +--rw group-id?                uint32
           |  +--rw vid-to-fid-allocation* [vids]
           |  |  +--rw vids               dot1qtypes:vid-range-type
           |  |  +--ro fid?               uint32
           |  |  +--ro allocation-type?   enumeration
           |  +--rw fid-to-vid-allocation* [fid]
           |  |  +--rw fid                uint32
           |  |  +--ro allocation-type?   enumeration
           |  |  +--ro vid*               dot1qtypes:vlan-index-type
           |  +--rw vid-to-fid* [vid]
           |     +--rw vid    dot1qtypes:vlan-index-type
           |     +--rw fid?   uint32
           +--rw bridge-mst
              +--rw mstid*                     dot1qtypes:mstid-type
              +--rw fid-to-mstid* [fid]
              |  +--rw fid      uint32
              |  +--rw mstid?   dot1qtypes:mstid-type
              +--rw fid-to-mstid-allocation* [fids]
                 +--rw fids     dot1qtypes:vid-range-type
                 +--rw mstid?   dot1qtypes:mstid-type

  augment /if:interfaces/if:interface:
    +--rw bridge-port
       +--rw component-name?                        string
       +--rw port-type?                             identityref
       +--rw pvid?                                  dot1qtypes:vlan-index-type
       +--rw default-priority?                      dot1qtypes:priority-type
       +--rw priority-regeneration
       |  +--rw priority0?   priority-type
       |  +--rw priority1?   priority-type
       |  +--rw priority2?   priority-type
       |  +--rw priority3?   priority-type
       |  +--rw priority4?   priority-type
       |  +--rw priority5?   priority-type
       |  +--rw priority6?   priority-type
       |  +--rw priority7?   priority-type
       +--rw pcp-selection?                         dot1qtypes:pcp-selection-type
       +--rw pcp-decoding-table
       |  +--rw pcp-decoding-map* [pcp]
       |     +--rw pcp             pcp-selection-type
       |     +--rw priority-map* [priority-code-point]
       |        +--rw priority-code-point    priority-type
       |        +--rw priority?              priority-type
       |        +--rw drop-eligible?         boolean
       +--rw pcp-encoding-table
       |  +--rw pcp-encoding-map* [pcp]
       |     +--rw pcp             pcp-selection-type
       |     +--rw priority-map* [priority dei]
       |        +--rw priority               priority-type
       |        +--rw dei                    boolean
       |        +--rw priority-code-point?   priority-type
       +--rw use-dei?                               boolean
       +--rw drop-encoding?                         boolean
       +--rw service-access-priority-selection?     boolean
       +--rw service-access-priority
       |  +--rw priority0?   priority-type
       |  +--rw priority1?   priority-type
       |  +--rw priority2?   priority-type
       |  +--rw priority3?   priority-type
       |  +--rw priority4?   priority-type
       |  +--rw priority5?   priority-type
       |  +--rw priority6?   priority-type
       |  +--rw priority7?   priority-type
       +--rw traffic-class
       |  +--rw traffic-class-map* [priority]
       |     +--rw priority                   priority-type
       |     +--rw available-traffic-class* [num-traffic-class]
       |        +--rw num-traffic-class    uint8
       |        +--rw traffic-class?       traffic-class-type
       +--rw acceptable-frame?                      enumeration
       +--rw enable-ingress-filtering?              boolean
       +--rw enable-restricted-vlan-registration?   boolean
       +--rw enable-vid-translation-table?          boolean
       +--rw enable-egress-vid-translation-table?   boolean
       +--rw protocol-group-vid-set* [group-id] {port-and-protocol-based-vlan}?
       |  +--rw group-id    uint32
       |  +--rw vid*        dot1qtypes:vlanid
       +--rw admin-point-to-point?                  enumeration
       +--ro protocol-based-vlan-classification?    boolean {port-and-protocol-based-vlan}?
       +--ro max-vid-set-entries?                   uint16 {port-and-protocol-based-vlan}?
       +--ro port-number?                           dot1qtypes:port-number-type
       +--ro address?                               ieee:mac-address
       +--ro capabilities?                          bits
       +--ro type-capabilties?                      bits
       +--ro external?                              boolean
       +--ro oper-point-to-point?                   boolean
       +--ro statistics
       |  +--ro delay-exceeded-discards?          yang:counter64
       |  +--ro mtu-exceeded-discards?            yang:counter64
       |  +--ro frame-rx?                         yang:counter64
       |  +--ro octets-rx?                        yang:counter64
       |  +--ro frame-tx?                         yang:counter64
       |  +--ro octets-tx?                        yang:counter64
       |  +--ro discard-inbound?                  yang:counter64
       |  +--ro forward-outbound?                 yang:counter64
       |  +--ro discard-lack-of-buffers?          yang:counter64
       |  +--ro discard-transit-delay-exceeded?   yang:counter64
       |  +--ro discard-on-error?                 yang:counter64
       |  +--ro discard-on-ingress-filtering?     yang:counter64 {ingress-filtering}?
       +--rw vid-translations* [local-vid]
       |  +--rw local-vid    dot1qtypes:vlanid
       |  +--rw relay-vid?   dot1qtypes:vlanid
       +--rw egress-vid-translations* [relay-vid]
          +--rw relay-vid    dot1qtypes:vlanid
          +--rw local-vid?   dot1qtypes:vlanid
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ieee802-types.yang
Pyang Validation
ieee802-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ieee802-dot1q-cfm-types.yang
Pyang Validation
ieee802-dot1q-cfm-types.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
No warnings or errors
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors
ieee802-dot1q-cfm-bridge.yang
Pyang Validation
ieee802-dot1q-cfm-bridge.yang:1: warning: RFC 6087: 4.1: the module name should start with the string "ieee-"
Pyang Output
module: ieee802-dot1q-cfm-bridge
  augment /dot1q-cfm:cfm:
    +--ro cfm-stack* [port service-selector service-id md-level direction]
    |  +--ro port                    port-ref
    |  +--ro md-level                cfm-types:md-level-type
    |  +--ro direction               cfm-types:mp-direction-type
    |  +--ro service-selector        cfm-types:service-selector-type
    |  +--ro service-id              cfm-types:service-selector-value-type
    |  +--ro maintenance-group-id    -> /dot1q-cfm:cfm/maintenance-group/maintenance-group-id
    |  +--ro mep-id                  -> /dot1q-cfm:cfm/maintenance-group[dot1q-cfm:maintenance-group-id = current()/../maintenance-group-id]/mep/mep-id
    |  +--ro md-id?                  -> /dot1q-cfm:cfm/maintenance-domain/md-id
    |  +--ro ma-id?                  -> /dot1q-cfm:cfm/maintenance-domain[dot1q-cfm:md-id = current()/../md-id]/maintenance-association/ma-id
    |  +--ro mac-address             ieee:mac-address
    |  +--ro maintenance-point       cfm-types:mp-type
    +--rw default-md-level* [bridge-id component-id service-selector primary-service-id]
    |  +--rw bridge-id                 bridge-ref
    |  +--rw component-id              -> /dot1q:bridges/bridge[dot1q:name = current()/../bridge-id]/component/name
    |  +--rw service-selector          cfm-types:service-selector-type
    |  +--rw primary-service-id        cfm-types:service-selector-value-type
    |  +--rw associated-service-ids
    |  |  +--rw (service-id)?
    |  |     +--:(vids)
    |  |     |  +--rw vid* [vlan-id]
    |  |     |     +--rw vlan-id    dot1q-types:vlanid
    |  |     +--:(isid)
    |  |     |  +--rw isid?         uint32
    |  |     +--:(tesid)
    |  |     |  +--rw tesid?        uint32
    |  |     +--:(segid)
    |  |     |  +--rw segid?        uint32
    |  |     +--:(path-tesid)
    |  |     |  +--rw path-tesid?   uint32
    |  |     +--:(group-isid)
    |  |        +--rw group-isid?   uint32
    |  +--ro md-status                 boolean
    |  +--rw md-level                  cfm-types:md-level-type
    |  +--rw mhf-creation?             cfm-types:mhf-creation-type
    |  +--rw id-permission?            cfm-types:sender-id-permission-type
    +--ro config-error* [port service-selector service-id]
       +--ro port                port-ref
       +--ro service-selector    cfm-types:service-selector-type
       +--ro service-id          cfm-types:service-selector-value-type
       +--ro error-type          cfm-types:config-error-type
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group:
    +--rw bridge-id?        bridge-ref
    +--rw component-name    -> /dot1q:bridges/bridge[dot1q:name = current()/../cfm-bridge:bridge-id]/dot1q:component/name
    +--rw service-id
       +--rw (service-id)?
          +--:(vids)
          |  +--rw vid* [vlan-id]
          |     +--rw vlan-id    dot1q-types:vlanid
          +--:(isid)
          |  +--rw isid?         uint32
          +--:(tesid)
          |  +--rw tesid?        uint32
          +--:(segid)
          |  +--rw segid?        uint32
          +--:(path-tesid)
          |  +--rw path-tesid?   uint32
          +--:(group-isid)
             +--rw group-isid?   uint32
  augment /dot1q-cfm:cfm/dot1q-cfm:maintenance-group/dot1q-cfm:mep:
    +--rw port           port-ref
    +--rw primary-vid?   -> ../../service-id/vid/vlan-id
Confdc Output
No warnings or errors
yanglint Validation
No warnings or errors