### PR TITLE
P802.1Qcx D1.5 changes

### DIFF
--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-alarm.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-alarm.yang
@@ -32,7 +32,7 @@ module ieee802-dot1q-cfm-alarm {
     organizations, each with restricted management access to each 
     other's equipment.";
   
-  revision 2019-07-10 {
+  revision 2019-09-30 {
     description
       "Creation for Working Group review.";
     reference

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-bridge.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-bridge.yang
@@ -35,7 +35,7 @@ module ieee802-dot1q-cfm-bridge {
     in Virtual Bridged Local Area Networks. This module binds
     the CFM modules to an IEEE 802.1Q Bridge.";
   
-  revision 2019-03-28 {
+  revision 2019-09-30 {
     description
       "Creation for Working Group review.";
     reference

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-types.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-types.yang
@@ -25,7 +25,7 @@ module ieee802-dot1q-cfm-types {
   description
     "Common types used within ieee802-dot1q-cfm modules.";
   
-  revision 2019-03-28 {
+  revision 2019-09-30 {
     description
       "Creation for Working Group review.";
     reference

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm.yang
@@ -37,7 +37,7 @@ module ieee802-dot1q-cfm {
     organizations, each with restricted management access to each 
     other's equipment.";
   
-  revision 2019-03-28 {
+  revision 2019-09-30 {
     description
       "Creation for Working Group review.";
     reference
@@ -731,8 +731,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3b, 20.20 of IEEE Std 802.1Q-2018";
           }
           leaf rmep-failed-ok-time {
-            type yang:date-and-time;
-            units milliseconds;
+            type yang:timeticks;
             mandatory true;
             description
               "The time (SysUpTime) at which the Remote MEP state

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-tpmr.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-tpmr.yang
@@ -1,0 +1,315 @@
+module ieee802-dot1q-tpmr {
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-tpmr;
+  prefix dot1q-tpmr;
+  import ieee802-dot1q-bridge {
+    prefix dot1q;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
+  organization
+    "IEEE 802.1 Working Group";
+  contact
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+    
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08854
+            USA
+    
+    E-mail: STDS-802-1-L@IEEE.ORG";
+  description
+    "This YANG module describes the bridge configuration model for the
+    Two Port MAC Relays.";
+  revision 2018-09-30 {
+    description
+      "Creation for Working Group review.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  
+  augment "/if:interfaces/if:interface/dot1q:bridge-port" {
+    when "dot1q:port-type = 'dot1q:d-bridge-port'" {
+      description
+        "Applies to TPMRs ports";
+    }
+    description
+      "Augment Interface model with TPMR port configuration
+      specific nodes.";
+    leaf managed-address {
+      type boolean;
+      default "true";
+      description
+        "A Boolean value, which is TRUE if the MAC address is the
+        management address for the TPMR, and is otherwise FALSE.
+        
+        The TPMR management entity may make use of one or both Ports
+        of a TPMR to transmit and receive management frames. However,
+        the MAC address used by the TPMR management entity as the
+        source MAC address in transmitted management frames (the
+        management MAC address) is the individual MAC address
+        associated with one of the Ports of the TPMR";
+      reference
+        "12.19.1.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    container mac-status-propagation {
+      description
+        "MAC status propagation configuration node parameters.";
+      leaf link-notify {
+        type boolean;
+        default "true";
+        description
+          "The current value (Boolean) of LinkNotify (23.5.1) being
+          used by the MSP state machines.";
+        reference
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf link-notify-wait {
+        type yang:timeticks {
+          range "20..100";
+        }
+        default "40";
+        description
+          "The current value, in centiseconds, of LinkNotifyWait
+          (23.5.2) being used by the MSP state machines.";
+        reference
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf link-notify-retry {
+        type yang:timeticks {
+          range "10..100";
+        }
+        default "100";
+        description
+          "The current value, in centiseconds, of LinkNotifyRetry
+          (23.5.3) being used by the MSP state machines.";
+        reference
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf mac-notify {
+        type boolean;
+        default "true";
+        description
+          "The current value (Boolean) of MACNotify (23.5.4) being
+          used by the MSP state machines.";
+        reference
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf mac-notify-time {
+        type yang:timeticks {
+          range "1..50";
+        }
+        default "20";
+        description
+          "The current value, in centiseconds, of MACNotifyTime
+          (23.5.5) being used by the MSP state machines.";
+        reference
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf mac-recover-time {
+        type yang:timeticks {
+          range "2..50";
+        }
+        default "10";
+        description
+          "The current value, in centiseconds, of MACRecoverTime
+          (23.5.6) being used by the MSP state machines.";
+        reference
+          "12.19.4.1.1.3 of IEEE Std 802.1Q-2018
+          12.19.4.1.2.2 of IEEE Std 802.1Q-2018";
+      }
+    }
+  }
+  augment
+    "/if:interfaces/if:interface/dot1q:bridge-port/dot1q:statistics" {
+    when "../dot1q:port-type = 'dot1q:d-bridge-port'" {
+      description
+        "Applies to TPMRs ports";
+    }
+    description
+      "Augment Interface model with TPMR port operational state
+      specific nodes.";
+    leaf acks-tx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of acks transmitted (23.6.15) by the Ports
+        Transmit Process as a consequence of txAck being set.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf add-notificatons-tx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of adds transmitted (23.6.16) by the Ports
+        Transmit Process as a consequence of txAdd being set.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf add-confirmations-tx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of add confirms transmitted (23.6.17) by the Ports
+        Transmit Process as a consequence of txAddConfirm being set.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf loss-notification-tx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of losses transmitted (23.6.18) by the Ports
+        Transmit Process as a consequence of txLoss being set.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf loss-confirmation-tx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of loss confirms transmitted (23.6.19) by the
+        Ports Transmit Process as a consequence of txLossConfirm being
+        set.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf acks-rx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of acks received (23.6.10) by the Ports Transmit
+        Process.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf add-notificatons-rx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of adds received (23.6.11) by the Ports Receive
+        Process.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf add-confirmations-rx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of add confirms received (23.6.12) by the Ports
+        Receive Process.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf loss-notification-rx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of losses received (23.6.13) by the Ports Receive
+        Process.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf loss-confirmation-rx {
+      type yang:counter64;
+      config false;
+      description
+        "The number of loss confirms received (23.6.14) by the Ports
+        Receive Process.
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf add-events {
+      type yang:counter64;
+      config false;
+      description
+        "The number of transitions to STM:ADD directly from STM:DOWN
+        or STM:LOSS (23.8).
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf loss-events {
+      type yang:counter64;
+      config false;
+      description
+        "The number of transitions to STM:LOSS directly from STM:UP or
+        STM:ADD (23.8).
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf mac-status-notifications {
+      type yang:counter64;
+      config false;
+      description
+        "The number of transitions to SNM:MAC_NOTIFICATION (23.9).
+        
+        Discontinuities in the value of this counter can occur at
+        re-initialization of the management system, and at other times
+        as indicated by the value of 'discontinuity-time'.";
+      reference
+        "12.19.4.1.3.3 of IEEE Std 802.1Q-2018";
+    }
+  }
+}


### PR DESCRIPTION
Clean YANG Validation and PYANG compilation

-----------------------
ieee802-dot1q-tpmr.yang
-----------------------
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors

----------------------------
ieee802-dot1q-cfm-types.yang
----------------------------
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors

-----------------------------
ieee802-dot1q-cfm-bridge.yang
-----------------------------
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors

----------------------------
ieee802-dot1q-cfm-alarm.yang
----------------------------
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors

----------------------
ieee802-dot1q-cfm.yang
----------------------
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors
