### PR TITLE
 Removed default revision date from capabilities when model itself doesn't carry it.

### DIFF
--- a/vendor/cisco/xr/621/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/621/capabilities-ncs6k.xml
@@ -244,7 +244,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-vrrp-oper?module=Cisco-IOS-XR-ipv4-vrrp-oper&amp;revision=2016-12-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-telemetry-model-driven-oper?module=Cisco-IOS-XR-telemetry-model-driven-oper&amp;revision=2016-07-14</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-alarmgr-server-oper?module=Cisco-IOS-XR-alarmgr-server-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://www.cisco.com/panini/calvados/slice_control/modena/types?module=modena_driver_types&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://www.cisco.com/panini/calvados/slice_control/modena/types?module=modena_driver_types</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-telnet-mgmt-cfg?module=Cisco-IOS-XR-ipv4-telnet-mgmt-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-ipcp-cfg?module=Cisco-IOS-XR-ppp-ma-ipcp-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tty-management-cmd-oper?module=Cisco-IOS-XR-tty-management-cmd-oper&amp;revision=2015-11-09</nc:capability>

--- a/vendor/cisco/xr/621/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/621/capabilities-xrv9k.xml
@@ -20,7 +20,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tty-management-datatypes?module=Cisco-IOS-XR-tty-management-datatypes&amp;revision=2015-01-07</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-group-cfg?module=Cisco-IOS-XR-group-cfg&amp;revision=2016-04-29</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-config-mibs-cfg?module=Cisco-IOS-XR-config-mibs-cfg&amp;revision=2015-09-29</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-instmgr-cfg?module=Cisco-IOS-XR-sysadmin-instmgr-cfg&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-instmgr-cfg?module=Cisco-IOS-XR-sysadmin-instmgr-cfg</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-lcp-cfg?module=Cisco-IOS-XR-ppp-ma-lcp-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://openconfig.net/yang/mpls?module=openconfig-mpls&amp;revision=2015-11-05&amp;deviations=cisco-xr-openconfig-mpls-deviations</nc:capability>

--- a/vendor/cisco/xr/622/capabilities-ncs1001.xml
+++ b/vendor/cisco/xr/622/capabilities-ncs1001.xml
@@ -56,7 +56,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-config-mda-cfg?module=Cisco-IOS-XR-config-mda-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-config-mibs-cfg?module=Cisco-IOS-XR-config-mibs-cfg&amp;revision=2015-09-29</nc:capability>
     <nc:capability>http://openconfig.net/yang/interfaces/aggregate?module=openconfig-if-aggregate&amp;revision=2016-05-26</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-instmgr-cfg?module=Cisco-IOS-XR-sysadmin-instmgr-cfg&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-instmgr-cfg?module=Cisco-IOS-XR-sysadmin-instmgr-cfg</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://openconfig.net/yang/mpls?module=openconfig-mpls&amp;revision=2015-11-05&amp;deviations=cisco-xr-openconfig-mpls-deviations</nc:capability>

--- a/vendor/cisco/xr/622/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/622/capabilities-ncs5500.xml
@@ -24,7 +24,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tty-management-datatypes?module=Cisco-IOS-XR-tty-management-datatypes&amp;revision=2015-01-07</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-group-cfg?module=Cisco-IOS-XR-group-cfg&amp;revision=2016-04-29</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-config-mibs-cfg?module=Cisco-IOS-XR-config-mibs-cfg&amp;revision=2015-09-29</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-instmgr-cfg?module=Cisco-IOS-XR-sysadmin-instmgr-cfg&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-instmgr-cfg?module=Cisco-IOS-XR-sysadmin-instmgr-cfg</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg?module=Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://openconfig.net/yang/mpls?module=openconfig-mpls&amp;revision=2015-11-05&amp;deviations=cisco-xr-openconfig-mpls-deviations</nc:capability>
@@ -264,7 +264,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-telemetry-model-driven-oper?module=Cisco-IOS-XR-telemetry-model-driven-oper&amp;revision=2017-05-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/lacp?module=openconfig-lacp&amp;revision=2016-05-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-alarmgr-server-oper?module=Cisco-IOS-XR-alarmgr-server-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://www.cisco.com/panini/calvados/slice_control/modena/types?module=modena_driver_types&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://www.cisco.com/panini/calvados/slice_control/modena/types?module=modena_driver_types</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-telnet-mgmt-cfg?module=Cisco-IOS-XR-ipv4-telnet-mgmt-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-ipcp-cfg?module=Cisco-IOS-XR-ppp-ma-ipcp-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tty-management-cmd-oper?module=Cisco-IOS-XR-tty-management-cmd-oper&amp;revision=2015-11-09</nc:capability>

--- a/vendor/cisco/xr/623/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/623/capabilities-ncs5500.xml
@@ -251,7 +251,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-telemetry-model-driven-oper?module=Cisco-IOS-XR-telemetry-model-driven-oper&amp;revision=2017-05-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/lacp?module=openconfig-lacp&amp;revision=2016-05-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-alarmgr-server-oper?module=Cisco-IOS-XR-alarmgr-server-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://www.cisco.com/panini/calvados/slice_control/modena/types?module=modena_driver_types&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://www.cisco.com/panini/calvados/slice_control/modena/types?module=modena_driver_types</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-telnet-mgmt-cfg?module=Cisco-IOS-XR-ipv4-telnet-mgmt-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-ipcp-cfg?module=Cisco-IOS-XR-ppp-ma-ipcp-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tty-management-cmd-oper?module=Cisco-IOS-XR-tty-management-cmd-oper&amp;revision=2015-11-09</nc:capability>

--- a/vendor/cisco/xr/631/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/631/capabilities-ncs5500.xml
@@ -289,7 +289,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-iarm-cfg?module=Cisco-IOS-XR-ip-iarm-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-nto-misc-set-hostname?module=Cisco-IOS-XR-sysadmin-nto-misc-set-hostname&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-fdb?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-fdb&amp;revision=2017-05-01</nc:capability>
-    <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fabric-cxp?module=Cisco-IOS-XR-sysadmin-fabric-cxp&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fabric-cxp?module=Cisco-IOS-XR-sysadmin-fabric-cxp</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-locald-cfg?module=Cisco-IOS-XR-aaa-locald-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-nd-subscriber-cfg?module=Cisco-IOS-XR-ipv6-nd-subscriber-cfg&amp;revision=2016-12-19</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-syslogmib-cfg?module=Cisco-IOS-XR-snmp-syslogmib-cfg&amp;revision=2015-12-01</nc:capability>

--- a/vendor/cisco/xr/631/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/631/capabilities-ncs6k.xml
@@ -274,7 +274,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-sdr?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-sdr&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-nto-misc-set-hostname?module=Cisco-IOS-XR-sysadmin-nto-misc-set-hostname&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-fdb?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-fdb&amp;revision=2017-05-01</nc:capability>
-    <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fabric-cxp?module=Cisco-IOS-XR-sysadmin-fabric-cxp&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fabric-cxp?module=Cisco-IOS-XR-sysadmin-fabric-cxp</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-locald-cfg?module=Cisco-IOS-XR-aaa-locald-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-nd-subscriber-cfg?module=Cisco-IOS-XR-ipv6-nd-subscriber-cfg&amp;revision=2016-12-19</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-syslogmib-cfg?module=Cisco-IOS-XR-snmp-syslogmib-cfg&amp;revision=2015-12-01</nc:capability>
@@ -314,7 +314,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-telemetry-model-driven-oper?module=Cisco-IOS-XR-telemetry-model-driven-oper&amp;revision=2017-05-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/lacp?module=openconfig-lacp&amp;revision=2016-05-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-alarmgr-server-oper?module=Cisco-IOS-XR-alarmgr-server-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://www.cisco.com/panini/calvados/slice_control/modena/types?module=modena_driver_types&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://www.cisco.com/panini/calvados/slice_control/modena/types?module=modena_driver_types</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-telnet-mgmt-cfg?module=Cisco-IOS-XR-ipv4-telnet-mgmt-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-controllers?module=Cisco-IOS-XR-sysadmin-controllers&amp;revision=2017-01-31</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-ipcp-cfg?module=Cisco-IOS-XR-ppp-ma-ipcp-cfg&amp;revision=2015-11-09</nc:capability>

--- a/vendor/cisco/xr/632/capabilities-ncs1001.xml
+++ b/vendor/cisco/xr/632/capabilities-ncs1001.xml
@@ -94,7 +94,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-system?module=Cisco-IOS-XR-sysadmin-system&amp;revision=2017-01-31</nc:capability>
     <nc:capability>http://openconfig.net/yang/isis-lsdb-types?module=openconfig-isis-lsdb-types&amp;revision=2017-05-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-cfg?module=Cisco-IOS-XR-ppp-ma-cfg&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/control_driver?module=control_driver&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/control_driver?module=control_driver</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-mpp-oper?module=Cisco-IOS-XR-lib-mpp-oper&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-tcp-cfg?module=Cisco-IOS-XR-ip-tcp-cfg&amp;revision=2016-02-26</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-interfaces?module=ietf-interfaces&amp;revision=2014-05-08</nc:capability>
@@ -107,7 +107,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2015-07-27</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-hwmod-mpa-reload-act?module=Cisco-IOS-XR-hwmod-mpa-reload-act&amp;revision=2016-06-30</nc:capability>

--- a/vendor/cisco/xr/632/capabilities-ncs1k.xml
+++ b/vendor/cisco/xr/632/capabilities-ncs1k.xml
@@ -115,7 +115,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ncs1k-mxp-cfg?module=Cisco-IOS-XR-ncs1k-mxp-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2015-07-27</nc:capability>

--- a/vendor/cisco/xr/632/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/632/capabilities-ncs5500.xml
@@ -130,7 +130,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2015-07-27</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-hwmod-mpa-reload-act?module=Cisco-IOS-XR-hwmod-mpa-reload-act&amp;revision=2016-06-30</nc:capability>

--- a/vendor/cisco/xr/633/capabilities-asr9k-x64.xml
+++ b/vendor/cisco/xr/633/capabilities-asr9k-x64.xml
@@ -149,7 +149,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lpts-pre-ifib-oper?module=Cisco-IOS-XR-lpts-pre-ifib-oper&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-debug?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-debug&amp;revision=2017-05-01</nc:capability>
@@ -193,7 +193,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-01-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-lcp-cfg?module=Cisco-IOS-XR-ppp-ma-lcp-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>
@@ -433,7 +433,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ha-eem-cfg?module=Cisco-IOS-XR-ha-eem-cfg&amp;revision=2015-07-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-oper?module=Cisco-IOS-XR-man-ems-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rib-ipv4-oper?module=Cisco-IOS-XR-ip-rib-ipv4-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-oper?module=Cisco-IOS-XR-crypto-sam-oper&amp;revision=2015-01-07</nc:capability>
     <nc:capability>http://openconfig.net/yang/openconfig-isis-policy?module=openconfig-isis-policy&amp;revision=2017-05-15</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-summary?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-summary&amp;revision=2017-05-01</nc:capability>

--- a/vendor/cisco/xr/633/capabilities-ncs540.xml
+++ b/vendor/cisco/xr/633/capabilities-ncs540.xml
@@ -135,7 +135,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2015-07-27</nc:capability>
@@ -175,7 +175,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg?module=Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-01-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-lcp-cfg?module=Cisco-IOS-XR-ppp-ma-lcp-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>
@@ -410,7 +410,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-dnx-driver-oper?module=Cisco-IOS-XR-dnx-driver-oper&amp;revision=2017-08-29</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-oper?module=Cisco-IOS-XR-man-ems-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rib-ipv4-oper?module=Cisco-IOS-XR-ip-rib-ipv4-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-oper?module=Cisco-IOS-XR-crypto-sam-oper&amp;revision=2015-01-07</nc:capability>
     <nc:capability>http://openconfig.net/yang/openconfig-isis-policy?module=openconfig-isis-policy&amp;revision=2017-05-15</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-summary?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-summary&amp;revision=2017-05-01</nc:capability>

--- a/vendor/cisco/xr/633/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/633/capabilities-ncs5500.xml
@@ -136,7 +136,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2015-07-27</nc:capability>
@@ -176,7 +176,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-01-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>
@@ -410,7 +410,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-dnx-driver-oper?module=Cisco-IOS-XR-dnx-driver-oper&amp;revision=2017-08-29</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-oper?module=Cisco-IOS-XR-man-ems-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rib-ipv4-oper?module=Cisco-IOS-XR-ip-rib-ipv4-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-oper?module=Cisco-IOS-XR-crypto-sam-oper&amp;revision=2015-01-07</nc:capability>
     <nc:capability>http://openconfig.net/yang/openconfig-isis-policy?module=openconfig-isis-policy&amp;revision=2017-05-15</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-summary?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-summary&amp;revision=2017-05-01</nc:capability>

--- a/vendor/cisco/xr/633/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/633/capabilities-ncs5k.xml
@@ -124,7 +124,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2015-07-27</nc:capability>
@@ -164,7 +164,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-skp-qos-oper?module=Cisco-IOS-XR-skp-qos-oper&amp;revision=2016-02-18</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-01-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
@@ -362,7 +362,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ha-eem-cfg?module=Cisco-IOS-XR-ha-eem-cfg&amp;revision=2015-07-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-oper?module=Cisco-IOS-XR-man-ems-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rib-ipv4-oper?module=Cisco-IOS-XR-ip-rib-ipv4-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-oper?module=Cisco-IOS-XR-crypto-sam-oper&amp;revision=2015-01-07</nc:capability>
     <nc:capability>http://openconfig.net/yang/openconfig-isis-policy?module=openconfig-isis-policy&amp;revision=2017-05-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-fpd-infra-cfg?module=Cisco-IOS-XR-fpd-infra-cfg&amp;revision=2015-11-09</nc:capability>

--- a/vendor/cisco/xr/633/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/633/capabilities-ncs6k.xml
@@ -135,7 +135,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lpts-pre-ifib-oper?module=Cisco-IOS-XR-lpts-pre-ifib-oper&amp;revision=2017-05-01</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-debug?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-debug&amp;revision=2017-05-01</nc:capability>
@@ -181,7 +181,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-01-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2017-08-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>
@@ -404,7 +404,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ha-eem-cfg?module=Cisco-IOS-XR-ha-eem-cfg&amp;revision=2015-07-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-dnx-driver-oper?module=Cisco-IOS-XR-dnx-driver-oper&amp;revision=2017-08-29</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rib-ipv4-oper?module=Cisco-IOS-XR-ip-rib-ipv4-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-oper?module=Cisco-IOS-XR-crypto-sam-oper&amp;revision=2015-01-07</nc:capability>
     <nc:capability>http://openconfig.net/yang/openconfig-isis-policy?module=openconfig-isis-policy&amp;revision=2017-05-15</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-summary?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-summary&amp;revision=2017-05-01</nc:capability>

--- a/vendor/cisco/xr/633/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/633/capabilities-xrv9k.xml
@@ -126,7 +126,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2015-07-27</nc:capability>
@@ -164,7 +164,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-01-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>
@@ -362,7 +362,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ha-eem-cfg?module=Cisco-IOS-XR-ha-eem-cfg&amp;revision=2015-07-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-man-ems-oper?module=Cisco-IOS-XR-man-ems-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rib-ipv4-oper?module=Cisco-IOS-XR-ip-rib-ipv4-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/issu/test/it/client/client-requests?module=client-requests</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-oper?module=Cisco-IOS-XR-crypto-sam-oper&amp;revision=2015-01-07</nc:capability>
     <nc:capability>http://openconfig.net/yang/openconfig-isis-policy?module=openconfig-isis-policy&amp;revision=2017-05-15</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-aaa-aaa-show?module=Cisco-IOS-XR-sysadmin-aaa-aaa-show&amp;revision=2017-05-10</nc:capability>

--- a/vendor/cisco/xr/641/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/641/capabilities-ncs5k.xml
@@ -119,7 +119,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2017-09-07</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2015-07-27</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-ma-oper?module=Cisco-IOS-XR-ipv4-ma-oper&amp;revision=2017-08-23</nc:capability>

--- a/vendor/cisco/xr/641/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/641/capabilities-ncs6k.xml
@@ -130,7 +130,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-l2-eth-infra-datatypes?module=Cisco-IOS-XR-l2-eth-infra-datatypes&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2017-09-07</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-debug-trace?module=Cisco-IOS-XR-sysadmin-debug-trace&amp;revision=2017-04-12</nc:capability>
-    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/Cisco-IOS-XR-sysadmin-issu?module=Cisco-IOS-XR-sysadmin-issu</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-cfg?module=Cisco-IOS-XR-crypto-sam-cfg&amp;revision=2017-11-21</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-debug?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-debug&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-acl-oper?module=Cisco-IOS-XR-ipv4-acl-oper&amp;revision=2017-05-01</nc:capability>
@@ -419,7 +419,7 @@
     <nc:capability>http://openconfig.net/yang/fib-types?module=openconfig-aft-types&amp;revision=2017-05-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ocni-intfbase-oper?module=Cisco-IOS-XR-ocni-intfbase-oper&amp;revision=2017-11-23</nc:capability>
     <nc:capability>http://openconfig.net/yang/rib/bgp?module=openconfig-rib-bgp&amp;revision=2016-04-11</nc:capability>
-    <nc:capability>http://www.cisco.com/calvados/calvados_controllers/slice_control/modena?module=modena_driver&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://www.cisco.com/calvados/calvados_controllers/slice_control/modena?module=modena_driver</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-shellutil-cfg?module=Cisco-IOS-XR-shellutil-cfg&amp;revision=2015-10-12</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-services?module=Cisco-IOS-XR-sysadmin-services&amp;revision=2016-11-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-tcp-cfg?module=Cisco-IOS-XR-ip-tcp-cfg&amp;revision=2017-09-30</nc:capability>

--- a/vendor/cisco/xr/642/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/642/capabilities-ncs6k.xml
@@ -425,7 +425,7 @@
     <nc:capability>http://openconfig.net/yang/fib-types?module=openconfig-aft-types&amp;revision=2017-05-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ocni-intfbase-oper?module=Cisco-IOS-XR-ocni-intfbase-oper&amp;revision=2017-11-23</nc:capability>
     <nc:capability>http://openconfig.net/yang/rib/bgp?module=openconfig-rib-bgp&amp;revision=2016-04-11</nc:capability>
-    <nc:capability>http://www.cisco.com/calvados/calvados_controllers/slice_control/modena?module=modena_driver&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://www.cisco.com/calvados/calvados_controllers/slice_control/modena?module=modena_driver</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-shellutil-cfg?module=Cisco-IOS-XR-shellutil-cfg&amp;revision=2015-10-12</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-services?module=Cisco-IOS-XR-sysadmin-services&amp;revision=2016-11-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-tcp-cfg?module=Cisco-IOS-XR-ip-tcp-cfg&amp;revision=2017-09-30</nc:capability>

--- a/vendor/cisco/xr/651/capabilities-ncs1001.xml
+++ b/vendor/cisco/xr/651/capabilities-ncs1001.xml
@@ -101,7 +101,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-system?module=Cisco-IOS-XR-sysadmin-system&amp;revision=2017-10-31</nc:capability>
     <nc:capability>http://openconfig.net/yang/isis-lsdb-types?module=openconfig-isis-lsdb-types&amp;revision=2017-05-15</nc:capability>
-    <nc:capability>http://cisco.com/calvados/control_driver?module=control_driver&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://cisco.com/calvados/control_driver?module=control_driver</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-ma-subscriber-cfg?module=Cisco-IOS-XR-ipv4-ma-subscriber-cfg&amp;revision=2015-07-30</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-types?module=Cisco-IOS-XR-sysadmin-types&amp;revision=2017-01-31</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-interfaces?module=ietf-interfaces&amp;revision=2014-05-08</nc:capability>

--- a/vendor/cisco/xr/652/capabilities-asr9k-x64.xml
+++ b/vendor/cisco/xr/652/capabilities-asr9k-x64.xml
@@ -204,7 +204,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg?module=Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg&amp;revision=2017-09-07</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-lcp-cfg?module=Cisco-IOS-XR-ppp-ma-lcp-cfg&amp;revision=2017-09-07</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/652/capabilities-iosxrv-x64.xml
+++ b/vendor/cisco/xr/652/capabilities-iosxrv-x64.xml
@@ -169,7 +169,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-07-02</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/652/capabilities-ncs1001.xml
+++ b/vendor/cisco/xr/652/capabilities-ncs1001.xml
@@ -150,7 +150,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/calvados/ccc?module=ccc&amp;revision=2016-10-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg?module=Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg&amp;revision=2017-09-07</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-07-02</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/652/capabilities-ncs1k.xml
+++ b/vendor/cisco/xr/652/capabilities-ncs1k.xml
@@ -162,7 +162,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-07-02</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/652/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/652/capabilities-ncs5500.xml
@@ -185,7 +185,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-07-02</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/652/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/652/capabilities-ncs5k.xml
@@ -174,7 +174,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-skp-qos-oper?module=Cisco-IOS-XR-skp-qos-oper&amp;revision=2016-02-18</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-07-02</nc:capability>

--- a/vendor/cisco/xr/652/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/652/capabilities-xrv9k.xml
@@ -180,7 +180,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/653/capabilities-asr9k-x64.xml
+++ b/vendor/cisco/xr/653/capabilities-asr9k-x64.xml
@@ -202,7 +202,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/653/capabilities-ncs540.xml
+++ b/vendor/cisco/xr/653/capabilities-ncs540.xml
@@ -186,7 +186,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-07-02</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/653/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/653/capabilities-ncs5500.xml
@@ -185,7 +185,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-07-02</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/653/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/653/capabilities-ncs5k.xml
@@ -173,7 +173,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg?module=Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg&amp;revision=2017-09-07</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-skp-qos-oper?module=Cisco-IOS-XR-skp-qos-oper&amp;revision=2016-02-18</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-07-02</nc:capability>

--- a/vendor/cisco/xr/653/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/653/capabilities-xrv9k.xml
@@ -179,7 +179,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2017-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2017-04-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/662/capabilities-asr9k-x64.xml
+++ b/vendor/cisco/xr/662/capabilities-asr9k-x64.xml
@@ -210,7 +210,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2018-10-24</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg?module=Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg&amp;revision=2017-09-07</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2018-04-24</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/662/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/662/capabilities-ncs5k.xml
@@ -177,7 +177,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-sensor-mib?module=Cisco-IOS-XR-sysadmin-entity-sensor-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2018-10-24</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sdr-invmgr-oper?module=Cisco-IOS-XR-sdr-invmgr-oper&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-skp-qos-oper?module=Cisco-IOS-XR-skp-qos-oper&amp;revision=2016-02-18</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2018-04-24</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-oper?module=Cisco-IOS-XR-ipv6-ma-oper&amp;revision=2018-08-01</nc:capability>

--- a/vendor/cisco/xr/662/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/662/capabilities-xrv9k.xml
@@ -190,7 +190,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-rip-cfg?module=Cisco-IOS-XR-ip-rip-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-dhcpd-cfg?module=Cisco-IOS-XR-ipv4-dhcpd-cfg&amp;revision=2018-10-24</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg?module=Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg&amp;revision=2017-09-07</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/types/yang?module=openconfig-yang-types&amp;revision=2018-04-24</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ppp-ma-lcp-cfg?module=Cisco-IOS-XR-ppp-ma-lcp-cfg&amp;revision=2017-09-07</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-types?module=ietf-yang-types&amp;revision=2013-07-15</nc:capability>

--- a/vendor/cisco/xr/663/capabilities-asr9k-x64.xml
+++ b/vendor/cisco/xr/663/capabilities-asr9k-x64.xml
@@ -251,7 +251,7 @@
     <nc:capability>http://openconfig.net/yang/openconfig-types?module=openconfig-types&amp;revision=2018-05-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-upgrade-fpd-ng-act?module=Cisco-IOS-XR-upgrade-fpd-ng-act&amp;revision=2017-04-04</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-cfg?module=Cisco-IOS-XR-manageability-perfmgmt-cfg&amp;revision=2017-09-07</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://www.cisco.com/panini/calvados/opertest1?module=opertest1&amp;revision=2016-10-12</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:yang:ietf-yang-smiv2?module=ietf-yang-smiv2&amp;revision=2012-06-22</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-l2-eth-infra-cfg?module=Cisco-IOS-XR-l2-eth-infra-cfg&amp;revision=2018-06-15</nc:capability>

--- a/vendor/cisco/xr/663/capabilities-iosxrwbd.xml
+++ b/vendor/cisco/xr/663/capabilities-iosxrwbd.xml
@@ -532,7 +532,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg?module=Cisco-IOS-XR-lib-keychain-masterkey-aes-cfg&amp;revision=2017-09-07</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fpd-infra-cli-fpd?module=Cisco-IOS-XR-sysadmin-fpd-infra-cli-fpd&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-alarm-mgr?module=Cisco-IOS-XR-sysadmin-alarm-mgr&amp;revision=2018-04-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-show-diag?module=Cisco-IOS-XR-sysadmin-show-diag&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-tacacs-tacacs-server?module=Cisco-IOS-XR-sysadmin-tacacs-tacacs-server&amp;revision=2017-05-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lpts-pa-oper?module=Cisco-IOS-XR-lpts-pa-oper&amp;revision=2015-11-09</nc:capability>

--- a/vendor/cisco/xr/663/capabilities-ncs540.xml
+++ b/vendor/cisco/xr/663/capabilities-ncs540.xml
@@ -276,7 +276,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-traffmon-netflow-cfg?module=Cisco-IOS-XR-traffmon-netflow-cfg&amp;revision=2018-06-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-optics-driver-cfg?module=Cisco-IOS-XR-optics-driver-cfg&amp;revision=2016-03-21</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-bundlemgr-cfg?module=Cisco-IOS-XR-bundlemgr-cfg&amp;revision=2017-05-01</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:netconf:base:1.0?module=ietf-netconf&amp;revision=2011-06-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-rsi-subscriber-cfg?module=Cisco-IOS-XR-infra-rsi-subscriber-cfg&amp;revision=2015-07-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-ldp-oper-datatypes?module=Cisco-IOS-XR-mpls-ldp-oper-datatypes&amp;revision=2015-11-09</nc:capability>

--- a/vendor/cisco/xr/663/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/663/capabilities-ncs5500.xml
@@ -289,7 +289,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-ciscosensormib-cfg?module=Cisco-IOS-XR-snmp-ciscosensormib-cfg&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-wdmon?module=Cisco-IOS-XR-sysadmin-wdmon&amp;revision=2018-04-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-rsi-cfg?module=Cisco-IOS-XR-infra-rsi-cfg&amp;revision=2018-06-15</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-cdp-cfg?module=Cisco-IOS-XR-cdp-cfg&amp;revision=2017-08-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg?module=Cisco-IOS-XR-infra-infra-locale-cfg&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-pbr-cfg?module=Cisco-IOS-XR-pbr-cfg&amp;revision=2018-05-17</nc:capability>

--- a/vendor/cisco/xr/663/capabilities-ncs560.xml
+++ b/vendor/cisco/xr/663/capabilities-ncs560.xml
@@ -52,7 +52,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-vpn-cfg?module=Cisco-IOS-XR-mpls-vpn-cfg&amp;revision=2017-09-07</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-syncc-controller-cfg?module=Cisco-IOS-XR-syncc-controller-cfg&amp;revision=2017-06-22</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-notification-log-mib-cfg?module=Cisco-IOS-XR-infra-notification-log-mib-cfg&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/interfaces/ip?module=openconfig-if-ip&amp;revision=2016-05-26</nc:capability>
     <nc:capability>http://tail-f.com/yang/xsd-types?module=tailf-xsd-types&amp;revision=2017-11-20</nc:capability>
     <nc:capability>urn:ietf:params:xml:ns:netmod:notification?module=nc-notifications&amp;revision=2008-07-14</nc:capability>

--- a/vendor/cisco/xr/663/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/663/capabilities-ncs5k.xml
@@ -439,7 +439,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-msdp-cfg?module=Cisco-IOS-XR-ipv4-msdp-cfg&amp;revision=2017-10-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-config-cfgmgr-exec-oper?module=Cisco-IOS-XR-config-cfgmgr-exec-oper&amp;revision=2017-09-07</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-kim-tpa-cfg?module=Cisco-IOS-XR-kim-tpa-cfg&amp;revision=2018-07-27</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-statsd-cfg?module=Cisco-IOS-XR-infra-statsd-cfg&amp;revision=2017-05-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-subscriber-cfg?module=Cisco-IOS-XR-ipv6-ma-subscriber-cfg&amp;revision=2017-01-11</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-wdsysmon-fd-oper?module=Cisco-IOS-XR-wdsysmon-fd-oper&amp;revision=2019-07-05</nc:capability>

--- a/vendor/cisco/xr/663/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/663/capabilities-ncs6k.xml
@@ -261,7 +261,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-statsd-act?module=Cisco-IOS-XR-infra-statsd-act&amp;revision=2018-01-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-linux-os-reboot-history-oper?module=Cisco-IOS-XR-linux-os-reboot-history-oper&amp;revision=2015-11-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-rt-check-cfg?module=Cisco-IOS-XR-infra-rt-check-cfg&amp;revision=2015-11-09</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fabric-driver-sfe?module=Cisco-IOS-XR-sysadmin-fabric-driver-sfe&amp;revision=2018-04-09</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-mib?module=Cisco-IOS-XR-sysadmin-entity-mib&amp;revision=2017-04-12</nc:capability>
     <nc:capability>http://openconfig.net/yang/channel-monitor?module=openconfig-channel-monitor&amp;revision=2017-07-08</nc:capability>

--- a/vendor/cisco/xr/663/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/663/capabilities-xrv9k.xml
@@ -122,7 +122,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-dumper?module=Cisco-IOS-XR-sysadmin-dumper&amp;revision=2017-05-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-oper?module=Cisco-IOS-XR-segment-routing-ms-oper&amp;revision=2017-09-07</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-pim-cfg?module=Cisco-IOS-XR-ipv4-pim-cfg&amp;revision=2017-10-15</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/platform/linecard?module=openconfig-platform-linecard&amp;revision=2017-08-03</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-envmon-ui?module=Cisco-IOS-XR-sysadmin-envmon-ui&amp;revision=2018-04-09</nc:capability>
     <nc:capability>http://openconfig.net/yang/transport-line-common?module=openconfig-transport-line-common&amp;revision=2017-07-08</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-asr9k-x64.xml
+++ b/vendor/cisco/xr/701/capabilities-asr9k-x64.xml
@@ -6,7 +6,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ma-cfg?module=Cisco-IOS-XR-ipv6-ma-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-tcp-cfg?module=Cisco-IOS-XR-ip-tcp-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-cli-asr9k?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-cli-asr9k&amp;revision=2019-04-15</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-pfi-im-cmd-ctrlr-oper?module=Cisco-IOS-XR-pfi-im-cmd-ctrlr-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-keyring-cfg?module=Cisco-IOS-XR-keyring-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-acl-oper?module=Cisco-IOS-XR-ipv6-acl-oper&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-ncs1001.xml
+++ b/vendor/cisco/xr/701/capabilities-ncs1001.xml
@@ -441,7 +441,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-cfgmgr-rollback-act?module=Cisco-IOS-XR-cfgmgr-rollback-act&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/INET-ADDRESS-MIB/200205090000Z?module=INET-ADDRESS-MIB&amp;revision=2002-05-09</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-serg-oper?module=Cisco-IOS-XR-infra-serg-oper&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ncs1001-envmon-ui?module=Cisco-IOS-XR-sysadmin-ncs1001-envmon-ui&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-iarm-cfg?module=Cisco-IOS-XR-ip-iarm-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-rt-check-cfg?module=Cisco-IOS-XR-infra-rt-check-cfg&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-ncs1004.xml
+++ b/vendor/cisco/xr/701/capabilities-ncs1004.xml
@@ -460,7 +460,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-perf-meas-cfg?module=Cisco-IOS-XR-perf-meas-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-hsrp-oper?module=Cisco-IOS-XR-ipv4-hsrp-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://www.cisco.com/panini/calvados/opertest1?module=opertest1&amp;revision=2016-10-12</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/network-instance-l3?module=openconfig-network-instance-l3&amp;revision=2017-01-13</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-opendns-deviceid-cfg?module=Cisco-IOS-XR-opendns-deviceid-cfg&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-ncs1k.xml
+++ b/vendor/cisco/xr/701/capabilities-ncs1k.xml
@@ -82,7 +82,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entstatemib-cfg?module=Cisco-IOS-XR-snmp-entstatemib-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lpts-ifib-oper?module=Cisco-IOS-XR-lpts-ifib-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-remote-attestation-act?module=Cisco-IOS-XR-remote-attestation-act&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-linux-os-heap-summary-oper?module=Cisco-IOS-XR-linux-os-heap-summary-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/interfaces?module=openconfig-interfaces&amp;revision=2016-05-26&amp;deviations=cisco-xr-openconfig-interfaces-deviations</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-lsd-cfg?module=Cisco-IOS-XR-mpls-lsd-cfg&amp;revision=2019-05-12</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-ncs540.xml
+++ b/vendor/cisco/xr/701/capabilities-ncs540.xml
@@ -265,7 +265,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-policy-repository-cfg?module=Cisco-IOS-XR-policy-repository-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-flashmib-cfg?module=Cisco-IOS-XR-flashmib-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-config-mda-cfg?module=Cisco-IOS-XR-config-mda-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-ma-subscriber-cfg?module=Cisco-IOS-XR-ipv4-ma-subscriber-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-alarmgr-server-oper?module=Cisco-IOS-XR-alarmgr-server-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/701/capabilities-ncs5500.xml
@@ -137,7 +137,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ship?module=Cisco-IOS-XR-sysadmin-ship&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-trunk?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-trunk&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://openconfig.net/yang/interfaces/ip?module=openconfig-if-ip&amp;revision=2016-05-26&amp;deviations=cisco-xr-openconfig-if-ip-deviations</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-cm?module=Cisco-IOS-XR-sysadmin-cm&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ethernet-cfm-datatypes?module=Cisco-IOS-XR-ethernet-cfm-datatypes&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/openconfig-isis?module=openconfig-isis&amp;revision=2018-11-21</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-ncs560.xml
+++ b/vendor/cisco/xr/701/capabilities-ncs560.xml
@@ -402,7 +402,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-bridgemib-cfg?module=Cisco-IOS-XR-snmp-bridgemib-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-spirit-corehelper-cfg?module=Cisco-IOS-XR-spirit-corehelper-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-wdsysmon-fd-oper?module=Cisco-IOS-XR-wdsysmon-fd-oper&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-cinetd-cfg?module=Cisco-IOS-XR-ipv4-cinetd-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-ntp-admin-oper?module=Cisco-IOS-XR-ip-ntp-admin-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-entitymib-oper?module=Cisco-IOS-XR-snmp-entitymib-oper&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/701/capabilities-ncs5k.xml
@@ -236,7 +236,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-rvm-mgr?module=Cisco-IOS-XR-sysadmin-rvm-mgr&amp;revision=2019-06-12</nc:capability>
     <nc:capability>http://openconfig.net/yang/interfaces?module=openconfig-interfaces&amp;revision=2016-05-26&amp;deviations=cisco-xr-openconfig-interfaces-deviations</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-static-oper?module=Cisco-IOS-XR-mpls-static-oper&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-cfg?module=Cisco-IOS-XR-ip-static-cfg&amp;revision=2019-07-18</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-invproxy-hwmodule-cfg?module=Cisco-IOS-XR-invproxy-hwmodule-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-igmp-cfg?module=Cisco-IOS-XR-ipv4-igmp-cfg&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/701/capabilities-ncs6k.xml
@@ -159,7 +159,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-procfind-oper?module=Cisco-IOS-XR-procfind-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-type6-cfg?module=Cisco-IOS-XR-lib-type6-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-icpe-infra-cfg?module=Cisco-IOS-XR-icpe-infra-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-rcmd-oper?module=Cisco-IOS-XR-infra-rcmd-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-sdr?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-sdr&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-mpls-cfg?module=Cisco-IOS-XR-um-if-mpls-cfg&amp;revision=2019-06-10</nc:capability>

--- a/vendor/cisco/xr/701/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/701/capabilities-xrv9k.xml
@@ -364,7 +364,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-cm?module=Cisco-IOS-XR-sysadmin-cm&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-drivers-mpa-infra-cfg?module=Cisco-IOS-XR-drivers-mpa-infra-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-raw-cfg?module=Cisco-IOS-XR-ip-raw-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-object-tracking-oper?module=Cisco-IOS-XR-manageability-object-tracking-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-lib-datatypes?module=Cisco-IOS-XR-aaa-lib-datatypes&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-um-mpls-ldp-cfg?module=Cisco-IOS-XR-um-mpls-ldp-cfg&amp;revision=2019-06-10</nc:capability>

--- a/vendor/cisco/xr/702/capabilities-asr9k-x64.xml
+++ b/vendor/cisco/xr/702/capabilities-asr9k-x64.xml
@@ -140,7 +140,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-hwmod-mpa-reload-act?module=Cisco-IOS-XR-hwmod-mpa-reload-act&amp;revision=2019-10-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-es-acl-datatypes?module=Cisco-IOS-XR-es-acl-datatypes&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-fpd-infra-cfg?module=Cisco-IOS-XR-fpd-infra-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ethernet-cfm-oper?module=Cisco-IOS-XR-ethernet-cfm-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-nsr-cfg?module=Cisco-IOS-XR-infra-nsr-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/lacp?module=openconfig-lacp&amp;revision=2017-05-05&amp;deviations=cisco-xr-openconfig-lacp-deviations</nc:capability>

--- a/vendor/cisco/xr/702/capabilities-ncs540.xml
+++ b/vendor/cisco/xr/702/capabilities-ncs540.xml
@@ -297,7 +297,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-arp-act?module=Cisco-IOS-XR-ipv4-arp-act&amp;revision=2019-10-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-oper?module=Cisco-IOS-XR-crypto-sam-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-traceroute-act?module=Cisco-IOS-XR-traceroute-act&amp;revision=2019-10-01</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-authenticated-variable-act?module=Cisco-IOS-XR-authenticated-variable-act&amp;revision=2019-10-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-nacm-oper?module=Cisco-IOS-XR-aaa-nacm-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://tail-f.com/ns/aaa/1.1?module=tailf-aaa&amp;revision=2019-05-04</nc:capability>

--- a/vendor/cisco/xr/702/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/702/capabilities-ncs5500.xml
@@ -516,7 +516,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-accounting-cfg?module=Cisco-IOS-XR-accounting-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ncs5500-coherent-portmode-cfg?module=Cisco-IOS-XR-ncs5500-coherent-portmode-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/system/logging?module=openconfig-system-logging&amp;revision=2017-09-18</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-autorp-oper?module=Cisco-IOS-XR-ipv4-autorp-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-gnss-cfg?module=Cisco-IOS-XR-gnss-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/network-instance-l3?module=openconfig-network-instance-l3&amp;revision=2017-01-13</nc:capability>

--- a/vendor/cisco/xr/702/capabilities-ncs560.xml
+++ b/vendor/cisco/xr/702/capabilities-ncs560.xml
@@ -274,7 +274,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ethernet-lldp-cfg?module=Cisco-IOS-XR-ethernet-lldp-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-cfg?module=Cisco-IOS-XR-lib-keychain-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-aaacore-cfg?module=Cisco-IOS-XR-aaa-aaacore-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/platform?module=openconfig-platform&amp;revision=2018-06-29&amp;deviations=cisco-xr-openconfig-platform-deviations</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-msdp-cfg?module=Cisco-IOS-XR-ipv4-msdp-cfg&amp;revision=2019-10-31</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-protocol-radius-oper?module=Cisco-IOS-XR-aaa-protocol-radius-oper&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/702/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/702/capabilities-ncs5k.xml
@@ -520,7 +520,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ping-act?module=Cisco-IOS-XR-ping-act&amp;revision=2019-10-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ethernet-link-oam-cfg?module=Cisco-IOS-XR-ethernet-link-oam-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-iarm-datatypes?module=Cisco-IOS-XR-ip-iarm-datatypes&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/aaa?module=openconfig-aaa&amp;revision=2018-04-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-pfilter-oper?module=Cisco-IOS-XR-ip-pfilter-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-config-mibs-cfg?module=Cisco-IOS-XR-config-mibs-cfg&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/702/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/702/capabilities-xrv9k.xml
@@ -68,7 +68,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-bfd-cfg?module=Cisco-IOS-XR-ip-bfd-cfg&amp;revision=2019-10-31</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-perfmgmt-oper?module=Cisco-IOS-XR-manageability-perfmgmt-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg?module=Cisco-IOS-XR-infra-infra-locale-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-show-trace?module=Cisco-IOS-XR-sysadmin-show-trace&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://openconfig.net/yang/acl?module=openconfig-acl&amp;revision=2017-05-26&amp;deviations=cisco-xr-openconfig-acl-deviations</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-udp-cfg?module=Cisco-IOS-XR-ip-udp-cfg&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-asr9k-x64.xml
+++ b/vendor/cisco/xr/711/capabilities-asr9k-x64.xml
@@ -395,7 +395,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-linux-os-heap-summary-oper?module=Cisco-IOS-XR-linux-os-heap-summary-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-asr9k-fab-cfg?module=Cisco-IOS-XR-asr9k-fab-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-um-access-list-datatypes?module=Cisco-IOS-XR-um-access-list-datatypes&amp;revision=2019-06-10</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-object-tracking-datatypes?module=Cisco-IOS-XR-manageability-object-tracking-datatypes&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-call-home-cfg?module=Cisco-IOS-XR-call-home-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tunnel-nve-oper?module=Cisco-IOS-XR-tunnel-nve-oper&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-ncs1001.xml
+++ b/vendor/cisco/xr/711/capabilities-ncs1001.xml
@@ -108,7 +108,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sysmgr-oper?module=Cisco-IOS-XR-sysmgr-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/panini/calvados/fit?module=fit&amp;revision=2018-06-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-placed-act?module=Cisco-IOS-XR-infra-placed-act&amp;revision=2018-01-10</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/network-instance?module=openconfig-network-instance&amp;revision=2017-01-13&amp;deviations=cisco-xr-openconfig-network-instance-deviations</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tty-management-cmd-oper?module=Cisco-IOS-XR-tty-management-cmd-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-um-arp-cfg?module=Cisco-IOS-XR-um-arp-cfg&amp;revision=2019-10-10</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-ncs1004.xml
+++ b/vendor/cisco/xr/711/capabilities-ncs1004.xml
@@ -352,7 +352,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-lsd-cfg?module=Cisco-IOS-XR-mpls-lsd-cfg&amp;revision=2019-08-20</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-bundlemgr-cfg?module=Cisco-IOS-XR-bundlemgr-cfg&amp;revision=2019-05-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-l2rib-cfg?module=Cisco-IOS-XR-l2rib-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/platform/psu?module=openconfig-platform-psu&amp;revision=2018-01-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ikev2-oper?module=Cisco-IOS-XR-ikev2-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ship?module=Cisco-IOS-XR-sysadmin-ship&amp;revision=2019-04-15</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-ncs1k.xml
+++ b/vendor/cisco/xr/711/capabilities-ncs1k.xml
@@ -384,7 +384,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-snmp-mib-rfmib-cfg?module=Cisco-IOS-XR-snmp-mib-rfmib-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tty-management-oper?module=Cisco-IOS-XR-tty-management-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-ntp-admin-oper?module=Cisco-IOS-XR-ip-ntp-admin-oper&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tamsvcs-oper?module=Cisco-IOS-XR-tamsvcs-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/platform/fan?module=openconfig-platform-fan&amp;revision=2018-01-18</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-lsd-cfg?module=Cisco-IOS-XR-mpls-lsd-cfg&amp;revision=2019-08-20</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-ncs540.xml
+++ b/vendor/cisco/xr/711/capabilities-ncs540.xml
@@ -66,7 +66,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-oper?module=Cisco-IOS-XR-infra-syslog-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-object-tracking-datatypes?module=Cisco-IOS-XR-manageability-object-tracking-datatypes&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-VIEW-BASED-ACM-MIB/200210160000Z?module=SNMP-VIEW-BASED-ACM-MIB&amp;revision=2002-10-16</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-um-mpls-ldp-cfg?module=Cisco-IOS-XR-um-mpls-ldp-cfg&amp;revision=2019-12-10</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-cli-ncs5500?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-cli-ncs5500&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-oper?module=Cisco-IOS-XR-segment-routing-ms-oper&amp;revision=2019-07-19</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/711/capabilities-ncs5500.xml
@@ -145,7 +145,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-rmf-oper?module=Cisco-IOS-XR-infra-rmf-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-es-acl-oper?module=Cisco-IOS-XR-es-acl-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-manageability-object-tracking-cfg?module=Cisco-IOS-XR-manageability-object-tracking-cfg&amp;revision=2019-09-07</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/interfaces/ip-ext?module=openconfig-if-ip-ext&amp;revision=2018-11-21</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fm?module=Cisco-IOS-XR-sysadmin-fm&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-MIB/200210160000Z?module=SNMPv2-MIB&amp;revision=2002-10-16</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-ncs560.xml
+++ b/vendor/cisco/xr/711/capabilities-ncs560.xml
@@ -59,7 +59,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-ipv6-oper?module=Cisco-IOS-XR-ip-static-ipv6-oper&amp;revision=2019-06-01</nc:capability>
     <nc:capability>http://openconfig.net/yang/network-instance-types?module=openconfig-network-instance-types&amp;revision=2016-12-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ethernet-lldp-cfg?module=Cisco-IOS-XR-ethernet-lldp-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-sam-oper?module=Cisco-IOS-XR-crypto-sam-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-io-oper?module=Cisco-IOS-XR-mpls-io-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-uea-envmon-ui?module=Cisco-IOS-XR-sysadmin-uea-envmon-ui&amp;revision=2019-04-15</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/711/capabilities-ncs5k.xml
@@ -502,7 +502,7 @@
     <nc:capability>http://openconfig.net/yang/fib-types?module=openconfig-aft-types&amp;revision=2017-05-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-locale-cfg?module=Cisco-IOS-XR-infra-infra-locale-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-alarm-logger-datatypes?module=Cisco-IOS-XR-infra-alarm-logger-datatypes&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ikev2-oper?module=Cisco-IOS-XR-ikev2-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/aft?module=openconfig-aft&amp;revision=2017-05-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-vpn-oper?module=Cisco-IOS-XR-mpls-vpn-oper&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/711/capabilities-ncs6k.xml
@@ -602,7 +602,7 @@
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fpd-infra-cli-fpd-service?module=Cisco-IOS-XR-sysadmin-fpd-infra-cli-fpd-service&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-systemmib-cfg?module=Cisco-IOS-XR-infra-systemmib-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/mpls-sr?module=openconfig-mpls-sr&amp;revision=2017-03-22</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-ssh-cfg?module=Cisco-IOS-XR-crypto-ssh-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-crypto-cepki-cfg?module=Cisco-IOS-XR-crypto-cepki-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-ldp-cfg-datatypes?module=Cisco-IOS-XR-mpls-ldp-cfg-datatypes&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/711/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/711/capabilities-xrv9k.xml
@@ -600,7 +600,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-io-oper?module=Cisco-IOS-XR-ipv6-io-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-USER-BASED-SM-MIB/200210160000Z?module=SNMP-USER-BASED-SM-MIB&amp;revision=2002-10-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-shellutil-delete-act?module=Cisco-IOS-XR-shellutil-delete-act&amp;revision=2019-10-01</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-ospfv3-act?module=Cisco-IOS-XR-ipv6-ospfv3-act&amp;revision=2019-10-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-ldp-cfg-datatypes?module=Cisco-IOS-XR-mpls-ldp-cfg-datatypes&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-ospf-act?module=Cisco-IOS-XR-ipv4-ospf-act&amp;revision=2019-10-01</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-iosxrwbd.xml
+++ b/vendor/cisco/xr/721/capabilities-iosxrwbd.xml
@@ -26,7 +26,7 @@
     <nc:capability>http://www.cisco.com/panini/calvados/valtest?module=valtest&amp;revision=2012-08-20</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-acl-cfg?module=Cisco-IOS-XR-ipv6-acl-cfg&amp;revision=2019-10-22</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-entity-state-mib?module=Cisco-IOS-XR-sysadmin-entity-state-mib&amp;revision=2019-04-15</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-protocol-radius-cfg?module=Cisco-IOS-XR-aaa-protocol-radius-cfg&amp;revision=2019-10-31</nc:capability>
     <nc:capability>http://tail-f.com/ns/aaa/1.1?module=tailf-aaa&amp;revision=2019-05-04</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-sysmgr-act?module=Cisco-IOS-XR-sysmgr-act&amp;revision=2020-01-23</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-ncs1001.xml
+++ b/vendor/cisco/xr/721/capabilities-ncs1001.xml
@@ -136,7 +136,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lpts-lib-cfg?module=Cisco-IOS-XR-lpts-lib-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/panini/calvados/fit?module=fit&amp;revision=2018-06-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv4-bgp-act?module=Cisco-IOS-XR-ipv4-bgp-act&amp;revision=2019-10-01</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-es-acl-datatypes?module=Cisco-IOS-XR-es-acl-datatypes&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ip-static-ipv4-oper?module=Cisco-IOS-XR-ip-static-ipv4-oper&amp;revision=2019-12-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-aaa-diameter-base-mib-cfg?module=Cisco-IOS-XR-aaa-diameter-base-mib-cfg&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-ncs1004.xml
+++ b/vendor/cisco/xr/721/capabilities-ncs1004.xml
@@ -466,7 +466,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-shellutil-delete-act?module=Cisco-IOS-XR-shellutil-delete-act&amp;revision=2019-10-01</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-man-netconf-oper?module=Cisco-IOS-XR-man-netconf-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-hw-module?module=Cisco-IOS-XR-sysadmin-hw-module&amp;revision=2019-04-15</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://tail-f.com/ns/mibs/SNMP-VIEW-BASED-ACM-MIB/200210160000Z?module=SNMP-VIEW-BASED-ACM-MIB&amp;revision=2002-10-16</nc:capability>
     <nc:capability>http://cisco.com/calvados/ccc?module=ccc&amp;revision=2016-10-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-pfi-im-cmd-oper?module=Cisco-IOS-XR-pfi-im-cmd-oper&amp;revision=2019-12-03</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-ncs1k.xml
+++ b/vendor/cisco/xr/721/capabilities-ncs1k.xml
@@ -315,7 +315,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-perf-meas-cfg?module=Cisco-IOS-XR-perf-meas-cfg&amp;revision=2020-03-31</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-serg-cfg?module=Cisco-IOS-XR-infra-serg-cfg&amp;revision=2019-12-12</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-ms-oper?module=Cisco-IOS-XR-segment-routing-ms-oper&amp;revision=2019-07-19</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/local-routing?module=openconfig-local-routing&amp;revision=2017-05-15&amp;deviations=cisco-xr-openconfig-local-routing-deviations</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-um-object-group-cfg?module=Cisco-IOS-XR-um-object-group-cfg&amp;revision=2019-06-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-config-mibs-cfg?module=Cisco-IOS-XR-config-mibs-cfg&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-ncs540.xml
+++ b/vendor/cisco/xr/721/capabilities-ncs540.xml
@@ -528,7 +528,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-freqsync-cfg?module=Cisco-IOS-XR-freqsync-cfg&amp;revision=2020-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-lib-keychain-oper?module=Cisco-IOS-XR-lib-keychain-oper&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-ethsw-esdma-cli-ncs5500?module=Cisco-IOS-XR-sysadmin-ethsw-esdma-cli-ncs5500&amp;revision=2019-04-15</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-oper&amp;revision=2019-12-18</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-plat-chas-invmgr-ng-oper?module=Cisco-IOS-XR-plat-chas-invmgr-ng-oper&amp;revision=2020-05-14</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-drivers-media-eth-act?module=Cisco-IOS-XR-drivers-media-eth-act&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-ncs5500.xml
+++ b/vendor/cisco/xr/721/capabilities-ncs5500.xml
@@ -194,7 +194,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-tty-vty-cfg?module=Cisco-IOS-XR-tty-vty-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-show-trace-instmgr?module=Cisco-IOS-XR-sysadmin-show-trace-instmgr&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-pmengine-clear-act?module=Cisco-IOS-XR-pmengine-clear-act&amp;revision=2019-10-15</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-spirit-install-act?module=Cisco-IOS-XR-spirit-install-act&amp;revision=2019-12-03</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-infra-cfg?module=Cisco-IOS-XR-infra-infra-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/network-instance?module=openconfig-network-instance&amp;revision=2017-01-13</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-ncs560.xml
+++ b/vendor/cisco/xr/721/capabilities-ncs560.xml
@@ -571,7 +571,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-gnss-oper?module=Cisco-IOS-XR-gnss-oper&amp;revision=2019-09-30</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mdrv-lib-cfg?module=Cisco-IOS-XR-mdrv-lib-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-traceroute-act?module=Cisco-IOS-XR-traceroute-act&amp;revision=2019-10-01</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-um-ipv6-access-list-cfg?module=Cisco-IOS-XR-um-ipv6-access-list-cfg&amp;revision=2019-06-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-segment-routing-srv6-cfg?module=Cisco-IOS-XR-segment-routing-srv6-cfg&amp;revision=2019-11-21</nc:capability>
     <nc:capability>http://tail-f.com/ns/netconf/query?module=tailf-netconf-query&amp;revision=2017-01-06</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-ncs5k.xml
+++ b/vendor/cisco/xr/721/capabilities-ncs5k.xml
@@ -576,7 +576,7 @@
     <nc:capability>http://openconfig.net/yang/vlan-types?module=openconfig-vlan-types&amp;revision=2016-05-26</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-man-ipsla-cfg?module=Cisco-IOS-XR-man-ipsla-cfg&amp;revision=2019-05-10</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-notification-log-mib-cfg?module=Cisco-IOS-XR-infra-notification-log-mib-cfg&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-nsr-cfg?module=Cisco-IOS-XR-infra-nsr-cfg&amp;revision=2019-04-05</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-syslog-cfg?module=Cisco-IOS-XR-infra-syslog-cfg&amp;revision=2020-05-22</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-new-dhcpv6d-client-oper?module=Cisco-IOS-XR-ipv6-new-dhcpv6d-client-oper&amp;revision=2019-11-16</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-ncs6k.xml
+++ b/vendor/cisco/xr/721/capabilities-ncs6k.xml
@@ -103,7 +103,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-dwdm-ui-cfg?module=Cisco-IOS-XR-dwdm-ui-cfg&amp;revision=2020-02-04</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-cm?module=Cisco-IOS-XR-sysadmin-cm&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-acl-datatypes?module=Cisco-IOS-XR-ipv6-acl-datatypes&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-mpls-ldp-cfg?module=Cisco-IOS-XR-mpls-ldp-cfg&amp;revision=2019-06-05</nc:capability>
     <nc:capability>http://openconfig.net/yang/alarms/types?module=openconfig-alarm-types&amp;revision=2018-01-16</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-l2-eth-infra-oper?module=Cisco-IOS-XR-l2-eth-infra-oper&amp;revision=2019-04-05</nc:capability>

--- a/vendor/cisco/xr/721/capabilities-xrv9k.xml
+++ b/vendor/cisco/xr/721/capabilities-xrv9k.xml
@@ -619,7 +619,7 @@
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-infra-statsd-act?module=Cisco-IOS-XR-infra-statsd-act&amp;revision=2019-10-01</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-show-inv?module=Cisco-IOS-XR-sysadmin-show-inv&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-ipv6-acl-oper?module=Cisco-IOS-XR-ipv6-acl-oper&amp;revision=2019-04-05</nc:capability>
-    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI&amp;revision=1970-01-01</nc:capability>
+    <nc:capability>http://tail-f.com/ns/mibs/SNMPv2-SMI/1.0?module=SNMPv2-SMI</nc:capability>
     <nc:capability>http://openconfig.net/yang/isis-lsdb-types?module=openconfig-isis-lsdb-types&amp;revision=2018-11-21</nc:capability>
     <nc:capability>http://www.cisco.com/ns/yang/Cisco-IOS-XR-sysadmin-fpd-infra-cli-shhwfpd?module=Cisco-IOS-XR-sysadmin-fpd-infra-cli-shhwfpd&amp;revision=2019-04-15</nc:capability>
     <nc:capability>http://cisco.com/ns/yang/Cisco-IOS-XR-pbr-datatypes?module=Cisco-IOS-XR-pbr-datatypes&amp;revision=2019-04-05</nc:capability>


### PR DESCRIPTION
Removed the revision date from capabilities if the model doesn't carry it.  This caused pyang process when using the capabilities file, e.g. pyang -f tree <capabilities>.