### PR TITLE
Updates based on IEEE P802.1Qcx (CFM YANG) project version D2.1

### DIFF
--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-alarm.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-alarm.yang
@@ -17,9 +17,8 @@ module ieee802-dot1q-cfm-alarm {
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
             445 Hoes Lane
-            P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
   
     E-mail: STDS-802-1-L@IEEE.ORG";

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-bridge.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-bridge.yang
@@ -22,9 +22,8 @@ module ieee802-dot1q-cfm-bridge {
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
             445 Hoes Lane
-            P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
   
     E-mail: STDS-802-1-L@IEEE.ORG";

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-types.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm-types.yang
@@ -15,9 +15,8 @@ module ieee802-dot1q-cfm-types {
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
             445 Hoes Lane
-            P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
   
     E-mail: STDS-802-1-L@IEEE.ORG";

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-cfm.yang
@@ -5,7 +5,6 @@ module ieee802-dot1q-cfm {
   prefix "dot1q-cfm";
   
   import ieee802-dot1q-cfm-types { prefix "cfm-types"; }
-  import ieee802-dot1ab-types { prefix "lldp-types"; }
   import ieee802-dot1q-types { prefix "dot1q-types"; }
   import ieee802-types { prefix "ieee"; }
   import ietf-yang-types { prefix "yang"; }
@@ -22,9 +21,8 @@ module ieee802-dot1q-cfm {
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
             445 Hoes Lane
-            P.O. Box 1331
             Piscataway
-            NJ 08855-1331
+            NJ 08854
             USA
   
     E-mail: STDS-802-1-L@IEEE.ORG";
@@ -782,7 +780,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3g, 20.19.4 of IEEE Std 802.1Q-2018";
           }
           leaf chassis-id-subtype {
-            type lldp-types:chassis-id-subtype-type;
+            type ieee:chassis-id-subtype-type;
             description
               "This object specifies the format of the Chassis ID
               received in the last CCM.";
@@ -790,7 +788,7 @@ module ieee802-dot1q-cfm {
               "12.14.7.6.3h, 21.5.3.2 of IEEE Std 802.1Q-2018";
           }
           leaf chassis-id {
-            type lldp-types:chassis-id-type;
+            type ieee:chassis-id-type;
             description
               "The Chassis ID. The format of this object is
               determined by the value of the 
@@ -1173,7 +1171,7 @@ module ieee802-dot1q-cfm {
                 "12.14.7.5.3g, 20.41.2.5 of IEEE Std 802.1Q-2018";
             }           
             leaf ltr-chassis-id-subtype {
-              type lldp-types:chassis-id-subtype-type;
+              type ieee:chassis-id-subtype-type;
               description
                 "Specifies the format of the Chassis ID returned
                 in the Sender ID TLV of the LTR, if any. This leaf
@@ -1185,7 +1183,7 @@ module ieee802-dot1q-cfm {
             }           
             leaf ltr-chassis-id {
               when "../ltr-chassis-id-subtype";
-              type lldp-types:chassis-id-type;
+              type ieee:chassis-id-type;
               mandatory true;
               description
                 "The Chassis ID returned in the Sender ID TLV of 
@@ -1231,7 +1229,7 @@ module ieee802-dot1q-cfm {
             }
             leaf ltr-ingress-port-id-subtype {
               when "../ltr-ingress";
-              type lldp-types:port-id-subtype-type;
+              type ieee:port-id-subtype-type;
               description
                 "Format of the ingress Port ID. This leaf is not 
                 present if the ltr-ingress leaf is not present, or if
@@ -1242,7 +1240,7 @@ module ieee802-dot1q-cfm {
             leaf ltr-ingress-port-id {
               when '../ltr-ingress and '+
                    '../ltr-ingress-port-id-subtype';
-              type lldp-types:port-id-type;
+              type ieee:port-id-type;
               mandatory true;
               description
                 "Ingress Port ID. The format of this object is 
@@ -1275,7 +1273,7 @@ module ieee802-dot1q-cfm {
             }           
             leaf ltr-egress-port-id-subtype {
               when '../ltr-egress';
-              type lldp-types:port-id-subtype-type;
+              type ieee:port-id-subtype-type;
               description
                 "Format of the egress Port ID. This leaf is not 
                 present if the ltr-egress leaf is not present, or if
@@ -1286,7 +1284,7 @@ module ieee802-dot1q-cfm {
             leaf ltr-egress-port-id {
               when '../ltr-egress and '+
                    '../ltr-egress-port-id-subtype';
-              type lldp-types:port-id-type;
+              type ieee:port-id-type;
               mandatory true;
               description
                 "Egress Port ID. The format of this object is

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-tpmr.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-tpmr.yang
@@ -35,6 +35,13 @@ module ieee802-dot1q-tpmr {
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
+  revision 2018-03-07 {
+    description
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
   
   augment "/if:interfaces/if:interface/dot1q:bridge-port" {
     when "dot1q:port-type = 'dot1q:d-bridge-port'" {

--- a/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-tpmr.yang
+++ b/standard/ieee/draft/802.1/Qcx/ieee802-dot1q-tpmr.yang
@@ -20,7 +20,6 @@ module ieee802-dot1q-tpmr {
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
             445 Hoes Lane
-            P.O. Box 1331
             Piscataway
             NJ 08854
             USA

--- a/standard/ieee/draft/802/ieee802-types.yang
+++ b/standard/ieee/draft/802/ieee802-types.yang
@@ -11,7 +11,6 @@ module ieee802-types {
     Postal: C/O IEEE 802.1 Working Group
             IEEE Standards Association
             445 Hoes Lane
-            P.O. Box 1331
             Piscataway
             NJ 08854
             USA
@@ -39,5 +38,229 @@ module ieee802-types {
     reference
       "3.1 of IEEE Std 802-2014
       8.1 of IEEE Std 802-2014";
+  }
+  
+  typedef chassis-id-subtype-type {
+    type enumeration {
+      enum chassis-component {
+        value 1;
+        description
+          "Represents a chassis identifier based on the value of
+          entPhysicalAlias object (defined in IETF RFC 2737) for a
+          chassis component (i.e., an entPhysicalClass value of
+          chassis(3))";
+      }
+      enum interface-alias {
+        value 2;
+        description
+          "Represents a chassis identifier based on the value of
+          ifAlias object (defined in IETF RFC 2863) for an interface
+          on the containing chassis.";
+      }
+      enum port-component {
+        value 3;
+        description
+          "Represents a chassis identifier based on the value of
+          entPhysicalAlias object (defined in IETF RFC 2737) for a
+          port or backplane component (i.e., entPhysicalClass value of
+          port(10) or backplane(4)), within the containing chassis.";
+      }
+      enum mac-address {
+        value 4;
+        description
+          "Represents a chassis identifier based on the value of a
+          unicast source address (encoded in network byte order and
+          IEEE 802.3 canonical bit order), of a port on the containing
+          chassis as defined in IEEE Std 802-2001.";
+      }
+      enum network-address {
+        value 5;
+        description
+          "Represents a chassis identifier based on a network address,
+          associated with a particular chassis.  The encoded address is
+          actually composed of two fields.  The first field is a
+          single octet, representing the IANA AddressFamilyNumbers
+          value for the specific address type, and the second field is
+          the network address value.";
+      }
+      enum interface-name {
+        value 6;
+        description
+          "Represents a chassis identifier based on the value of
+          ifName object (defined in IETF RFC 2863) for an interface
+          on the containing chassis.";
+      }
+      enum local {
+        value 7;
+        description
+          "Represents a chassis identifier based on a locally defined
+          value.";
+      }
+    }
+    description
+      "The source of a chassis identifier.";
+    reference
+      "LLDP MIB 20050506";
+  }
+  
+  typedef chassis-id-type {
+    type string {
+      length "1..255";
+    }
+    description
+      "The format of a chassis identifier string. Objects of this type
+      are always used with an associated lldp-chassis-is-subtype
+      object, which identifies the format of the particular
+      lldp-chassis-id object instance.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      chassis-component, then the octet string identifies
+      a particular instance of the entPhysicalAlias object
+      (defined in IETF RFC 2737) for a chassis component (i.e.,
+      an entPhysicalClass value of chassis(3)).
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of interface-alias, then the octet string identifies
+      a particular instance of the ifAlias object (defined in
+      IETF RFC 2863) for an interface on the containing chassis.
+      If the particular ifAlias object does not contain any values,
+      another chassis identifier type should be used.
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of port-component, then the octet string identifies a
+      particular instance of the entPhysicalAlias object (defined
+      in IETF RFC 2737) for a port or backplane component within
+      the containing chassis.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      mac-address, then this string identifies a particular
+      unicast source address (encoded in network byte order and
+      IEEE 802.3 canonical bit order), of a port on the containing
+      chassis as defined in IEEE Std 802-2001.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      network-address, then this string identifies a particular
+      network address, encoded in network byte order, associated
+      with one or more ports on the containing chassis.  The first
+      octet contains the IANA Address Family Numbers enumeration
+      value for the specific address type, and octets 2 through
+      N contain the network address value in network byte order.
+
+      If the associated lldp-chassis-id-subtype object has a value
+      of interface-name, then the octet string identifies
+      a particular instance of the ifName object (defined in
+      IETF RFC 2863) for an interface on the containing chassis.
+      If the particular ifName object does not contain any values,
+      another chassis identifier type should be used.
+
+      If the associated lldp-chassis-id-subtype object has a value of
+      local, then this string identifies a locally assigned
+      Chassis ID.";
+    reference
+      "LLDP MIB 20050506";
+  }
+  
+  typedef port-id-subtype-type {
+    type enumeration {
+      enum interface-alias {
+        value 1;
+        description
+          "Represents a port identifier based on the ifAlias
+          MIB object, defined in IETF RFC 2863.";
+      }
+      enum port-component {
+        value 2;
+        description
+          "Represents a port identifier based on the value of
+          entPhysicalAlias (defined in IETF RFC 2737) for a port
+          component (i.e., entPhysicalClass value of port(10)), 
+          within the containing chassis.";
+      }
+      enum mac-address {
+        value 3;
+        description
+          "Represents a port identifier based on a unicast source
+          address (encoded in network byte order and IEEE 802.3
+          canonical bit order), which has been detected by the agent
+          and associated with a particular port (IEEE Std 802-2001).";
+      }
+      enum network-address {
+        value 4;
+        description
+          "Represents a port identifier based on a network address,
+          detected by the agent and associated with a particular 
+          port.";
+      }
+      enum interface-name {
+        value 5;
+        description
+          "Represents a port identifier based on the ifName MIB object,
+          defined in IETF RFC 2863.";
+      }
+      enum agent-circuit-id {
+        value 6;
+        description
+          "Represents a port identifier based on the agent-local
+          identifier of the circuit (defined in RFC 3046), detected by
+          the agent and associated with a particular port.";
+      }
+      enum local {
+        value 7;
+        description
+          "Represents a port identifier based on a value locally
+          assigned.";
+      }
+    }
+    description
+      "The source of a particular type of port identifier used
+      in the LLDP YANG module.";
+  }
+  
+  typedef port-id-type {
+    type string {
+      length "8";
+    }
+    description
+      "The format of a port identifier string. Objects of this type
+      are always used with an associated lldp-port-id-subtype object,
+      which identifies the format of the particular lldp-port-id
+      object instance.
+
+      If the associated lldp-port-id-subtype object has a value of
+      interface-alias, then the octet string identifies a
+      particular instance of the ifAlias object (defined in IETF
+      RFC 2863).  If the particular ifAlias object does not contain
+      any values, another port identifier type should be used.
+
+      If the associated lldp-port-id-subtype object has a value of
+      port-component, then the octet string identifies a
+      particular instance of the entPhysicalAlias object (defined
+      in IETF RFC 2737) for a port or backplane component.
+
+      If the associated lldp-port-id-subtype object has a value of
+      mac-address, then this string identifies a particular
+      unicast source address (encoded in network byte order
+      and IEEE 802.3 canonical bit order) associated with the port
+      (IEEE Std 802-2001).
+
+      If the associated lldp-port-id-subtype object has a value of
+      network-address, then this string identifies a network
+      address associated with the port.  The first octet contains
+      the IANA AddressFamilyNumbers enumeration value for the
+      specific address type, and octets 2 through N contain the
+      networkAddress address value in network byte order.
+
+      If the associated lldp-port-id-subtype object has a value of
+      interface-name, then the octet string identifies a
+      particular instance of the ifName object (defined in IETF
+      RFC 2863).  If the particular ifName object does not contain
+      any values, another port identifier type should be used.
+
+      If the associated lldp-port-id-subtype object has a value of
+      agent-circuit-id, then this string identifies a agent-local
+      identifier of the circuit (defined in RFC 3046).
+
+      If the associated lldp-port-id-subtype object has a value of
+      local, then this string identifies a locally assigned port ID.";
   }
 }


### PR DESCRIPTION
Clean PYANG compile

mholness@ONW-MHOLNESS-02 MINGW32 /c/GitHub/yang/standard/ieee/draft/802.1/Qcx (master)
$ pyang --ietf  ../../802/ieee802-types.yang
../../802/ieee802-types.yang:1: warning: RFC 8407: 4.1: the module name should start with one of the strings "ietf-" or "iana-"
../../802/ieee802-types.yang:2: warning: RFC 8407: 4.9: namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-types"
../../802/ieee802-types.yang:21: warning: RFC 8407: 3.1: The IETF Trust Copyright statement seems to be missing (see pyang --ietf-help for details).

mholness@ONW-MHOLNESS-02 MINGW32 /c/GitHub/yang/standard/ieee/draft/802.1/Qcx (master)
$ pyang --ietf  ../../802/ieee802-types.yang
pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-cfm.yang
pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-cfm-bridge.yang
pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-cfm-alarm.yang
pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-tpmr.yang

../../802/ieee802-types.yang:1: warning: RFC 8407: 4.1: the module name should start with one of the strings "ietf-" or "iana-"
../../802/ieee802-types.yang:2: warning: RFC 8407: 4.9: namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-types"
../../802/ieee802-types.yang:21: warning: RFC 8407: 3.1: The IETF Trust Copyright statement seems to be missing (see pyang --ietf-help for details).

mholness@ONW-MHOLNESS-02 MINGW32 /c/GitHub/yang/standard/ieee/draft/802.1/Qcx (master)
$ pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-cfm-types.yang
ieee802-dot1q-cfm-types.yang:1: warning: RFC 8407: 4.1: the module name should start with one of the strings "ietf-" or "iana-"
ieee802-dot1q-cfm-types.yang:4: warning: RFC 8407: 4.9: namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-cfm-types"
ieee802-dot1q-cfm-types.yang:25: warning: RFC 8407: 3.1: The IETF Trust Copyright statement seems to be missing (see pyang --ietf-help for details).

mholness@ONW-MHOLNESS-02 MINGW32 /c/GitHub/yang/standard/ieee/draft/802.1/Qcx (master)
$ pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-cfm.yang
ieee802-dot1q-cfm.yang:1: warning: RFC 8407: 4.1: the module name should start with one of the strings "ietf-" or "iana-"
ieee802-dot1q-cfm.yang:4: warning: RFC 8407: 4.9: namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-cfm"
ieee802-dot1q-cfm.yang:36: warning: RFC 8407: 3.1: The IETF Trust Copyright statement seems to be missing (see pyang --ietf-help for details).
ieee802-dot1q-cfm.yang:240: warning: the module seems to use RFC 2119 keywords, but the required text from RFC 8174 is not found (see pyang --ietf-help for details).

mholness@ONW-MHOLNESS-02 MINGW32 /c/GitHub/yang/standard/ieee/draft/802.1/Qcx (master)
$ pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-cfm-bridge.yang
ieee802-dot1q-cfm-bridge.yang:1: warning: RFC 8407: 4.1: the module name should start with one of the strings "ietf-" or "iana-"
ieee802-dot1q-cfm-bridge.yang:4: warning: RFC 8407: 4.9: namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-cfm-bridge"
ieee802-dot1q-cfm-bridge.yang:35: warning: RFC 8407: 3.1: The IETF Trust Copyright statement seems to be missing (see pyang --ietf-help for details).
ieee802-dot1q-cfm-bridge.yang:170: warning: the module seems to use RFC 2119 keywords, but the required text from RFC 8174 is not found (see pyang --ietf-help for details).

mholness@ONW-MHOLNESS-02 MINGW32 /c/GitHub/yang/standard/ieee/draft/802.1/Qcx (master)
$ pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-cfm-alarm.yang
ieee802-dot1q-cfm-alarm.yang:1: warning: RFC 8407: 4.1: the module name should start with one of the strings "ietf-" or "iana-"
ieee802-dot1q-cfm-alarm.yang:4: warning: RFC 8407: 4.9: namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-cfm-alarm"
ieee802-dot1q-cfm-alarm.yang:32: warning: RFC 8407: 3.1: The IETF Trust Copyright statement seems to be missing (see pyang --ietf-help for details).
ieee802-dot1q-cfm-alarm.yang:62: warning: explicit config statement is ignored

mholness@ONW-MHOLNESS-02 MINGW32 /c/GitHub/yang/standard/ieee/draft/802.1/Qcx (master)
$ pyang --ietf -p ../../802/ -p ../../../published/802.1/ ieee802-dot1q-tpmr.yang
ieee802-dot1q-tpmr.yang:1: warning: RFC 8407: 4.1: the module name should start with one of the strings "ietf-" or "iana-"
ieee802-dot1q-tpmr.yang:2: warning: RFC 8407: 4.9: namespace value should be "urn:ietf:params:xml:ns:yang:ieee802-dot1q-tpmr"
ieee802-dot1q-tpmr.yang:30: warning: RFC 8407: 3.1: The IETF Trust Copyright statement seems to be missing (see pyang --ietf-help for details).
