### PR TITLE
Adding ETSI repository for SOL006

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "vendor/fujitsu"]
 	path = vendor/fujitsu
 	url = https://github.com/FujitsuNetworkCommunications/FSS2-Yang.git
+[submodule "standard/etsi/SOL006"]
+	path = standard/etsi/SOL006
+	url = https://forge.etsi.org/rep/nfv/SOL006.git


### PR DESCRIPTION
This is an effort to add ETSI repository as a submodule in YangModules/yang repository. It will be ultimately used to make the ETSI YANG modules visible in YANG Catalog.