### PR TITLE
Fix the broken CI config for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 before_install:
   - sudo apt-get update
   # this will work from Focal Fossa onwards
-  - sudo apt-get install -y yang-tools libyang-dev
+  # - sudo apt-get install -y yang-tools libyang-dev
 install: "pip install pyang==2.1 requests"
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 sudo: required
-dist: xenial
+dist: bionic
 language: python
 python:
   - "3.8"
 before_install:
   - sudo apt-get update
+  # this will work from Focal Fossa onwards
   - sudo apt-get install -y yang-tools libyang-dev
 install: "pip install pyang==2.1 requests"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 language: python
 python:
   - "3.8"
+before_install:
   - sudo apt-get update
   - sudo apt-get install -y yang-tools libyang-dev
 install: "pip install pyang==2.1 requests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: bionic
 language: python
 python:
   - "3.8"
-before_install:
-  - sudo apt-get update
+# before_install:
+  # - sudo apt-get update
   # this will work from Focal Fossa onwards
   # - sudo apt-get install -y yang-tools libyang-dev
 install: "pip install pyang==2.1 requests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@ dist: bionic
 language: python
 python:
   - "3.8"
-before_install:
-  - wget -nv https://download.opensuse.org/repositories/home:liberouter/xUbuntu_18.04/Release.key -O Release.key
-  - sudo apt-key add - < Release.key
-  - sudo sh -c "echo 'deb http://download.opensuse.org/repositories/home:/liberouter/xUbuntu_18.04/ /' > /etc/apt/sources.list.d/libyang.list"
   - sudo apt-get update
-  - sudo apt-get install --allow-unauthenticated libyang
+  - sudo apt-get install -y yang-tools libyang-dev
 install: "pip install pyang==2.1 requests"
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: xenial
 language: python
 python:
   - "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ notifications:
     on_error: never # default: always
 script:
   - ./vendor/fujitsu/yang-validate.sh
-  - travis_wait 30 ./vendor/cisco/check.sh
+  - travis_wait 30 ./vendor/cisco/nx/check.sh
+  - travis_wait 30 ./vendor/cisco/xr/check.sh
+  - travis_wait 30 ./vendor/cisco/xe/check.sh
   - ./standard/ietf/check.sh
   - ./standard/bbf/check.sh
   - ./experimental/ieee/check.sh

--- a/testall.sh
+++ b/testall.sh
@@ -5,7 +5,9 @@
 #
 
 ./vendor/fujitsu/yang-validate.sh
-./vendor/cisco/check.sh
+./vendor/cisco/nx/check.sh
+./vendor/cisco/xr/check.sh
+./vendor/cisco/xe/check.sh
 ./standard/ietf/check.sh
 ./standard/bbf/check.sh
 ./experimental/ieee/check.sh

--- a/vendor/cisco/nx/check.sh
+++ b/vendor/cisco/nx/check.sh
@@ -17,7 +17,7 @@ to_check="7.0-3-I7-8 9.3-5"
 
 inc_path="."
 pyang_flags="--lax-quote-checks"
-debug="0"
+debug="1"
 
 checkDir () {
     if [ "$debug" -eq "1" ]; then

--- a/vendor/cisco/nx/check.sh
+++ b/vendor/cisco/nx/check.sh
@@ -17,7 +17,7 @@ to_check="7.0-3-I7-8 9.3-5"
 
 inc_path="."
 pyang_flags="--lax-quote-checks"
-debug="1"
+debug="0"
 
 checkDir () {
     if [ "$debug" -eq "1" ]; then

--- a/vendor/cisco/nx/check.sh
+++ b/vendor/cisco/nx/check.sh
@@ -11,7 +11,10 @@
 # be removed.
 #
 platform_dir="vendor/cisco/nx"
+
+# NOTE: please just have the directories you are checking here
 to_check="7.0-3-I7-8 9.3-5"
+
 inc_path="."
 pyang_flags="--lax-quote-checks"
 debug="0"

--- a/vendor/cisco/xe/check.sh
+++ b/vendor/cisco/xe/check.sh
@@ -30,7 +30,7 @@ platform_dir="vendor/cisco/xe"
 to_check="cedge/1721 cedge/1721/MIBS 1721 1721/MIBS"
 
 inc_path="."
-debug=0
+debug=1
 
 checkDir () {
     if [ "$debug" -eq "1" ]; then

--- a/vendor/cisco/xe/check.sh
+++ b/vendor/cisco/xe/check.sh
@@ -58,10 +58,10 @@ checkDir () {
 	    printf "PYANG: Errors in $f\n"
 	    printf "$errors\n"
 	    exit_status="failed!"
-	    if [ "$debug" -eq "1" ]; then
-		printf "\n\n*** EARLY EXIT DUE TO ERROR ***\n\n"
-		exit 1
-	    fi
+	    # if [ "$debug" -eq "1" ]; then
+	    # 	printf "\n\n*** EARLY EXIT DUE TO ERROR ***\n\n"
+	    # 	exit 1
+	    # fi
 	fi
     done
     cd $cwd

--- a/vendor/cisco/xe/check.sh
+++ b/vendor/cisco/xe/check.sh
@@ -30,7 +30,7 @@ platform_dir="vendor/cisco/xe"
 to_check="cedge/1721 cedge/1721/MIBS 1721 1721/MIBS"
 
 inc_path="."
-debug=1
+debug=0
 
 checkDir () {
     if [ "$debug" -eq "1" ]; then

--- a/vendor/cisco/xe/check.sh
+++ b/vendor/cisco/xe/check.sh
@@ -10,6 +10,14 @@
 # release is added, the current first release (left to right) should
 # be removed.
 #
+# 2020-08-01 einarnn:
+#
+# Deprecating use of yanglint at least until Focal Fossa Ubuntu release
+# is out.
+#
+# Added note to maintainers to just have the release being checked in
+# in `to_check`.
+#
 # 2017-09-21 einarnn:
 #
 # 16.4.1 currently excluded because this release does not include all
@@ -17,7 +25,10 @@
 # ietf-routing draft without versioned imports.
 #
 platform_dir="vendor/cisco/xe"
-to_check="1691 1691/MIBS 1693 1693/MIBS 16101 16101/MIBS 16111 16111/MIBS 16121 16121/MIBS 1711 1711/MIBS cedge/1721 cedge/1721/MIBS 1721 1721/MIBS"
+
+# NOTE: please just have the directories you are checking here
+to_check="cedge/1721 cedge/1721/MIBS 1721 1721/MIBS"
+
 inc_path="."
 debug=0
 
@@ -42,22 +53,16 @@ checkDir () {
 	if [ "$debug" -eq "1" ]; then
 	    echo Checking $f...
 	fi
-        errors=`yanglint $yanglint_flags $f 2>&1`
-        if [ "$?" -eq 1 ]; then
+	errors=`YANG_INSTALL="." pyang --lax-quote-checks $yanglint_flags $f 2>&1 | grep -v "warning:"`
+	if [ ! -z "$errors" ]; then
+	    printf "PYANG: Errors in $f\n"
+	    printf "$errors\n"
+	    exit_status="failed!"
 	    if [ "$debug" -eq "1" ]; then
-		printf "YANGLINT: found errors in $f, secondary pyang check running...\n"
+		printf "\n\n*** EARLY EXIT DUE TO ERROR ***\n\n"
+		exit 1
 	    fi
-	    errors=`YANG_INSTALL="." pyang --lax-quote-checks $yanglint_flags $f 2>&1 | grep -v "warning:"`
-	    if [ ! -z "$errors" ]; then
-		printf "PYANG: Errors in $f\n"
-		printf "$errors\n"
-		exit_status="failed!"
-		if [ "$debug" -eq "1" ]; then
-		    printf "\n\n*** EARLY EXIT DUE TO ERROR ***\n\n"
-		    exit 1
-		fi
-	    fi
-        fi
+	fi
     done
     cd $cwd
     

--- a/vendor/cisco/xr/check.sh
+++ b/vendor/cisco/xr/check.sh
@@ -24,7 +24,7 @@ platform_dir="vendor/cisco/xr"
 # NOTE: please just have the directories you are checking here
 to_check="711"
 
-debug=1
+debug=0
 
 checkDir () {
     if [ "$debug" -eq "1" ]; then

--- a/vendor/cisco/xr/check.sh
+++ b/vendor/cisco/xr/check.sh
@@ -24,7 +24,8 @@ platform_dir="vendor/cisco/xr"
 # NOTE: please just have the directories you are checking here
 to_check="711"
 
-debug=0
+debug=1
+
 checkDir () {
     if [ "$debug" -eq "1" ]; then
 	echo Checking yang files in $platform_dir/$1

--- a/vendor/cisco/xr/check.sh
+++ b/vendor/cisco/xr/check.sh
@@ -10,8 +10,20 @@
 # When a new set of models is committed for a version, the previous
 # should be removed.
 #
+# 2020-08-01 einarnn:
+#
+# Deprecating use of yanglint at least until Focal Fossa Ubuntu release
+# is out.
+#
+# Added note to maintainers to just have the release being checked in
+# in `to_check`.
+#
+#
 platform_dir="vendor/cisco/xr"
+
+# NOTE: please just have the directories you are checking here
 to_check="711"
+
 debug=0
 checkDir () {
     if [ "$debug" -eq "1" ]; then

--- a/vendor/cisco/xr/check.sh
+++ b/vendor/cisco/xr/check.sh
@@ -43,10 +43,10 @@ checkDir () {
 	    printf "PYANG: Errors in $f\n"
 	    printf "$errors\n"
 	    exit_status="failed!"
-	    if [ "$debug" -eq "1" ]; then
-		printf "\n\n*** EARLY EXIT DUE TO ERROR ***\n\n"
-		exit 1
-	    fi
+	    # if [ "$debug" -eq "1" ]; then
+	    # 	printf "\n\n*** EARLY EXIT DUE TO ERROR ***\n\n"
+	    # 	exit 1
+	    # fi
 	fi
     done
     cd $cwd

--- a/vendor/cisco/xr/check.sh
+++ b/vendor/cisco/xr/check.sh
@@ -11,7 +11,7 @@
 # should be removed.
 #
 platform_dir="vendor/cisco/xr"
-to_check="623 632 642 651 652 653 662 663 701 702 711"
+to_check="711"
 debug=0
 checkDir () {
     if [ "$debug" -eq "1" ]; then
@@ -25,20 +25,14 @@ checkDir () {
 	if [ "$debug" -eq "1" ]; then
 	    echo Checking $f...
 	fi
-        errors=`yanglint $f 2>&1`
-        if [ "$?" -eq 1 ]; then
+	errors=`pyang --lax-quote-checks $yanglint_flags $f 2>&1 | grep -v "warning:"`
+	if [ ! -z "$errors" ]; then
+	    printf "PYANG: Errors in $f\n"
+	    printf "$errors\n"
+	    exit_status="failed!"
 	    if [ "$debug" -eq "1" ]; then
-		printf "YANGLINT: found errors in $f, secondary pyang check running...\n"
-	    fi
-	    errors=`pyang --lax-quote-checks $yanglint_flags $f 2>&1 | grep -v "warning:"`
-	    if [ ! -z "$errors" ]; then
-		printf "PYANG: Errors in $f\n"
-		printf "$errors\n"
-		exit_status="failed!"
-		if [ "$debug" -eq "1" ]; then
-		    printf "\n\n*** EARLY EXIT DUE TO ERROR ***\n\n"
-		    exit 1
-		fi
+		printf "\n\n*** EARLY EXIT DUE TO ERROR ***\n\n"
+		exit 1
 	    fi
 	fi
     done


### PR DESCRIPTION
The libyang/yanglint dependencies have been broken for a while. This PR (temporarily?) stops using yanglint in preference of just pyang. This is slower, but easier to manage. To mitigate this, I has also reduced the number of old versions of Cisco IOS XR and IOS XE models that are checked, and left advice for any model PR submitters to only include the content actually being checked in in their PR. This should sufficiently mitigate the loss of performance of not using yanglint.

Once Ubuntu "Focal Fossa" is supported by Travis, we can consider reinstating the use of yanglint. While there are other approaches (e.g. build a CLI tool container for yanglint), waiting for Focal Fossa is probably the easiest for now.
