### PR TITLE
Comment resolution changes for draft 1.2 of P802.1Qcz

### DIFF
--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
@@ -160,8 +160,8 @@ typedef abs-traffic-class-plus-one-type {
         type inet:ipv4-address;
         config false;
         description
-          "The souce IPv4 address of a CIM, belonging to the system
-          transmitting the IPv4 Layer-3 CIM.";
+          "The source IPv4 address of a CIM, belonging to the system
+          transmitting the IPv4 layer-3 CIM.";
         reference
           "98.4.1.2.2 of IEEE Std 802.1Qcz-202X";
       }
@@ -169,10 +169,19 @@ typedef abs-traffic-class-plus-one-type {
         type inet:ipv6-address;
         config false;
         description
-          "The souce IPv6 address of a CIM, belonging to the system
-          transmitting the IPv6 Layer-3 CIM.";
+          "The source IPv6 address of a CIM, belonging to the system
+          transmitting the IPv6 layer-3 CIM.";
         reference
           "98.4.1.2.3 of IEEE Std 802.1Qcz-202X";
+      }
+      leaf cip-cim-port {
+        type inet:port-number;
+        config false;
+        description
+          "The UDP port number to be used by a peer transmitting a layer-3 
+           CIM.  This value will be sent to the peer via LLDP in the CI TLV";
+        reference
+          "98.4.1.2.4 of IEEE Std 802.1Qcz-202X";
       }
       list queue-map {
         key "priority";
@@ -309,6 +318,14 @@ typedef abs-traffic-class-plus-one-type {
           description
             "The destination IPv6 address to use when generating an IPv6
             layer-3 CIM for the peer.";
+          reference
+            "98.3.6 of IEEE Std 802.1Qcz-202X";
+        }
+        leaf peer-udp-port {
+          type inet:port-number;
+          description
+            "The UDP port number to use when generating a layer-3 CIM for the 
+             peer.";
           reference
             "98.3.6 of IEEE Std 802.1Qcz-202X";
         }

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
@@ -8,6 +8,9 @@ module ieee802-dot1q-congestion-isolation {
   import ietf-yang-types {
     prefix yang;
   }
+  import ieee802-types {
+    prefix ieee;
+  }
   import ieee802-dot1q-stream-filters-gates {
     prefix sfsg;
   }
@@ -132,8 +135,8 @@ typedef abs-traffic-class-plus-one-type {
     if-feature "congestion-isolation";
     description
       "Dot1q Congestion Isolation";
-    container none {
-      leaf none {
+    container congestion-isolation {
+      leaf null-handle {
         type empty;
         description
           "The stream_handle specification represents the value when no
@@ -145,7 +148,7 @@ typedef abs-traffic-class-plus-one-type {
     if-feature "congestion-isolation";
     container cip-port-parameters {
       leaf cip-mac-address {
-        type yang:mac-address;
+        type ieee:mac-address;
         config false;
         description
           "The source MAC address of a CIM, belonging to the system
@@ -238,7 +241,7 @@ typedef abs-traffic-class-plus-one-type {
         "98.4.1.1.1 of IEEE Std 802.1Qcz-202X";
     }
     leaf ci-cim-tx-priority {
-      type uint32;
+      type dot1q-types:priority-type;
       config false;
       description
         "Specifies the priority value to be used when transmitting CIMs from
@@ -286,7 +289,7 @@ typedef abs-traffic-class-plus-one-type {
             "98.3.6 of IEEE Std 802.1Qcz-202X";
         }
         leaf peer-mac-address {
-          type yang:mac-address;
+          type ieee:mac-address;
           description
             "The destination MAC address to use when generating a CIM for
             the peer.";
@@ -310,7 +313,9 @@ typedef abs-traffic-class-plus-one-type {
             "98.3.6 of IEEE Std 802.1Qcz-202X";
         }
         leaf peer-cim-encap-len {
-          type uint16;
+          type uint16 {
+            range "0..512";
+          }
           description
             "The number of octets from the MSDU to include in the
             Encapsulated MSDU field of the CIM PDU";
@@ -320,6 +325,7 @@ typedef abs-traffic-class-plus-one-type {
       }
       leaf max-ci-peer-entries {
         type uint32;
+        config false;
         description
           "Specifies the maximum number of CI peer entries that can be
           stored";
@@ -330,6 +336,7 @@ typedef abs-traffic-class-plus-one-type {
     container ci-streams {
       list ci-stream-table {
         key "stream-handle-id";
+        config false;
         description
           "Contains entries for each congesting flow and has a 1:1 mapping
           to entries in the IEEE Std 802.1CB Stream Identity table.";
@@ -337,6 +344,7 @@ typedef abs-traffic-class-plus-one-type {
           "98.3.7 of IEEE Std 802.1Qcz-202X";
         leaf stream-handle-id {
           type uint32;
+          config false;
           description
             "There is a unique stream handle ID for each congesting flow
             stored in the CI stream table";
@@ -345,6 +353,7 @@ typedef abs-traffic-class-plus-one-type {
         }
         leaf cim-count {
           type uint16;
+          config false;
           description
             "Contains a count of the number of CIMs sent for a congesting
             flow";
@@ -375,6 +384,7 @@ typedef abs-traffic-class-plus-one-type {
                 CIM.";
             }
           }
+          config false;
           description
             "Indicates the reason for creating or updating the CI stream
             table entry. The LSB indicates that the entry was created or
@@ -397,7 +407,7 @@ typedef abs-traffic-class-plus-one-type {
           "98.4.1.5.5 of IEEE Std 802.1Qcz-202X";
       }
       leaf dest-mac-address {
-        type yang:mac-address;
+        type ieee:mac-address;
         config false;
         description
           "The destination MAC addresss of a congesting flow.";
@@ -405,7 +415,7 @@ typedef abs-traffic-class-plus-one-type {
           "98.4.1.5.6 of IEEE Std 802.1Qcz-202X";
       }
       leaf source-mac-address {
-        type yang:mac-address;
+        type ieee:mac-address;
         config false;
         description
           "The source MAC addresss of a congesting flow.";
@@ -433,6 +443,7 @@ typedef abs-traffic-class-plus-one-type {
     }
     leaf max-ci-stream-entries {
       type uint32;
+      config false;
       description
         "Specifies the maximum number of CI stream entries that can be
         stored";

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-basic-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-basic-tlv.yang
@@ -66,7 +66,8 @@ module ieee802-dot1q-lldp-basic-tlv {
         }
       }
       description
-        "Port and Protocol VLAN capability and status";
+        "Port and Protocol VLAN capability and status. Bit positions 0 and 3-7 
+         are reserved for future standardization";
       reference
         "IEEE Std 802.1Q-2018 Annex D.2.2.1";
     }
@@ -164,7 +165,8 @@ module ieee802-dot1q-lldp-basic-tlv {
         }
       }
       description
-        "Link Aggregation capability and status";
+        "Link Aggregation capability and status.  Bit positions 4-7 are 
+         reserved for future standardization";
       reference
         "IEEE Std 802.1AX-2014 Annex F.1.1";
     }

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-basic-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-basic-tlv.yang
@@ -54,11 +54,6 @@ module ieee802-dot1q-lldp-basic-tlv {
     }
     leaf flags {
       type bits {
-        bit reserved0 {
-          position 0;
-          description
-            "Reserved for future standardization";
-        }
         bit port-and-protocol-vlan-supported {
           position 1;
           description
@@ -68,31 +63,6 @@ module ieee802-dot1q-lldp-basic-tlv {
           position 2;
           description
             "1 = enabled, 0 = not enabled";
-        }
-        bit reserved3 {
-          position 3;
-          description
-            "Reserved for future standardization";
-        }
-        bit reserved4 {
-          position 4;
-          description
-            "Reserved for future standardization";
-        }
-        bit reserved5 {
-          position 5;
-          description
-            "Reserved for future standardization";
-        }
-        bit reserved6 {
-          position 6;
-          description
-            "Reserved for future standardization";
-        }
-        bit reserved7 {
-          position 7;
-          description
-            "Reserved for future standardization";
         }
       }
       description
@@ -145,6 +115,7 @@ module ieee802-dot1q-lldp-basic-tlv {
       "IEEE Std 802.1Q-2018 Annex D.2.5";
     leaf vid-usage-digest {
       type uint32;
+      config false;
       description
         "Advertise VID Usage Digest";
       reference
@@ -157,7 +128,7 @@ module ieee802-dot1q-lldp-basic-tlv {
     reference
       "IEEE Std 802.1Q-2018 Annex D.2.6";
     leaf management-vid {
-      type uint32;
+      type dot1qtypes:vlanid;
       description
         "Advertise Management VID";
       reference
@@ -190,26 +161,6 @@ module ieee802-dot1q-lldp-basic-tlv {
           position 3;
           description
             "Most Significant Bit of 2 bit port type value";
-        }
-        bit reserved4 {
-          position 4;
-          description
-            "Reserved for future standardization";
-        }
-        bit reserved5 {
-          position 5;
-          description
-            "Reserved for future standardization";
-        }
-        bit reserved6 {
-          position 6;
-          description
-            "Reserved for future standardization";
-        }
-        bit reserved7 {
-          position 7;
-          description
-            "Reserved for future standardization";
         }
       }
       description

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-ci-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-ci-tlv.yang
@@ -8,14 +8,8 @@ module ieee802-dot1q-lldp-ci-tlv {
   import ieee802-dot1q-congestion-isolation {
     prefix dot1q-ci;
   }
-  import iana-routing-types {
-    prefix rt;
-  }
   import ietf-inet-types {
     prefix inet;
-  }
-  import ietf-yang-types {
-    prefix yang;
   }
   import ieee802-types { 
     prefix "ieee"; 
@@ -107,6 +101,15 @@ module ieee802-dot1q-lldp-ci-tlv {
       reference
         "D.2.15.5 of IEEE Std 802.1Qcz-202X";
     }
+    leaf udp-port-number {
+      type inet:port-number;
+      config false;
+      description
+        "The UDP port number to be used as the destination port number of a 
+         layer-3 CIM sent by the peer to reach this station.";
+      reference
+        "D.2.15.6 of IEEE Std 802.1Qcz-202X";
+    }
     leaf ip-address {
       type inet:ip-address;
       config false;
@@ -122,7 +125,7 @@ module ieee802-dot1q-lldp-ci-tlv {
          IP address field is 16 octets representing the IPv6 address.  No 
          address shall be provided for any other address families.";
       reference
-        "D.2.15.6 and D.2.15.7 of IEEE Std 802.1Qcz-202X";
+        "D.2.15.7 and D.2.15.8 of IEEE Std 802.1Qcz-202X";
     }  
   }
 

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-ci-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-ci-tlv.yang
@@ -8,12 +8,17 @@ module ieee802-dot1q-lldp-ci-tlv {
   import ieee802-dot1q-congestion-isolation {
     prefix dot1q-ci;
   }
-
   import iana-routing-types {
     prefix rt;
   }
+  import ietf-inet-types {
+    prefix inet;
+  }
   import ietf-yang-types {
     prefix yang;
+  }
+  import ieee802-types { 
+    prefix "ieee"; 
   }
   import ieee802-dot1q-types { 
     prefix "dot1q-types"; 
@@ -72,7 +77,7 @@ module ieee802-dot1q-lldp-ci-tlv {
         reference
           "D.2.15.3 of IEEE Std 802.1Qcz-202X";
       }
-      leaf abs-traffic-class-plus-one {
+      leaf queue-config {
         type dot1q-ci:abs-traffic-class-plus-one-type;
         description
           "A value that can be translated to represent a traffic class or
@@ -94,7 +99,7 @@ module ieee802-dot1q-lldp-ci-tlv {
         "D.3.15.4 of IEEE Std 802.1Qcz-202X";
     }
     leaf mac-address {
-      type yang:mac-address;
+      type ieee:mac-address;
       config false;
       description
         "The MAC address to be used as the destination MAC address of a CIM
@@ -102,29 +107,22 @@ module ieee802-dot1q-lldp-ci-tlv {
       reference
         "D.2.15.5 of IEEE Std 802.1Qcz-202X";
     }
-    leaf address-family-subtype {
-      type rt:address-family;
-      config false;
-      description
-        "The management address subtype field shall contain an
-         integer value indicating the type of address.";
-      reference
-        "D.2.15.6 of IEEE Std 802.1Qcz-202X";
-    }
     leaf ip-address {
-      type binary {
-        length "0..16";
-      }
+      type inet:ip-address;
       config false;
       description
-        "An octet string with length of 0, 4 or 16 octets dependent upon the 
-         address-family-subtype specified. If the address-family-subtype is 1, 
-         the address shall be an IPv4 address as specified in IETF RFC 791.  If 
-         the address-family-subtype is 2, the address shall be an IPv6 address 
-         as specified in IETF RFC 8200. No address shall be provided for any 
-         other Address Families specified by address-family-subtype.";
+        "This leaf holds the IP address that will be used to populate both
+         the address family and IP address fields of the TLV.  The IP address
+         field in the TLV is an octect string to be encoded in network octet 
+         order with length of 0, 4 or 16 octets dependent upon the address 
+         family. If this leaf is an IPv4 address, the address family field is 
+         1 and the IP address field is 4 octets representing the IPv4 address
+         (e.g IPv4 address 192.0.2.10 would be encoded as C0-00-02-0A).  If 
+         this leaf is an IPv6 address, the address family field is 2 and the 
+         IP address field is 16 octets representing the IPv6 address.  No 
+         address shall be provided for any other address families.";
       reference
-        "D.2.15.7 of IEEE Std 802.1Qcz-202X";
+        "D.2.15.6 and D.2.15.7 of IEEE Std 802.1Qcz-202X";
     }  
   }
 

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
@@ -33,19 +33,100 @@ module ieee802-dot1q-lldp-dcbx-tlv {
       "IEEE Std 802.1Q-2018 Annex D";
   }
 
+  identity application-priority-selector {
+    description 
+      "Specify the application priority selection of IEEE Std 802.1Q-2018
+       Clause D.11.2.3, Table D-8";
+  }
+  identity default {
+    base application-priority-selector;
+    description
+      "Indicates the default application selection of the Application Priority 
+       Table field of the Application Priority TLV specified in IEEE Std 
+       802.1Q-2018 Clause D.2.11. Signalled as value 1.";
+  }
+  identity pri-tcp-sctp {
+    base application-priority-selector;
+    description
+      "Indicates TCP or SCTP application selection of the Application Priority 
+       Table field of the Application Priority TLV specified in IEEE Std 
+       802.1Q-2018 Clause D.2.11. Signalled as value 2.";
+  }
+  identity pri-udp-dccp {
+    base application-priority-selector;
+    description
+      "Indicates UDP or DCCP application selection of the Application Priority 
+       Table field of the Application Priority TLV specified in IEEE Std 
+       802.1Q-2018 Clause D.2.11. Signalled as value 3.";
+  }
+  identity pri-tcp-sctp-udp-dccp {
+    base application-priority-selector;
+    description
+      "Indicates TCP, SCTP, UDP or DCCP application selection of the Application
+       Priority Table field of the Application Priority TLV specified in IEEE 
+       Std 802.1Q-2018 Clause D.2.11. Signalled as value 4.";
+  }
+  identity pri-dscp {
+    base application-priority-selector;
+    description
+      "Indicates DSCP application selection of the Application Priority 
+       Table field of the Application Priority TLV specified in IEEE Std 
+       802.1Q-2018 Clause D.2.11. Signalled as value 5.";
+  }
+
+  identity application-vlan-selector {
+    description
+      "Specify the application vlan selection of IEEE Std 802.1Q-2018
+       Clause D.11.14.3, Table D-12";
+  }
+  identity vlan-pvid-ethertype {
+    base application-vlan-selector;
+    description
+      "Indicates the a PVID or and Ethertype selection of the Application VLAN 
+       Table field of the Application VLAn TLV specified in IEEE Std 802.1Q-2018       Clause D.2.14. Signalled as value 1.";
+  }
+  identity vlan-tcp-sctp {
+    base application-vlan-selector;
+    description
+      "Indicates TCP or SCTP application selection of the Application VLAN 
+       Table field of the Application VLAN TLV specified in IEEE Std 802.1Q-2018
+       Clause D.2.14. Signalled as value 2.";
+  }
+  identity vlan-udp-dccp {
+    base application-vlan-selector;
+    description
+      "Indicates UDP or DCCP application selection of the Application VLAN 
+       Table field of the Application VLAN TLV specified in IEEE Std 802.1Q-2018
+       Clause D.2.14. Signalled as value 3.";
+  }
+  identity vlan-tcp-sctp-udp-dccp {
+    base application-vlan-selector;
+    description
+      "Indicates TCP, SCTP, UDP or DCCP application selection of the Application
+       VLAN Table field of the Application VLAN TLV specified in IEEE Std 
+       802.1Q-2018 Clause D.2.14. Signalled as value 4.";
+  }
+  identity vlan-dscp {
+    base application-vlan-selector;
+    description
+      "Indicates DSCP application selection of the Application VLAN Table field
+       of the Application VLAN TLV specified in IEEE Std 802.1Q-2018 Clause 
+       D.2.14. Signalled as value 5.";
+  }
+
   grouping ets-configuration-tlv {
     description
       "The Enhanced Transmission Selection configuration TLV";
     reference
       "IEEE Std 802.1Q-2018 Annex D.2.8";
-    leaf ets-config-willing {
+    leaf willing {
       type boolean;
       description
         "True indicates willing to accept configurations from remote station";
       reference
         "IEEE Std 802.1Q-2018 Annex D.2.8.3";
     }
-    leaf ets-config-credit-based-shaper {
+    leaf credit-based-shaper {
       type boolean;
       description
         "True indicates station supports the Credit-based Shaper transmission
@@ -53,42 +134,50 @@ module ieee802-dot1q-lldp-dcbx-tlv {
       reference
         "IEEE Std 802.1Q-2018 Annex D.2.8.4";
     }
-    leaf ets-config-traffic-classes-supported {
-      type uint8 {
-        range "1..8";
-      }
+    leaf traffic-classes-supported {
+      type dot1q-types:num-traffic-class-type;
       description
-        "Indicates number of traffic classes supported";
+        "Indicates number of traffic classes supported.  The value of 8 is
+         encoded as 0 in the TLV since 3-bits are used to specify the number";
       reference
         "IEEE Std 802.1Q-2018 Annex D.2.8.5";
     }
-    list ets-config-priority-assignment-table {
-      key "ets-priority";
-      leaf ets-priority {
+    list priority-assignment-table {
+      key "priority";
+      leaf priority {
         type dot1q-types:priority-type;
         description
           "Indicates priority";
         reference
           "IEEE Std 802.1Q-2018 Annex D.2.8.6";
       }
-      leaf ets-priority-traffic-class {
+      leaf priority-traffic-class {
         type dot1q-types:traffic-class-type;
         description
           "Indicates mapped traffic class for priority";
         reference
           "IEEE Std 802.1Q-2018 Annex D.2.8.6";
       }
+      leaf transmission-selection-algorithm {
+        type identityref {
+          base dot1q-types:transmission-selection-algorithm;
+        }
+        description
+          "Transmission selection algorithm";
+        reference
+          "IEEE Std 802.1Q-2018 Clause 8.6.8, Table 8-6";
+      }
     }
-    list ets-config-tc-bandwidth-table {
-      key "ets-traffic-class";
-      leaf ets-traffic-class {
+    list tc-bandwidth-table {
+      key "traffic-class";
+      leaf traffic-class {
         type dot1q-types:traffic-class-type;
         description
           "Indicates traffic class";
         reference
           "IEEE Std 802.1Q-2018 Annex D.2.8.7";
       }
-      leaf ets-percentage-bandwidth {
+      leaf percentage-bandwidth {
         type uint8 {
           range "0..100";
         }
@@ -98,17 +187,19 @@ module ieee802-dot1q-lldp-dcbx-tlv {
           "IEEE Std 802.1Q-2018 Annex D.2.8.7";
       }
     }
-    list ets-config-tsa-assignment-table {
-      key "ets-tsa-traffic-class";
-      leaf ets-tsa-traffic-class {
+    list tsa-assignment-table {
+      key "tsa-traffic-class";
+      leaf tsa-traffic-class {
         type dot1q-types:traffic-class-type;
         description
           "Indicates traffic class";
         reference
           "IEEE Std 802.1Q-2018 Annex D.2.8.8";
       }
-      leaf ets-transmission-selection-algorithm {
-        type uint8;
+      leaf transmission-selection-algorithm {
+        type identityref {
+          base dot1q-types:transmission-selection-algorithm;
+        }
         description
           "Transmission selection algorithm";
         reference
@@ -122,16 +213,16 @@ module ieee802-dot1q-lldp-dcbx-tlv {
       "Recommendation of Enhanced Transmission Selection configuration TLV";
     reference
       "IEEE Std 802.1Q-2018 Annex D.2.9";
-    list ets-recommendation-priority-assignment-table {
-      key "ets-priority";
-      leaf ets-priority {
+    list priority-assignment-table {
+      key "priority";
+      leaf priority {
         type dot1q-types:priority-type;
         description
           "Indicates priority";
         reference
           "IEEE Std 802.1Q-2018 Annex D.2.9.3";
       }
-      leaf ets-priority-traffic-class {
+      leaf priority-traffic-class {
         type dot1q-types:traffic-class-type;
         description
           "Indicates mapped traffic class for priority";
@@ -139,16 +230,16 @@ module ieee802-dot1q-lldp-dcbx-tlv {
           "IEEE Std 802.1Q-2018 Annex D.2.9.3";
       }
     }
-    list ets-recommendation-tc-bandwidth-table {
-      key "ets-traffic-class";
-      leaf ets-traffic-class {
+    list tc-bandwidth-table {
+      key "traffic-class";
+      leaf traffic-class {
         type dot1q-types:traffic-class-type;
         description
           "Indicates traffic class";
         reference
           "IEEE Std 802.1Q-2018 Annex D.2.9.4";
       }
-      leaf ets-percentage-bandwidth {
+      leaf percentage-bandwidth {
         type uint8 {
           range "0..100";
         }
@@ -158,32 +249,19 @@ module ieee802-dot1q-lldp-dcbx-tlv {
           "IEEE Std 802.1Q-2018 Annex D.2.9.4";
       }
     }
-    list ets-recommendation-tsa-assignment-table {
-      key "ets-tsa-traffic-class";
-      leaf ets-tsa-traffic-class {
+
+    list tsa-assignment-table {
+      key "tsa-traffic-class";
+      leaf tsa-traffic-class {
         type dot1q-types:traffic-class-type;
         description
           "Indicates traffic class";
         reference
           "IEEE Std 802.1Q-2018 Annex D.2.9.5";
       }
-      leaf ets-transmission-selection-algorithm {
-        type enumeration {
-          enum strict-priority {
-            value 0;
-          }
-          enum credit-based-shaper {
-            value 1;
-          }
-          enum enhanced-transmission-sel {
-            value 2;
-          }
-          enum asynch-traffic-shaping {
-            value 3;
-          }
-          enum vendor-specific {
-            value 255;
-          }
+      leaf transmission-selection-algorithm {
+        type identityref {
+          base dot1q-types:transmission-selection-algorithm;
         }
         description
           "Transmission selection algorithm";
@@ -198,67 +276,65 @@ module ieee802-dot1q-lldp-dcbx-tlv {
       "The Priority-based flow control configuration TLV";
     reference
       "IEEE Std 802.1Q-2018 Annex D.2.10";
-    leaf pfc-willing {
+    leaf willing {
       type boolean;
       description
         "True indicates willing to accept configurations from remote station";
       reference
         "IEEE Std 802.1Q-2018 Annex D.2.10.3";
     }
-    leaf pfc-macsec-bypass-capable {
+    leaf macsec-bypass-capable {
       type boolean;
       description
         "True indicates sending station is not capable of bypassing MACsec";
       reference
         "IEEE Std 802.1Q-2018 Annex D.2.10.4";
     }
-    leaf pfc-number-tc-capable {
-      type uint8 {
-        range "1..8";
-      }
+    leaf number-tc-capable {
+      type dot1q-types:num-traffic-class-type;
       description
-        "Indicates how many traffic classes may simultaneously support PFC";
+        "Indicates how many traffic classes may simultaneously support PFC.";
       reference
         "IEEE Std 802.1Q-2018 Annex D.2.10.5";
     }
-    leaf pfc-enable {
+    leaf enable {
       type bits {
-        bit priority0 {
+        bit p0 {
           position 0;
           description
             "1 indicates PFC is enabled on the priority";
         }
-        bit priority1 {
+        bit p1 {
           position 1;
           description
             "1 indicates PFC is enabled on the priority";
         }
-        bit priority2 {
+        bit p2 {
           position 2;
           description
             "1 indicates PFC is enabled on the priority";
         }
-        bit priority3 {
+        bit p3 {
           position 3;
           description
             "1 indicates PFC is enabled on the priority";
         }
-        bit priority4 {
+        bit p4 {
           position 4;
           description
             "1 indicates PFC is enabled on the priority";
         }
-        bit priority5 {
+        bit p5 {
           position 5;
           description
             "1 indicates PFC is enabled on the priority";
         }
-        bit priority6 {
+        bit p6 {
           position 6;
           description
             "1 indicates PFC is enabled on the priority";
         }
-        bit priority7 {
+        bit p7 {
           position 7;
           description
             "1 indicates PFC is enabled on the priority";
@@ -276,25 +352,6 @@ module ieee802-dot1q-lldp-dcbx-tlv {
       "The application priority table TLV";
     reference
       "IEEE Std 802.1Q-2018 Annex D.2.11";
-    typedef application-priority-selector-type {
-      type enumeration {
-        enum default-sel {
-          value 1;
-        }
-        enum tcp-or-sctp-sel {
-          value 2;
-        }
-        enum udp-dccp-sel {
-          value 3;
-        }
-        enum tcp-sctp-udp-dccp-sel {
-          value 4;
-        }
-        enum dscp-sel {
-          value 5;
-        }
-      }
-    }
 
     list application-priority-table {
       key "application-priority";
@@ -306,7 +363,9 @@ module ieee802-dot1q-lldp-dcbx-tlv {
           "IEEE Std 802.1Q-2018 Annex D.2.11.3";
       }
       leaf application-priority-selector {
-        type application-priority-selector-type;
+        type identityref {
+          base application-priority-selector;
+        }
         description
           "Selector to determine what the Protocol ID means.";
         reference
@@ -329,26 +388,6 @@ module ieee802-dot1q-lldp-dcbx-tlv {
       "The Application VLAN table TLV";
     reference
       "IEEE Std 802.1Q-2018 Annex D.2.14";
-    typedef application-vlan-selector-type {
-      type enumeration {
-        enum pvid-or-ethertype-sel {
-          value 1;
-        }
-        enum tcp-or-sctp-sel {
-          value 2;
-        }
-        enum udp-dccp-sel {
-          value 3;
-        }
-        enum tcp-sctp-udp-dccp-sel {
-          value 4;
-        }
-        enum dscp-sel {
-          value 5;
-        }
-      }
-    }
-
     list application-vlan-table {
       key "application-vlan";
       leaf application-vlan {
@@ -359,7 +398,9 @@ module ieee802-dot1q-lldp-dcbx-tlv {
           "IEEE Std 802.1Q-2018 Annex D.2.14.3";
       }
       leaf application-vlan-selector {
-        type application-vlan-selector-type;
+        type identityref {
+          base application-vlan-selector;
+        }
         description
           "Selector to determine what the Protocol ID means.";
         reference

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-evb-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-evb-tlv.yang
@@ -30,7 +30,7 @@ module ieee802-dot1q-lldp-evb-tlv {
 
   grouping evb-tlv {
     description
-      "Edge Vitural Bridging (EVB) TLV";
+      "Edge Virtual Bridging (EVB) TLV";
     reference
       "IEEE Std 802.1Q-2018 Annex D.2.12";
 
@@ -38,6 +38,7 @@ module ieee802-dot1q-lldp-evb-tlv {
       type binary {
          length "0..9";
       }
+      config false;
       description
         "Opaque string containing EVB TLV information string. As the elements 
          within the string are not individually manipulated by management (they
@@ -57,6 +58,7 @@ module ieee802-dot1q-lldp-evb-tlv {
       type binary {
          length "0..511";
       }
+      config false;
       description
         "Opaque string containing CDCP TLV information. Up to 167 S-channel 
          numbers are supported. As the elements within the string are not 

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
@@ -1,0 +1,975 @@
+module ieee802-dot1q-types {
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-types;
+  prefix dot1q-types;
+  import ietf-yang-types {
+    prefix yang;
+  }
+  organization
+    "IEEE 802.1 Working Group";
+  contact
+    "WG-URL: http://www.ieee802.org/1/
+    WG-EMail: stds-802-1-L@ieee.org
+    
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            P.O. Box 1331
+            Piscataway
+            NJ 08854
+            USA
+    
+    E-mail: STDS-802-1-L@IEEE.ORG";
+  description
+    "Common types used within dot1Q-bridge modules.";
+  revision 2018-03-07 {
+    description
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  
+  identity dot1q-vlan-type {
+    description
+      "Base identity from which all 802.1Q VLAN tag types are derived
+      from.";
+  }
+  identity c-vlan {
+    base dot1q-vlan-type;
+    description
+      "An 802.1Q Customer VLAN, using the 81-00 EtherType";
+    reference
+      "5.5 of IEEE Std 802.1Q-2018";
+  }
+  identity s-vlan {
+    base dot1q-vlan-type;
+    description
+      "An 802.1Q Service VLAN, using the 88-A8 EtherType originally
+      introduced in 802.1ad, and incorporated into 802.1Q (2011)";
+    reference
+      "5.6 of IEEE Std 802.1Q-2018";
+  }
+  identity transmission-selection-algorithm {
+  description 
+    "Specify the transmission selection algorithms of IEEE Std 802.1Q-2018
+     Table 8-6";
+  }
+  identity strict-priority {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the strict priority transmission selection algorithm."; 
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  identity credit-based-shaper {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the credit based shaper transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  identity enhanced-transmission-sel {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the enhanced transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  identity asynch-traffic-shaping {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the asynchronous transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  identity vendor-specific {
+    base transmission-selection-algorithm;
+    description
+      "Indicates a vendor specific transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  typedef name-type {
+    type string {
+      length "0..32";
+    }
+    description
+      "A text string of up to 32 characters, of locally determined
+      significance.";
+  }
+  typedef port-number-type {
+    type uint32 {
+      range "1..65535";
+    }
+    description
+      "The port number of the Bridge port for which this entry
+      contains Bridge management information.";
+  }
+  typedef priority-type {
+    type uint8 {
+      range "0..7";
+    }
+    description
+      "A range of priorities from 0 to 7 (inclusive). The Priority
+      Code Point (PCP) is a 3-bit field that refers to the class of
+      service associated with an 802.1Q VLAN tagged frame. The field
+      specifies a priority value between 0 and 7, these values can be
+      used by quality of service (QoS) to prioritize different classes
+      of traffic.";
+  }
+  typedef num-traffic-class-type {
+    type uint8 {
+      range "1..8";
+    }
+    description
+      "The number of traffic classes supported or participating in a 
+       particular feature.  There are between 1 and 8 supported traffic
+       classes defined by IEEE Std 802.1Q.";
+  }
+  typedef vid-range-type {
+    type string {
+      pattern
+        "([1-9]"+
+        "[0-9]{0,3}"+
+        "(-[1-9][0-9]{0,3})?"+
+        "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+    }
+    description
+      "A list of VLAN Ids, or non overlapping VLAN ranges, in
+      ascending order, between 1 and 4094.
+      
+      This type is used to match an ordered list of VLAN Ids, or
+      contiguous ranges of VLAN Ids. Valid VLAN Ids must be in the
+      range 1 to 4094, and included in the list in non overlapping
+      ascending order.
+      
+      For example: 1,10-100,250,500-1000";
+  }
+  typedef vlanid {
+    type uint16 {
+      range "1..4094";
+    }
+    description
+      "The vlanid type uniquely identifies a VLAN. This is the 12-bit
+      VLAN-ID used in the VLAN Tag header. The range is defined by the
+      referenced specification. This type is in the value set and its
+      semantics equivalent to the VlanId textual convention of the
+      SMIv2.";
+  }
+  typedef vlan-index-type {
+    type uint32 {
+      range "1..4094 | 4096..4294967295";
+    }
+    description
+      "A value used to index per-VLAN tables. Values of 0 and 4095 are
+      not permitted. The range of valid VLAN indices. If the value is
+      greater than 4095, then it represents a VLAN with scope local to
+      the particular agent, i.e., one without a global VLAN-ID
+      assigned to it. Such VLANs are outside the scope of IEEE 802.1Q,
+      but it is convenient to be able to manage them in the same way
+      using this YANG module.";
+    reference
+      "9.6 of IEEE Std 802.1Q-2018";
+  }
+  typedef mstid-type {
+    type uint32 {
+      range "1..4094";
+    }
+    description
+      "In an MSTP Bridge, an MSTID, i.e., a value used to identify a
+      spanning tree (or MST) instance";
+    reference
+      "13.8 of IEEE Std 802.1Q-2018";
+  }
+  typedef pcp-selection-type {
+    type enumeration {
+      enum 8P0D {
+        description
+          "8 priorities, 0 drop eligible";
+      }
+      enum 7P1D {
+        description
+          "7 priorities, 1 drop eligible";
+      }
+      enum 6P2D {
+        description
+          "6 priorities, 2 drop eligible";
+      }
+      enum 5P3D {
+        description
+          "5 priorities, 3 drop eligible";
+      }
+    }
+    description
+      "Priority Code Point selection types.";
+    reference
+      "12.6.2.5.3 of IEEE Std 802.1Q-2018
+      6.9.3 of IEEE Std 802.1Q-2018";
+  }
+  typedef protocol-frame-format-type {
+    type enumeration {
+      enum Ethernet {
+        description
+          "Ethernet frame format";
+      }
+      enum rfc1042 {
+        description
+          "RFC 1042 frame format";
+      }
+      enum snap8021H {
+        description
+          "SNAP 802.1H frame format";
+      }
+      enum snapOther {
+        description
+          "Other SNAP frame format";
+      }
+      enum llcOther {
+        description
+          "Other LLC frame format";
+      }
+    }
+    description
+      "A value representing the frame format to be matched.";
+    reference
+      "12.10.1.7.1 of IEEE Std 802.1Q-2018";
+  }
+  typedef ethertype-type {
+    type string {
+      pattern "[0-9a-fA-F]{2}-[0-9a-fA-F]{2}";
+    }
+    description
+      "The EtherType value represented in the canonical order defined
+      by IEEE 802. The canonical representation uses uppercase
+      characters.";
+    reference
+      "9.2 of IEEE Std 802-2014";
+  }
+  typedef dot1q-tag-type {
+    type identityref {
+      base dot1q-vlan-type;
+    }
+    description
+      "Identifies a specific 802.1Q tag type";
+    reference
+      "IEEE Std 802.1Q-2018";
+  }
+  typedef traffic-class-type {
+    type uint8 {
+      range "0..7";
+    }
+    description
+      "This is the numerical value associated with a traffic class in
+      a Bridge. Larger values are associated with higher priority
+      traffic classes.";
+    reference
+      "3.239 of IEEE Std 802.1Q-2018";
+  }
+  grouping dot1q-tag-classifier-grouping {
+    description
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id.";
+    leaf tag-type {
+      type dot1q-tag-type;
+      mandatory true;
+      description
+        "VLAN type";
+    }
+    leaf vlan-id {
+      type vlanid;
+      mandatory true;
+      description
+        "VLAN Id";
+    }
+  }
+  grouping dot1q-tag-or-any-classifier-grouping {
+    description
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id or 'any' to match on any VLAN Id.";
+    leaf tag-type {
+      type dot1q-tag-type;
+      mandatory true;
+      description
+        "VLAN type";
+    }
+    leaf vlan-id {
+      type union {
+        type vlanid;
+        type enumeration {
+          enum any {
+            value 4095;
+            description
+              "Matches 'any' VLAN in the range 1 to 4094 that is not
+              matched by a more specific VLAN Id match";
+          }
+        }
+      }
+      mandatory true;
+      description
+        "VLAN Id or any";
+    }
+  }
+  grouping dot1q-tag-ranges-classifier-grouping {
+    description
+      "A grouping which represents an 802.1Q VLAN that matches a range
+      of VLAN Ids.";
+    leaf tag-type {
+      type dot1q-tag-type;
+      mandatory true;
+      description
+        "VLAN type";
+    }
+    leaf vlan-ids {
+      type vid-range-type;
+      mandatory true;
+      description
+        "VLAN Ids";
+    }
+  }
+  grouping dot1q-tag-ranges-or-any-classifier-grouping {
+    description
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id, ordered list of ranges, or 'any'
+      to match on any VLAN Id.";
+    leaf tag-type {
+      type dot1q-tag-type;
+      mandatory true;
+      description
+        "VLAN type";
+    }
+    leaf vlan-id {
+      type union {
+        type vid-range-type;
+        type enumeration {
+          enum any {
+            value 4095;
+            description
+              "Matches 'any' VLAN in the range 1 to 4094.";
+          }
+        }
+      }
+      mandatory true;
+      description
+        "VLAN Ids or any";
+    }
+  }
+  grouping priority-regeneration-table-grouping {
+    description
+      "The priority regeneration table provides the ability to map
+      incoming priority values on a per-Port basis, under management
+      control.";
+    reference
+      "6.9.4 of IEEE Std 802.1Q-2018";
+    leaf priority0 {
+      type priority-type;
+      default "0";
+      description
+        "Priority 0";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority1 {
+      type priority-type;
+      default "1";
+      description
+        "Priority 1";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority2 {
+      type priority-type;
+      default "2";
+      description
+        "Priority 2";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority3 {
+      type priority-type;
+      default "3";
+      description
+        "Priority 3";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority4 {
+      type priority-type;
+      default "4";
+      description
+        "Priority 4";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority5 {
+      type priority-type;
+      default "5";
+      description
+        "Priority 5";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority6 {
+      type priority-type;
+      default "6";
+      description
+        "Priority 6";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority7 {
+      type priority-type;
+      default "7";
+      description
+        "Priority 7";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+  }
+  grouping pcp-decoding-table-grouping {
+    description
+      "The Priority Code Point decoding table enables the decoding of
+      the priority and drop-eligible parameters from the PCP.";
+    reference
+      "6.9.3 of IEEE Std 802.1Q-2018";
+    list pcp-decoding-map {
+      key "pcp";
+      description
+        "This map associates the priority code point field found in
+        the VLAN to a priority and drop eligible value based upon the
+        priority code point selection type.";
+      leaf pcp {
+        type pcp-selection-type;
+        description
+          "The priority code point selection type.";
+        reference
+          "12.6.2.7 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
+      }
+      list priority-map {
+        key "priority-code-point";
+        description
+          "This map associated a priority code point value to priority
+          and drop eligible parameters.";
+        leaf priority-code-point {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf priority {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf drop-eligible {
+          type boolean;
+          description
+            "Drop eligible value for pcp";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+  }
+  grouping pcp-encoding-table-grouping {
+    description
+      "The Priority Code Point encoding table encodes the priority and
+      drop-eligible parameters in the PCP field of the VLAN tag.";
+    reference
+      "12.6.2.9 of IEEE Std 802.1Q-2018
+      6.9.3 of IEEE Std 802.1Q-2018";
+    list pcp-encoding-map {
+      key "pcp";
+      description
+        "This map associated the priority and drop-eligible parameters
+        to the priority used to encode the PCP of the VLAN based upon
+        the priority code point selection type.";
+      leaf pcp {
+        type pcp-selection-type;
+        description
+          "The priority code point selection type.";
+        reference
+          "12.6.2.7 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
+      }
+      list priority-map {
+        key "priority dei";
+        description
+          "This map associated the priority and drop-eligible
+          parameters to the priority code point field of the VLAN tag.";
+        leaf priority {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf dei {
+          type boolean;
+          description
+            "The drop eligible value.";
+          reference
+            "12.6.2 of IEEE Std 802.1Q-2018
+            8.6.6 of IEEE Std 802.1Q-2018";
+        }
+        leaf priority-code-point {
+          type priority-type;
+          description
+            "PCP value for priority when DEI value";
+          reference
+            "12.6.2.9 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+  }
+  grouping service-access-priority-table-grouping {
+    description
+      "The Service Access Priority Table associates a received
+      priority with a serice access priority.";
+    reference
+      "12.6.2.17 of IEEE Std 802.1Q-2018
+      6.13.1 of IEEE Std 802.1Q-2018";
+    leaf priority0 {
+      type priority-type;
+      default "0";
+      description
+        "Service access priority value for priority 0";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority1 {
+      type priority-type;
+      default "1";
+      description
+        "Service access priority value for priority 1";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority2 {
+      type priority-type;
+      default "2";
+      description
+        "Service access priority value for priority 2";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority3 {
+      type priority-type;
+      default "3";
+      description
+        "Service access priority value for priority 3";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority4 {
+      type priority-type;
+      default "4";
+      description
+        "Service access priority value for priority 4";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority5 {
+      type priority-type;
+      default "5";
+      description
+        "Service access priority value for priority 5";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority6 {
+      type priority-type;
+      default "6";
+      description
+        "Service access priority value for priority 6";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority7 {
+      type priority-type;
+      default "7";
+      description
+        "Service access priority value for priority 7";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+  }
+  grouping traffic-class-table-grouping {
+    description
+      "The Traffic Class Table models the operations that can be
+      performed on, or inquire about, the current contents of the
+      Traffic Class Table (8.6.6) for a given Port.";
+    reference
+      "12.6.3 of IEEE Std 802.1Q-2018
+      8.6.6 of IEEE Std 802.1Q-2018";
+    list traffic-class-map {
+      key "priority";
+      description
+        "The priority index into the traffic class table.";
+      leaf priority {
+        type priority-type;
+        description
+          "The priority of the traffic class entry.";
+        reference
+          "8.6.6 of IEEE Std 802.1Q-2018";
+      }
+      list available-traffic-class {
+        key "num-traffic-class";
+        description
+          "The traffic class index associated with a given priority
+          within the traffic class table.";
+        reference
+          "8.6.6 of IEEE Std 802.1Q-2018";
+        leaf num-traffic-class {
+          type uint8 {
+            range "1..8";
+          }
+          description
+            "The available number of traffic classes.";
+          reference
+            "8.6.6 of IEEE Std 802.1Q-2018";
+        }
+        leaf traffic-class {
+          type traffic-class-type;
+          description
+            "The traffic class index associated with a given traffic
+            class entry.";
+          reference
+            "8.6.6 of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+  }
+  grouping port-map-grouping {
+    description
+      "A set of control indicators, one for each Port. A Port Map,
+      containing a control element for each outbound Port";
+    reference
+      "8.8.1 of IEEE Std 802.1Q-2018
+      8.8.2 of IEEE Std 802.1Q-2018";
+    list port-map {
+      key "port-ref";
+      description
+        "The list of entries composing the port map.";
+      leaf port-ref {
+        type port-number-type;
+        description
+          "The interface port reference associated with this map.";
+        reference
+          "8.8.1 of IEEE Std 802.1Q-2018";
+      }
+      choice map-type {
+        description
+          "Type of port map";
+        container static-filtering-entries {
+          description
+            "Static filtering entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum forward {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+              enum filter {
+                description
+                  "Filtered, independently of any dynamic filtering
+                  information.";
+              }
+              enum forward-filter {
+                description
+                  "Forwarded or filtered on the basis of dynamic
+                  filtering information, or on the basis of the
+                  default Group filtering behavior for the outbound
+                  Port (8.8.6) if no dynamic filtering information is
+                  present specifically for the MAC address.";
+              }
+            }
+            description
+              "containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.1 of IEEE Std 802.1Q-2018";
+          }
+          leaf connection-identifier {
+            type port-number-type;
+            description
+              "A Port MAP may contain a connection identifier (8.8.12)
+              for each outbound port. The connection identifier may be
+              associated with the Bridge Port value maintained in a
+              Dynamic Filtering Entry of the FDB for Bridge Ports.";
+            reference
+              "8.8.1 of IEEE Std 802.1Q-2018
+              8.8.12 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container static-vlan-registration-entries {
+          description
+            "Static VLAN registration entries.";
+          leaf registrar-admin-control {
+            type enumeration {
+              enum fixed-new-ignored {
+                description
+                  "Registration Fixed (New ignored).";
+              }
+              enum fixed-new-propagated {
+                description
+                  "Registration Fixed (New propagated.";
+              }
+              enum forbidden {
+                description
+                  "Registration Forbidden.";
+              }
+              enum normal {
+                description
+                  "Normal Registration.";
+              }
+            }
+            description
+              "The Registrar Administrative Control values for MVRP
+              and MIRP for the VID.";
+            reference
+              "8.8.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf vlan-transmitted {
+            type enumeration {
+              enum tagged {
+                description
+                  "VLAN-tagged";
+              }
+              enum untagged {
+                description
+                  "VLAN-untagged";
+              }
+            }
+            description
+              "Whether frames are to be VLAN-tagged or untagged when
+              transmitted.";
+            reference
+              "8.8.2 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container mac-address-registration-entries {
+          description
+            "MAC address registration entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum registered {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+              enum not-registered {
+                description
+                  "Filtered, independently of any dynamic filtering
+                  information.";
+              }
+            }
+            description
+              "containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.4 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container dynamic-vlan-registration-entries {
+          description
+            "Dynamic VLAN registration entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum registered {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+            }
+            description
+              "containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.5 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container dynamic-reservation-entries {
+          description
+            "Dynamic reservation entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum forward {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+              enum filter {
+                description
+                  "Filtered, independently of any dynamic filtering
+                  information.";
+              }
+            }
+            description
+              "Containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.7 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container dynamic-filtering-entries {
+          description
+            "Dynamic filtering entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum forward {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+            }
+            description
+              "Containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.3 of IEEE Std 802.1Q-2018";
+          }
+        }
+      }
+    }
+  }
+  grouping bridge-port-statistics-grouping {
+    description
+      "Grouping of bridge port statistics.";
+    reference
+      "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    leaf delay-exceeded-discards {
+      type yang:counter64;
+      description
+        "The number of frames discarded by this port due to excessive
+        transit delay through the Bridge. It is incremented by both
+        transparent and source route Bridges.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018
+        8.6.6 of IEEE Std 802.1Q-2018";
+    }
+    leaf mtu-exceeded-discards {
+      type yang:counter64;
+      description
+        "The number of frames discarded by this port due to an
+        excessive size. It is incremented by both transparent and
+        source route Bridges.";
+      reference
+        "12.6.1.1.3, item g) of IEEE Std 802.1Q-2018";
+    }
+    leaf frame-rx {
+      type yang:counter64;
+      description
+        "The number of frames that have been received by this port
+        from its segment. Note that a frame received on the interface
+        corresponding to this port is only counted by this object if
+        and only if it is for a protocol being processed by the local
+        bridging function, including Bridge management frames.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf octets-rx {
+      type yang:counter64;
+      description
+        "The total number of octets in all valid frames received
+        (including BPDUs, frames addressed to the Bridge as an end
+        station, and frames that were submitted to the Forwarding
+        Process).";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf frame-tx {
+      type yang:counter64;
+      description
+        "The number of frames that have been transmitted by this port
+        to its segment. Note that a frame transmitted on the interface
+        corresponding to this port is only counted by this object if
+        and only if it is for a protocol being processed by the local
+        bridging function, including Bridge management frames.";
+    }
+    leaf octets-tx {
+      type yang:counter64;
+      description
+        "The total number of octets that have been transmitted by this
+        port to its segment.";
+    }
+    leaf discard-inbound {
+      type yang:counter64;
+      description
+        "Count of received valid frames that were discarded (i.e.,
+        filtered) by the Forwarding Process.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf forward-outbound {
+      type yang:counter64;
+      description
+        "The number of frames forwarded to the associated MAC Entity
+        (8.5).";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf discard-lack-of-buffers {
+      type yang:counter64;
+      description
+        "The count of frames that were to be transmitted through the
+        associated Port but were discarded due to lack of buffers.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf discard-transit-delay-exceeded {
+      type yang:counter64;
+      description
+        "The number of frames discarded by this port due to excessive
+        transit delay through the Bridge. It is incremented by both
+        transparent and source route Bridges.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf discard-on-error {
+      type yang:counter64;
+      description
+        "The number of frames that were to be forwarded on the
+        associated MAC but could not be transmitted (e.g., frame would
+        be too large, 6.5.8).";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+  }
+}


### PR DESCRIPTION
Changes from comment resolution including prefix name clean-up, using identities instead of enums where appropriate, deleting reserved bit definitions, other various changes.  Updated dot1q-types.yang with a new identity for transmission selection.  CI has been successfully run manually.
