### PR TITLE
Fix to use ieee_dir

### DIFF
--- a/standard/ietf/check.sh
+++ b/standard/ietf/check.sh
@@ -3,18 +3,20 @@
 # Possible IETF check script. Assumes that pyang is on path and that
 # all standard modules are on its internal module path.
 #
+cwd=`pwd`
 ietf_dir="standard/ietf"
+ieee_dir="standard/ieee"
 to_check="RFC"
 
 # relax constraint for now
 # add --ietf if you want to do strict IETF checking
-pyang_flags="--verbose"
+ieee_dir_flag="--path $cwd/$ieee_dir/published/"
+pyang_flags="--verbose $ieee_dir_flag"
 
 checkDir () {
     local dir="$ietf_dir/$1"
     echo Checking yang files in $dir
     exit_status=""
-    cwd=`pwd`
     cd $dir
     printf "\n"
     for f in *.yang; do
@@ -38,4 +40,3 @@ printf "\n    pyang $pyang_flags MODULE\n\n"
 for d in $to_check; do
     checkDir $d
 done
-


### PR DESCRIPTION
Paths to IEEE modules added to pyang search path option.

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>