### PR TITLE
Update Cisco-IOS-XR-ipv4-bgp-oper.yang

### DIFF
--- a/vendor/cisco/xr/711/Cisco-IOS-XR-ipv4-bgp-oper.yang
+++ b/vendor/cisco/xr/711/Cisco-IOS-XR-ipv4-bgp-oper.yang
@@ -1595,7 +1595,7 @@ module Cisco-IOS-XR-ipv4-bgp-oper {
             "Active BGP operational data";
           container segment-routing {
             description
-              "Segment Rotuing related Operational Data";
+              "Segment Routing related Operational Data";
             container srv6 {
               description
                 "SRv6 related Operational Data";


### PR DESCRIPTION
This typo appears to be in almost every version, not sure what the best way is to resolve it...