### PR TITLE
P802.1Qcx D2.0

### DIFF
--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-tpmr.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-tpmr.yang
@@ -35,6 +35,13 @@ module ieee802-dot1q-tpmr {
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
+  revision 2018-03-07 {
+    description
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
   
   augment "/if:interfaces/if:interface/dot1q:bridge-port" {
     when "dot1q:port-type = 'dot1q:d-bridge-port'" {


### PR DESCRIPTION
Clean compile and Validation.


**ieee802-dot1q-tpmr.yang**
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 
Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors

**ieee802-dot1q-cfm-alarm.yang**
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors

**ieee802-dot1q-cfm-bridge.yang**
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors


**ieee802-dot1q-cfm-types.yang**
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors

**ieee802-dot1q-cfm.yang**
XYM Extraction

No warnings or errors

Pyang Validation

 Usage: pyang [options] [<filename>...]

Validates the YANG module in <filename> (or stdin), and all its dependencies.

pyang: error: no such option: --ieee
 

Pyang Output

No warnings or errors

Confdc Output

No warnings or errors

yanglint Validation

No warnings or errors
