### PR TITLE
Qcz/d2.0 changes for initial Standards Association ballot 

### DIFF
--- a/standard/ieee/check.sh
+++ b/standard/ieee/check.sh
@@ -5,7 +5,7 @@
 # Also assumes that the script is run from the root of the yang master.
 #
 ieee_dir="standard/ieee"
-to_check="draft/802 draft/802.1 draft/802.1/ABcu draft/802.1/CBcv draft/802.1/CBdb draft/802.1/Qcr draft/802.1/Qcw draft/802.1/Qcx draft/802.1/Qcz draft/802.1/x draft/802.3 published/1906.1 published/802 published/802.1"
+to_check="draft/802 draft/802.1 draft/802.1/ABcu draft/802.1/CBcv draft/802.1/CBdb draft/802.1/Qcw draft/802.1/QRev draft/802.1/Qcz draft/802.1/x draft/802.3 published/1906.1 published/802 published/802.1"
 
 checkDir () 
 {

--- a/standard/ieee/draft/802.1/QRev/ieee802-dot1q-bridge.yang
+++ b/standard/ieee/draft/802.1/QRev/ieee802-dot1q-bridge.yang
@@ -1,0 +1,1792 @@
+module ieee802-dot1q-bridge {
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-bridge;
+  prefix dot1q;
+  import ieee802-types {
+    prefix ieee;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
+  import iana-if-type {
+    prefix ianaif;
+  }
+  import ieee802-dot1q-types {
+    prefix dot1qtypes;
+  }
+  organization
+    "IEEE 802.1 Working Group";
+  contact
+    "WG-URL: http://ieee802.org/1/
+     WG-EMail: stds-802-1-l@ieee.org
+    
+     Contact: IEEE 802.1 Working Group Chair
+     Postal: C/O IEEE 802.1 Working Group
+             IEEE Standards Association
+             445 Hoes Lane
+             Piscataway, NJ 08854
+             USA
+    
+     E-mail: stds-802-1-chairs@ieee.org";
+  description
+    "This YANG module describes the bridge configuration model for the
+    following IEEE 802.1Q Bridges: 
+      1) Two Port MAC Relays
+      2) Customer VLAN Bridges
+      3) Provider Bridges.";
+  revision 2020-11-06 {
+    description
+      "Published as part of IEEE Std 802.1Qcr-2020.
+      Third version.";
+    reference
+      "IEEE Std 802.1Qcr-2020, Bridges and Bridged Networks -
+      Asynchronous Traffic Shaping.";
+  }
+  revision 2020-06-04 {
+    description
+      "Published as part of IEEE Std 802.1Qcx-2020.
+      Second version.";
+    reference
+      "IEEE Std 802.1Qcx-2020, Bridges and Bridged Networks -
+      YANG Data Model for Connectivity Fault Management.";
+  }
+  revision 2018-03-07 {
+    description
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  
+  feature ingress-filtering {
+    description
+      "Each Port may support an Enable Ingress Filtering parameter. A
+      frame received on a Port that is not in the member set (8.8.10)
+      associated with the frames VID shall be discarded if this
+      parameter is set. The default value for this parameter is reset,
+      i.e., Disable Ingress Filtering, for all Ports. Any Port that
+      supports setting this parameter shall also support resetting it.
+      The parameter may be configured by the management operations
+      defined in Clause 12.";
+    reference
+      "8.6.2 of IEEE Std 802.1Q-2018";
+  }
+  feature extended-filtering-services {
+    description
+      "Extended Filtering Services support the filtering behavior
+      required for regions of a network in which potential recipients
+      of multicast frames exist, and where both the potential
+      recipients of frames and the Bridges are able to support dynamic
+      configuration of filtering information for group MAC addresses.
+      In order to integrate this extended filtering behavior with the
+      needs of regions of the network that support only Basic
+      Filtering Services, Bridges that support Extended Filtering
+      Services can be statically and dynamically configured to modify
+      their filtering behavior on a per-group MAC address basis, and
+      also on the basis of the overall filtering service provided by
+      each outbound Port with regard to multicast frames. The latter
+      capability permits configuration of the Ports default forwarding
+      or filtering behavior with regard to group MAC addresses for
+      which no specific static or dynamic filtering information has
+      been configured.";
+    reference
+      "8.8.4 of IEEE Std 802.1Q-2018
+      Clause 10 of IEEE Std 802.1Q-2018";
+  }
+  feature port-and-protocol-based-vlan {
+    description
+      "A VLAN-aware bridge component implementation in conformance to
+      the provisions of this standard for Port-and-Protocol-based VLAN
+      classification (5.4.1) shall 1) Support one or more of the
+      following Protocol Classifications and Protocol Template
+      formats: Ethernet, RFC_1042, SNAP_8021H, SNAP_Other, or
+      LLC_Other (6.12); and may 2) Support configuration of the
+      contents of the Protocol Group Database.";
+    reference
+      "5.4.1.2 of IEEE Std 802.1Q-2018";
+  }
+  feature flow-filtering {
+    description
+      "Flow filtering support enables Bridges to distinguish frames
+      belonging to different client flows and to use this information
+      in the forwarding process. Information related to client flows
+      may be used at the boundary of an SPT Domain to generate a flow
+      hash value. The flow hash, carried in an F-TAG, serves to
+      distinguish frames belonging to different flows and can be used
+      in the forwarding process to distribute frames over equal cost
+      paths. This provides for finer granularity load spreading while
+      maintaining frame order for each client flow.";
+    reference
+      "44.2 of IEEE Std 802.1Q-2018";
+  }
+  feature simple-bridge-port {
+    description
+      "A simple bridge port allows underlying (MAC) layers to share
+      the same Interface as the Bridge Port.";
+  }
+  feature flexible-bridge-port {
+    description
+      "A flexible bridge port supports an Interface that is a Bridge
+      Port to be a separate Interface from the underlying (MAC) layer.";
+  }
+  
+  identity type-of-bridge {
+    description
+      "Represents the configured Bridge type.";
+  }
+  identity customer-vlan-bridge {
+    base type-of-bridge;
+    description
+      "Base identity for a Customer VLAN Bridge.";
+  }
+  identity provider-bridge {
+    base type-of-bridge;
+    description
+      "Base identity for a Provider Bridge (PB).";
+  }
+  identity provider-edge-bridge {
+    base type-of-bridge;
+    description
+      "Base identity for a Provider Edge Bridge (PEB).";
+  }
+  identity two-port-mac-relay-bridge {
+    base type-of-bridge;
+    description
+      "Base identity for a Two Port MAC Relay (TPMR).";
+  }
+  identity type-of-component {
+    description
+      "Represents the type of Component.";
+  }
+  identity c-vlan-component {
+    base type-of-component;
+    description
+      "Base identity for a C-VLAN component.";
+  }
+  identity s-vlan-component {
+    base type-of-component;
+    description
+      "Base identity for a S-VLAN component.";
+  }
+  identity d-bridge-component {
+    base type-of-component;
+    description
+      "Base identity for a VLAN unaware component.";
+  }
+  identity edge-relay-component {
+    base type-of-component;
+    description
+      "Base identity for an EVB station ER component.";
+  }
+  identity type-of-port {
+    description
+      "Represents the type of Bridge port.";
+  }
+  identity c-vlan-bridge-port {
+    base type-of-port;
+    description
+      "Indicates the port can be a C-TAG aware port of an enterprise
+      VLAN aware Bridge.";
+  }
+  identity provider-network-port {
+    base type-of-port;
+    description
+      "Indicates the port can be an S-TAG aware port of a Provider
+      Bridge or Backbone Edge Bridge used for connections within a PBN
+      (Provider Bridged Network) or PBBN (Provider Backbone Bridged
+      Network).";
+  }
+  identity customer-network-port {
+    base type-of-port;
+    description
+      "Indicates the port can be an S-TAG aware port of a Provider
+      Bridge or Backbone Edge Bridge used for connections to the
+      exterior of a PBN (Provider Bridged Network) or PBBN (Provider
+      Backbone Bridged Network).";
+  }
+  identity customer-edge-port {
+    base type-of-port;
+    description
+      "Indicates the port can be a C-TAG aware port of a Provider
+      Bridge used for connections to the exterior of a PBN (Provider
+      Bridged Network) or PBBN (Provider Backbone Bridged Network).";
+  }
+  identity d-bridge-port {
+    base type-of-port;
+    description
+      "Indicates the port can be a VLAN-unaware member of an 802.1Q
+      Bridge.";
+  }
+  identity remote-customer-access-port {
+    base type-of-port;
+    description
+      "Indicates the port can be an S-TAG aware port of a Provider
+      Bridge capable of providing Remote Customer Service Interfaces.";
+  }
+  identity bridge-interface {
+    description
+      "Generic interface property that represents any interface that
+      can be associated with an IEEE 802.1Q compliant Bridge
+      component. Any new Interface types would derive from this
+      identity to automatically pick up Bridge related configuration
+      or operational data.";
+  }
+   
+  container bridges {
+    description
+      "Contains the Bridge(s) configuration information.";
+    list bridge {
+      key "name";
+      unique "address";
+      description
+        "Provides configuration data in support of the Bridge
+        Configuration resources. There is a single bridge data node
+        per Bridge.";
+      leaf name {
+        type dot1qtypes:name-type;
+        description
+          "A text string associated with the Bridge, of locally
+          determined significance.";
+        reference
+          "12.4 of IEEE Std 802.1Q-2018";
+      }
+      leaf address {
+        type ieee:mac-address;
+        mandatory true;
+        description
+          "The MAC address for the Bridge from which the Bridge
+          Identifiers used by the STP, RSTP, and MSTP are derived.";
+        reference
+          "12.4 of IEEE Std 802.1Q-2018";
+      }
+      leaf bridge-type {
+        type identityref {
+          base type-of-bridge;
+        }
+        mandatory true;
+        description
+          "The type of Bridge.";
+      }
+      leaf ports {
+        type uint16 {
+          range "1..4095";
+        }
+        config false;
+        description
+          "The number of Bridge Ports (MAC Entities)";
+        reference
+          "12.4 of IEEE Std 802.1Q-2018";
+      }
+      leaf up-time {
+        type yang:zero-based-counter32;
+        units "seconds";
+        config false;
+        description
+          "The count in seconds of the time elapsed since the Bridge
+          was last reset or initialized.";
+        reference
+          "12.4 of IEEE Std 802.1Q-2018";
+      }
+      leaf components {
+        type uint32;
+        config false;
+        description
+          "The number of components associated with the Bridge.";
+      }
+      list component {
+        key "name";
+        description
+          "The set of components associated with a given Bridge. For
+          example, - A TPMR is associated with a single VLAN
+          unaware component. - A Customer VLAN Bridge is associated
+          with a single VLAN aware component. - A Provider Bridge is
+          associated with a single S-VLAN component and zero or more
+          C-VLAN components.";
+        reference
+          "12.3 of IEEE Std 802.1Q-2018";
+        leaf name {
+          type string;
+          description
+            "The name of the Component.";
+        }
+        leaf id {
+          type uint32;
+          description
+            "Unique identifier for a particular Bridge component
+            within the system.";
+          reference
+            "12.3, item l) of IEEE Std 802.1Q-2018";
+        }
+        leaf type {
+          type identityref {
+            base type-of-component;
+          }
+          mandatory true;
+          description
+            "The type of component used to classify a particular
+            Bridge component within a Bridge system comprising
+            multiple components.";
+          reference
+            "12.3, item m) of IEEE Std 802.1Q-2018";
+        }
+        leaf address {
+          type ieee:mac-address;
+          description
+            "Unique EUI-48 Universally Administered MAC address
+            assigned to a Bridge component.";
+          reference
+            "13.24 of IEEE Std 802.1Q-2018
+            8.13.8 of IEEE Std 802.1Q-2018";
+        }
+        leaf traffic-class-enabled {
+          type boolean;
+          default "true";
+          description
+            "Indication of Traffic Classes enablement associated with
+            the Bridge Component. A value of True indicates that
+            Traffic Classes are enabled on this Bridge Component. A
+            value of False indicates that the Bridge Component
+            operates with a single priority level for all traffic.";
+          reference
+            "12.4.1.5.1 of IEEE Std 802.1Q-2018";
+        }
+        leaf ports {
+          type uint16 {
+            range "1..4095";
+          }
+          config false;
+          description
+            "The number of Bridge Ports associated with the Bridge
+            Component.";
+          reference
+            "12.4.1.1.3, item c) of IEEE Std 802.1Q-2018";
+        }
+        leaf-list bridge-port {
+          type if:interface-ref;
+          config false;
+          description
+            "List of bridge-port references.";
+        }
+        container capabilities {
+          config false;
+          description
+            "Array of Boolean values of the feature capabilities
+            associated with a given Bridge Component.";
+          reference
+            "12.10.1.1.3, item b) of IEEE Std 802.1Q-2018
+            12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          leaf extended-filtering {
+            type boolean;
+            default "false";
+            description
+              "Can perform filtering on individual multicast addresses
+              controlled by MMRP.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf traffic-classes {
+            type boolean;
+            default "false";
+            description
+              "Can map priority to multiple traffic classes.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf static-entry-individual-port {
+            type boolean;
+            default "false";
+            description
+              "Static entries per port.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf ivl-capable {
+            type boolean;
+            default "true";
+            description
+              "Independent VLAN Learning (IVL).";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf svl-capable {
+            type boolean;
+            default "false";
+            description
+              "Shared VLAN Learning (SVL).";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf hybrid-capable {
+            type boolean;
+            default "false";
+            description
+              "Both IVL and SVL simultaneously.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf configurable-pvid-tagging {
+            type boolean;
+            default "false";
+            description
+              "Whether the implementation supports the ability to
+              override the default PVID setting and its egress status
+              (VLAN-tagged or Untagged) on each port.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf local-vlan-capable {
+            type boolean;
+            default "false";
+            description
+              "Can support multiple local Bridges, outside the scope
+              of 802.1Q defined VLANs.";
+            reference
+              "12.4.1.5.2 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container filtering-database {
+          when "../../bridge-type != 'two-port-mac-relay-bridge'" {
+            description
+              "Applies to non TPMRs.";
+          }
+          description
+            "Contains filtering information used by the Forwarding
+            Process in deciding through which Ports of the Bridge
+            frames should be forwarded.";
+          reference
+            "12.7 of IEEE Std 802.1Q-2018";
+          leaf aging-time {
+            type uint32 {
+              range "10..10000000";
+            }
+            units "seconds";
+            default "300";
+            description
+              "The timeout period in seconds for aging out
+              dynamically-learned forwarding information.";
+            reference
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf size {
+            type yang:gauge32;
+            config false;
+            description
+              "The maximum number of entries that can be held in the
+              FDB.";
+            reference
+              "12.7 of IEEE Std 802.1Q-2018";
+          }
+          leaf static-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static Filtering entries currently in the
+              FDB.";
+            reference
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.1 of IEEE Std 802.1Q-2018";
+          }
+          leaf dynamic-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Dynamic Filtering entries currently in
+              the FDB.";
+            reference
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf static-vlan-registration-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static VLAN Registration entries
+              currently in the FDB.";
+            reference
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf dynamic-vlan-registration-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Dynamic VLAN Registration entries
+              currently in the FDB.";
+            reference
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.5 of IEEE Std 802.1Q-2018";
+          }
+          leaf mac-address-registration-entries {
+            if-feature "extended-filtering-services";
+            type yang:gauge32;
+            config false;
+            description
+              "The number of MAC Address Registration entries
+              currently in the FDB.";
+            reference
+              "12.7 of IEEE Std 802.1Q-2018
+              8.8.4 of IEEE Std 802.1Q-2018";
+          }
+          list filtering-entry {
+            key "database-id vids address";
+            description
+              "Information for the entries associated with the
+              Permanent Database.";
+            leaf database-id {
+              type uint32;
+              description
+                "The identity of this Filtering Database.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf address {
+              type ieee:mac-address;
+              description
+                "A MAC address (unicast, multicast, broadcast) for
+                which the device has forwarding and/or filtering
+                information.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "The set of VLAN identifiers to which this entry
+                applies.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf entry-type {
+              type enumeration {
+                enum static {
+                  description
+                    "Static entry type";
+                }
+                enum dynamic {
+                  description
+                    "Dynamic/learnt entry type";
+                }
+              }
+              description
+                "The type of filtering entry. Whether static or
+                dynamic. Static entries can be created, deleted, and
+                retrieved. However, dynamic entries can only be
+                deleted or retrieved by the management entity.
+                Consequently, a Bridge is not required to accept a
+                command that can alter the dynamic entries except
+                delete a dynamic entry.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            uses dot1qtypes:port-map-grouping;
+            leaf status {
+              type enumeration {
+                enum other {
+                  description
+                    "None of the following. This may include the case
+                    where some other object is being used to determine
+                    if and how frames addressed to the value of the
+                    corresponding instance of 'address' are being
+                    forwarded.";
+                }
+                enum invalid {
+                  description
+                    "This entry is no longer valid (e.g., it was
+                    learned but has since aged out), but has not yet
+                    been flushed from the table.";
+                }
+                enum learned {
+                  description
+                    "The value of the corresponding instance of the
+                    port node was learned and is being used.";
+                }
+                enum self {
+                  description
+                    "The value of the corresponding instance of the
+                    address node representing one of the devices
+                    address.";
+                }
+                enum mgmt {
+                  description
+                    "The value of the corresponding instance of
+                    address node that is also the value of an existing
+                    instance.";
+                }
+              }
+              config false;
+              description
+                "The status of this entry.";
+            }
+          }
+          list vlan-registration-entry {
+            key "database-id vids";
+            description
+              "The VLAN Registration Entries models the operations
+              that can be performed on a single VLAN Registration
+              Entry in the FDB. The set of VLAN Registration Entries
+              within the FDB changes under management control and also
+              as a result of MVRP exchanges";
+            reference
+              "12.7.5 of IEEE Std 802.1Q-2018";
+            leaf database-id {
+              type uint32;
+              description
+                "The identity of this Filtering Database.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "The set of VLAN identifiers to which this entry
+                applies.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf entry-type {
+              type enumeration {
+                enum static {
+                  description
+                    "Static entry type";
+                }
+                enum dynamic {
+                  description
+                    "Dynamic/learnt entry type";
+                }
+              }
+              description
+                "The type of filtering entry. Whether static or
+                dynamic. Static entries can be created, deleted, and
+                retrieved. However, dynamic entries can only be
+                deleted or retrieved by the management entity.
+                Consequently, a Bridge is not required to accept a
+                command that can alter the dynamic entries except
+                delete a dynamic entry.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            uses dot1qtypes:port-map-grouping;
+          }
+        }
+        container permanent-database {
+          description
+            "The Permanent Database container models the operations
+            that can be performed on, or affect, the Permanent
+            Database. There is a single Permanent Database per FDB.";
+          leaf size {
+            type yang:gauge32;
+            config false;
+            description
+              "The maximum number of entries that can be held in the
+              FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q-2018";
+          }
+          leaf static-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static Filtering entries currently in the
+              FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q-2018";
+          }
+          leaf static-vlan-registration-entries {
+            type yang:gauge32;
+            config false;
+            description
+              "The number of Static VLAN Registration entries
+              currently in the FDB.";
+            reference
+              "12.7.6 of IEEE Std 802.1Q-2018";
+          }
+          list filtering-entry {
+            key "database-id vids address";
+            description
+              "Information for the entries associated with the
+              Permanent Database.";
+            leaf database-id {
+              type uint32;
+              description
+                "The identity of this Filtering Database.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf address {
+              type ieee:mac-address;
+              description
+                "A MAC address (unicast, multicast, broadcast) for
+                which the device has forwarding and/or filtering
+                information.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "The set of VLAN identifiers to which this entry
+                applies.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf status {
+              type enumeration {
+                enum other {
+                  description
+                    "None of the following. This may include the case
+                    where some other object is being used to determine
+                    if and how frames addressed to the value of the
+                    corresponding instance of 'address' are being
+                    forwarded.";
+                }
+                enum invalid {
+                  description
+                    "This entry is no longer valid (e.g., it was
+                    learned but has since aged out), but has not yet
+                    been flushed from the table.";
+                }
+                enum learned {
+                  description
+                    "The value of the corresponding instance of the
+                    port node was learned and is being used.";
+                }
+                enum self {
+                  description
+                    "The value of the corresponding instance of the
+                    address node representing one of the devices
+                    address.";
+                }
+                enum mgmt {
+                  description
+                    "The value of the corresponding instance of
+                    address node that is also the value of an existing
+                    instance.";
+                }
+              }
+              config false;
+              description
+                "The status of this entry.";
+            }
+            uses dot1qtypes:port-map-grouping;
+          }
+        }
+        container bridge-vlan {
+          when "../../bridge-type != 'two-port-mac-relay-bridge'" {
+            description
+              "Applies to non TPMRs.";
+          }
+          description
+            "The Bridge VLAN container models configuration
+            information that modify, or inquire about, the overall
+            configuration of the Bridges VLAN resources. There is a
+            single Bridge VLAN Configuration managed object per
+            Bridge.";
+          reference
+            "12.10 of IEEE Std 802.1Q-2018";
+          leaf version {
+            type uint16;
+            config false;
+            description
+              "The version number supported.";
+            reference
+              "12.10.1.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf max-vids {
+            type uint16;
+            config false;
+            description
+              "The maximum number of VIDs supported.";
+            reference
+              "12.10.1.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf override-default-pvid {
+            type boolean;
+            default "false";
+            config false;
+            description
+              "Indicates if the default PVID can be overridden, and
+              its egress status (VLAN-tagged or untagged) on each
+              port.";
+            reference
+              "12.10.1.3 of IEEE Std 802.1Q-2018";
+          }
+          leaf protocol-template {
+            if-feature "port-and-protocol-based-vlan";
+            type dot1qtypes:protocol-frame-format-type;
+            config false;
+            description
+              "The data-link encapsulation format or the
+              detagged_frame_type in a Protocol Template";
+            reference
+              "12.10.1.7 of IEEE Std 802.1Q-2018";
+          }
+          leaf max-msti {
+            type uint16;
+            config false;
+            description
+              "The maximum number of MSTIs supported within an MST
+              region (i.e., the number of spanning tree instances that
+              can be supported in addition to the CIST), for MST
+              Bridges. For SST Bridges, this parameter may be either
+              omitted or reported as 0.";
+            reference
+              "12.10.1.7 of IEEE Std 802.1Q-2018";
+          }
+          list vlan {
+            key "vid";
+            description
+              "List of VLAN related configuration nodes associated
+              with the Bridge.";
+            reference
+              "12.10.2 of IEEE Std 802.1Q-2018";
+            leaf vid {
+              type dot1qtypes:vlan-index-type;
+              description
+                "The VLAN identifier to which this entry applies.";
+              reference
+                "12.10.2 of IEEE Std 802.1Q-2018";
+            }
+            leaf name {
+              type dot1qtypes:name-type;
+              description
+                "A text string of up to 32 characters of locally
+                determined significance.";
+              reference
+                "12.10.2 of IEEE Std 802.1Q-2018";
+            }
+            leaf-list untagged-ports {
+              type if:interface-ref;
+              config false;
+              description
+                "The set of ports in the untagged set for this VID.";
+              reference
+                "12.10.2.1.3 of IEEE Std 802.1Q-2018
+                8.8.2 of IEEE Std 802.1Q-2018";
+            }
+            leaf-list egress-ports {
+              type if:interface-ref;
+              config false;
+              description
+                "The set of egress ports in the member set for this
+                VID.";
+              reference
+                "12.10.2.1.3 of IEEE Std 802.1Q-2018
+                8.8.10 of IEEE Std 802.1Q-2018";
+            }
+          }
+          list protocol-group-database {
+            if-feature "port-and-protocol-based-vlan";
+            key "db-index";
+            description
+              "List of the protocol group database entries.";
+            reference
+              "12.10.1.7 of IEEE Std 802.1Q-2018
+              6.12.3 of IEEE Std 802.1Q-2018";
+            leaf db-index {
+              type uint16;
+              description
+                "The protocol group database index.";
+            }
+            leaf frame-format-type {
+              type dot1qtypes:protocol-frame-format-type;
+              description
+                "The data-link encapsulation format or the
+                detagged_frame_type in a Protocol Template";
+              reference
+                "12.10.1.7 of IEEE Std 802.1Q-2018";
+            }
+            choice frame-format {
+              description
+                "The identification of the protocol above the
+                data-link layer in a Protocol Template. Depending on
+                the frame type, the octet string will have one of the
+                following values: - For ethernet, rfc1042 and
+                snap8021H, this is the 16-bit (2-octet) IEEE 802
+                Clause 9.3 EtherType field. - For snapOther, this is
+                the 40-bit (5-octet) PID. - For llcOther, this is the
+                2-octet IEEE 802.2 Link Service Access Point (LSAP)
+                pair: first octet for Destination Service Access Point
+                (DSAP) and second octet for Source Service Access
+                Point (SSAP).";
+              reference
+                "12.10.1.7 of IEEE Std 802.1Q-2018";
+              case ethernet-rfc1042-snap8021H {
+                when
+                  "frame-format-type = 'Ethernet' or "+
+                  "frame-format-type = 'rfc1042' or "+
+                  "frame-format-type = 'snap8021H'" {
+                  description
+                    "Applies to Ethernet, RFC 1042, SNAP 8021H frame
+                    formats.";
+                }
+                description
+                  "Identifier used if Ethenet, RFC1042, or SNAP 8021H.";
+                leaf ethertype {
+                  type dot1qtypes:ethertype-type;
+                  description
+                    "Format containing the 16-bit IEEE 802 EtherType
+                    field.";
+                  reference
+                    "9.3 of IEEE Std 802-2014";
+                }
+              }
+              case snap-other {
+                when "frame-format-type = 'snapOther'" {
+                  description
+                    "Applies to Snap Other frame formats.";
+                }
+                description
+                  "Identifier used if SNAP other.";
+                leaf protocol-id {
+                  type string {
+                    pattern "[0-9a-fA-F]{2}(-[0-9a-fA-F]{2}){4}";
+                  }
+                  description
+                    "Format containing the 40-bit protocol identifier
+                    (PID). The canonical representation uses uppercase
+                    characters.";
+                  reference
+                    "12.10.1.7.1 of IEEE Std 802.1Q-2018";
+                }
+              }
+              case llc-other {
+                when "frame-format-type = 'llcOther'" {
+                  description
+                    "Applies to LLC Other frame formats";
+                }
+                description
+                  "Identifier used if LLC other.";
+                container dsap-ssap-pairs {
+                  description
+                    "A pair of ISO/IEC 8802-2 DSAP and SSAP address
+                    field values, for matching frame formats of
+                    LLC_Other.";
+                  leaf llc-address {
+                    type string {
+                      pattern "[0-9a-fA-F]{2}-[0-9a-fA-F]{2}";
+                    }
+                    description
+                      "A pair of ISO/IEC 8802-2 DSAP and SSAP address
+                      field values, for matching frame formats of
+                      LLC_Other. The canonical representation uses
+                      uppercase characters.";
+                    reference
+                      "12.10.1.7.1 of IEEE Std 802.1Q-2018";
+                  }
+                }
+              }
+            }
+            leaf group-id {
+              type uint32;
+              description
+                "Designates a group of protocols in the Protocol Group
+                Database.";
+              reference
+                "6.12.2 of IEEE Std 802.1Q-2018";
+            }
+          }
+          list vid-to-fid-allocation {
+            key "vids";
+            description
+              "This list allows inquiries about VID to FID
+              allocations.";
+            leaf vids {
+              type dot1qtypes:vid-range-type;
+              description
+                "Range of VLAN identifiers.";
+              reference
+                "12.10.3 of IEEE Std 802.1Q-2018";
+            }
+            leaf fid {
+              type uint32;
+              config false;
+              description
+                "The Filtering Database used by a set of VIDs.";
+              reference
+                "12.10.3 of IEEE Std 802.1Q-2018";
+            }
+            leaf allocation-type {
+              type enumeration {
+                enum undefined {
+                  description
+                    "No allocation defined.";
+                }
+                enum fixed {
+                  description
+                    "A fixed allocation to FID is defined.";
+                }
+                enum dynamic {
+                  description
+                    "A dynamic allocation to FID is defined.";
+                }
+              }
+              config false;
+              description
+                "The type of allocation used";
+              reference
+                "12.10.3 of IEEE Std 802.1Q-2018";
+            }
+          }
+          list fid-to-vid-allocation {
+            key "fid";
+            description
+              "The FID to VID allocations managed object models
+              operations that inquire about FID to VID allocations.";
+            leaf fid {
+              type uint32;
+              description
+                "The Filtering Database used by a set of VIDs.";
+              reference
+                "12.10.3 of IEEE Std 802.1Q-2018";
+            }
+            leaf allocation-type {
+              type enumeration {
+                enum undefined {
+                  description
+                    "No allocation defined.";
+                }
+                enum fixed {
+                  description
+                    "A fixed allocation to FID is defined.";
+                }
+                enum dynamic {
+                  description
+                    "A dynamic allocation to FID is defined.";
+                }
+              }
+              config false;
+              description
+                "The type of allocation used";
+              reference
+                "12.10.3 of IEEE Std 802.1Q-2018";
+            }
+            leaf-list vid {
+              type dot1qtypes:vlan-index-type;
+              config false;
+              description
+                "The VLAN identifier to which this entry applies.";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+          }
+          list vid-to-fid {
+            key "vid";
+            description
+              "Fixed allocation of a VID to an FID. The underlying
+              system will ensure that subsequent commands that make
+              changes to the VID to FID mapping can override previous
+              associations.";
+            reference
+              "12.10.3.4 of IEEE Std 802.1Q-2018
+              12.10.3.5 of IEEE Std 802.1Q-2018";
+            leaf vid {
+              type dot1qtypes:vlan-index-type;
+              description
+                "A list of VLAN identifier associated with a given
+                database identifier (i.e., FID).";
+              reference
+                "12.7.7 of IEEE Std 802.1Q-2018";
+            }
+            leaf fid {
+              type uint32;
+              description
+                "The Filtering Database used by this VLAN";
+              reference
+                "12.10.3 of IEEE Std 802.1Q-2018";
+            }
+          }
+        }
+        container bridge-mst {
+          when "../../bridge-type != 'two-port-mac-relay-bridge'" {
+            description
+              "Applies to non TPMRs.";
+          }
+          description
+            "The Bridge MST container models configuration information
+            that modify, or inquire about, the overall configuration
+            of the Bridges MST resources.";
+          reference
+            "12.12 of IEEE Std 802.1Q-2018";
+          leaf-list mstid {
+            type dot1qtypes:mstid-type;
+            description
+              "The list of MSTID values that are currently supported
+              by the Bridge";
+          }
+          list fid-to-mstid {
+            key "fid";
+            description
+              "The FID to MSTID allocation table.";
+            reference
+              "12.12.2 of IEEE Std 802.1Q-2018";
+            leaf fid {
+              type uint32;
+              description
+                "The Filtering Database identifier.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q-2018";
+            }
+            leaf mstid {
+              type dot1qtypes:mstid-type;
+              description
+                "The MSTID to which the FID is to be allocated.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q-2018";
+            }
+          }
+          list fid-to-mstid-allocation {
+            key "fids";
+            description
+              "The FID to MSTID allocation table";
+            leaf fids {
+              type dot1qtypes:vid-range-type;
+              description
+                "Range of FIDs.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q-2018";
+            }
+            leaf mstid {
+              type dot1qtypes:mstid-type;
+              description
+                "The MSTID to which the FID is allocated.";
+              reference
+                "12.12.2 of IEEE Std 802.1Q-2018";
+            }
+          }
+        }
+      }
+    }
+  }
+  augment "/if:interfaces/if:interface" {
+    when
+      "if:type = 'ianaif:bridge' or if:type ="+
+      "'ianaif:ethernetCsmacd' or if:type = 'ianaif:ieee8023adLag'"+
+      "or if:type = 'ianaif:ilan'" {
+      description
+        "Applies when a Bridge interface.";
+    }
+    description
+      "Augment the interface model with the Bridge Port";
+    container bridge-port {
+      description
+        "Bridge Port is an extension of the IETF Interfaces model
+        (RFC7223).";
+      leaf component-name {
+        type string;
+        description
+          "Used to reference configured Component node.";
+      }
+      leaf port-type {
+        type identityref {
+          base type-of-port;
+        }
+        description
+          "The port type. Indicates the capabilities of this port.";
+        reference
+          "12.4.2.1 of IEEE Std 802.1Q-2018";
+      }
+      leaf pvid {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type dot1qtypes:vlan-index-type;
+        default "1";
+        description
+          "The primary (default) VID assigned to a specific Bridge
+          Port.";
+        reference
+          "12.10.1 of IEEE Std 802.1Q-2018
+          5.4, item m) of IEEE Std 802.1Q-2018";
+      }
+      leaf default-priority {
+        type dot1qtypes:priority-type;
+        default "0";
+        description
+          "The default priority assigned to a specific Bridge Port.";
+        reference
+          "12.6.2 of IEEE Std 802.1Q-2018";
+      }
+      container priority-regeneration {
+        description
+          "The Priority Regeneration Table parameters associated with
+          a specific Bridge Port. A list of Regenerated User
+          Priorities for each received priority on each port of a
+          Bridge. The regenerated priority value may be used to index
+          the Traffic Class Table for each input port. This only has
+          effect on media that support native priority. The default
+          values for Regenerated User Priorities are the same as the
+          User Priorities";
+        reference
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.9.4 of IEEE Std 802.1Q-2018";
+        uses dot1qtypes:priority-regeneration-table-grouping;
+      }
+      leaf pcp-selection {
+        type dot1qtypes:pcp-selection-type;
+        default "8P0D";
+        description
+          "The Priority Code Point selection assigned to a specific
+          Bridge Port. This object identifies the rows in the PCP
+          encoding and decoding tables that are used to remark frames
+          on this port if this remarking is enabled";
+        reference
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
+      }
+      container pcp-decoding-table {
+        description
+          "The Priority Code Point Decoding Table parameters
+          associated with a specific Bridge Port.";
+        uses dot1qtypes:pcp-decoding-table-grouping;
+      }
+      container pcp-encoding-table {
+        description
+          "The Priority Code Point Encoding Table parameters
+          associated with a specific Bridge Port.";
+        uses dot1qtypes:pcp-encoding-table-grouping;
+      }
+      leaf use-dei {
+        type boolean;
+        default "false";
+        description
+          "The Drop Eligible Indicator. If it is set to True, then the
+          drop_eligible parameter is encoded in the DEI of transmitted
+          frames, and the drop_eligible parameter shall be true(1) for
+          a received frame if the DEI is set in the VLAN tag or the
+          Priority Code Point Decoding Table indicates drop_eligible
+          True for the received PCP value. If this parameter is False,
+          the DEI shall be transmitted as zero and ignored on receipt.";
+        reference
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
+      }
+      leaf drop-encoding {
+        type boolean;
+        default "false";
+        description
+          "The Drop Encoding parameter. If a Bridge supports encoding
+          or decoding of drop_eligible from the PCP field of a VLAN
+          tag (6.7.3) on any of its Ports, then it shall implement a
+          Boolean parameter Require Drop Encoding on each of its Ports
+          with default value False. If Require Drop Encoding is True
+          and the Bridge Port cannot encode particular priorities with
+          drop_eligible, then frames queued with those priorities and
+          drop_eligible True shall be discarded and not transmitted.";
+        reference
+          "12.6.2 of IEEE Std 802.1Q-2018
+          8.6.6 of IEEE Std 802.1Q-2018";
+      }
+      leaf service-access-priority-selection {
+        type boolean;
+        default "false";
+        description
+          "The Service Access Priority selection. Indication of
+          whether the Service Access Priority Selection function is
+          supported on the Customer Bridge Port to request priority
+          handling of the frame from a Port-based service interface.";
+        reference
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.13 of IEEE Std 802.1Q-2018";
+      }
+      container service-access-priority {
+        description
+          "The Service Access Priority table parameters. A table that
+          contains information about the Service Access Priority
+          Selection function for a Provider Bridge. The use of this
+          table enables a mechanism for a Customer Bridge attached to
+          a Provider Bridged Network to request priority handling of
+          frames.";
+        reference
+          "12.6.2 of IEEE Std 802.1Q-2018
+          6.13.1 of IEEE Std 802.1Q-2018";
+        uses dot1qtypes:service-access-priority-table-grouping;
+      }
+      container traffic-class {
+        description
+          "The Traffic Class table parameters. A table mapping
+          evaluated priority to Traffic Class, for forwarding by the
+          Bridge";
+        reference
+          "12.6.3 of IEEE Std 802.1Q-2018
+          8.6.6 of IEEE Std 802.1Q-2018";
+        uses dot1qtypes:traffic-class-table-grouping;
+      }
+      container transmission-selection-algorithm-table {
+        description
+          "The Transmission Selection Algorithm Table for a given Port assigns,
+          for each traffic class that the Port supports, the transmission
+          selection algorithm that is to be used to select frames for
+          transmission from the corresponding queue. Transmission Selection
+          Algorithm Tables may be managed, and allow the identification of
+          vendor-specific transmission selection algorithms. The transmission
+          selection algorithms are identified in the Transmission Selection
+          Algorithm Table by means of integer identifiers.";
+        reference
+          "12.20.2 of IEEE Std 802.1Q-2018
+          8.6.8 of IEEE Std 802.1Q-2018";
+        uses dot1qtypes:transmission-selection-table-grouping;
+      }
+      leaf acceptable-frame {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type enumeration {
+          enum admit-only-VLAN-tagged-frames {
+            description
+              "Admit only VLAN-tagged frames.";
+          }
+          enum admit-only-untagged-and-priority-tagged {
+            description
+              "Admit only untagged and priority-tagged frames.";
+          }
+          enum admit-all-frames {
+            description
+              "Admit all frames.";
+          }
+        }
+        default "admit-all-frames";
+        description
+          "To configure the Acceptable Frame Types parameter
+          associated with one or more Ports";
+        reference
+          "12.10.1.3 of IEEE Std 802.1Q-2018
+          6.9 of IEEE Std 802.1Q-2018";
+      }
+      leaf enable-ingress-filtering {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type boolean;
+        default "false";
+        description
+          "To enable the Ingress Filtering feature associated with one
+          or more Ports.";
+        reference
+          "12.10.1.4 of IEEE Std 802.1Q-2018
+          8.6.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf enable-restricted-vlan-registration {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type boolean;
+        default "false";
+        description
+          "To enable the Restricted VLAN Registration associated with
+          one or more Ports.";
+        reference
+          "11.2.3.2.3 of IEEE Std 802.1Q-2018
+          12.10.1.6 of IEEE Std 802.1Q-2018";
+      }
+      leaf enable-vid-translation-table {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type boolean;
+        default "false";
+        description
+          "To enable VID Translation table associated with a Bridge
+          Port. This is not applicable to Bridge Ports that do no
+          support a VID Translation Table.";
+        reference
+          "12.10.1.8 of IEEE Std 802.1Q-2018
+          6.9 of IEEE Std 802.1Q-2018";
+      }
+      leaf enable-egress-vid-translation-table {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        type boolean;
+        default "false";
+        description
+          "To enable Egress VID Translation table associated with a
+          Bridge Port. This is not applicable to Ports that do not
+          support an Egress VID Translation table.";
+        reference
+          "12.10.1.9 of IEEE Std 802.1Q-2018
+          6.9 of IEEE Std 802.1Q-2018";
+      }
+      list protocol-group-vid-set {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        if-feature "port-and-protocol-based-vlan";
+        key "group-id";
+        description
+          "The list of VID values associated with the Protocol Group
+          Identifier for this port.";
+        reference
+          "12.10.1.1.3 of IEEE Std 802.1Q-2018";
+        leaf group-id {
+          type uint32;
+          description
+            "The protocol group identifier";
+          reference
+            "12.10.1.7 of IEEE Std 802.1Q-2018";
+        }
+        leaf-list vid {
+          type dot1qtypes:vlanid;
+          description
+            "The VLAN identifier to which this entry applies.";
+          reference
+            "12.10.2 of IEEE Std 802.1Q-2018";
+        }
+      }
+      leaf admin-point-to-point {
+        type enumeration {
+          enum force-true {
+            value 1;
+            description
+              "Indicates that this port should always be treated as if
+              it is connected to a point-to-point link.";
+          }
+          enum force-false {
+            value 2;
+            description
+              "Indicates that this port should be treated as having a
+              shared media connection.";
+          }
+          enum auto {
+            value 3;
+            description
+              "Indicates that this port is considered to have a
+              point-to-point link if it is an Aggregator and all of
+              its members are aggregatable, or if the MAC entity is
+              configured for full duplex operation, either through
+              auto-negotiation or by management means.";
+          }
+        }
+        description
+          "For a port running spanning tree, this object represents
+          the administrative point-to-point status of the LAN segment
+          attached to this port, using the enumeration values of IEEE
+          Std 802.1AC. A value of forceTrue(1) indicates that this
+          port should always be treated as if it is connected to a
+          point-to-point link. A value of forceFalse(2) indicates that
+          this port should be treated as having a shared media
+          connection. A value of auto(3) indicates that this port is
+          considered to have a point-to-point link if it is an
+          Aggregator and all of its members are aggregatable, or if
+          the MAC entity is configured for full duplex operation,
+          either through auto-negotiation or by management means.
+          Manipulating this object changes the underlying
+          adminPointToPointMAC.";
+        reference
+          "12.4.2 of IEEE Std 802.1Q-2018
+          6.8.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf protocol-based-vlan-classification {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        if-feature "port-and-protocol-based-vlan";
+        type boolean;
+        config false;
+        description
+          "A boolean indication indicating if Port-and-Protocol-based
+          VLAN classification is supported on a given Port.";
+        reference
+          "5.4.1.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf max-vid-set-entries {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        if-feature "port-and-protocol-based-vlan";
+        type uint16;
+        config false;
+        description
+          "The maximum number of entries supported in the VID set on a
+          given Port.";
+        reference
+          "12.10.1.1.3 of IEEE Std 802.1Q-2018";
+      }
+      leaf port-number {
+        type dot1qtypes:port-number-type;
+        config false;
+        description
+          "An integer that uniquely identifies a Bridge Port.";
+        reference
+          "12.3, item i) of IEEE Std 802.1Q-2018
+          17.3.2.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf address {
+        type ieee:mac-address;
+        config false;
+        description
+          "The specific MAC address of the individual MAC Entity
+          associated with the Port.";
+        reference
+          "12.4.2 of IEEE Std 802.1Q-2018
+          12.4.2.1.1.3, item a) of IEEE Std 802.1Q-2018";
+      }
+      leaf capabilities {
+        type bits {
+          bit tagging {
+            position "0";
+            description
+              "Supports 802.1Q VLAN tagging of frames and MVRP.";
+          }
+          bit configurable-acceptable-frame-type {
+            position "1";
+            description
+              "Allows modified values of acceptable frame types";
+          }
+          bit ingress-filtering {
+            position "2";
+            description
+              "Supports the discarding of any frame received on a Port
+              whose VLAN classification does not include that Port in
+              its member set.";
+          }
+        }
+        config false;
+        description
+          "The feature capabilities associated with port. Indicates
+          the parts of IEEE 802.1Q that are optional on a per-port
+          basis, that are implemented by this device, and that are
+          manageable.";
+        reference
+          "12.10.1.1.3, item c) of IEEE Std 802.1Q-2018
+          12.4.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf type-capabilties {
+        type bits {
+          bit customer-vlan-port {
+            position "0";
+            description
+              "Indicates the port can be a C-TAG aware port of an
+              enterprise VLAN aware Bridge";
+          }
+          bit provider-network-port {
+            position "1";
+            description
+              "Indicates the port can be an S-TAG aware port of a
+              Provider Bridge or Backbone Edge Bridge used for
+              connections within a PBN or PBBN.";
+          }
+          bit customer-network-port {
+            position "2";
+            description
+              "Indicates the port can be an S-TAG aware port of a
+              Provider Bridge or Backbone Edge Bridge used for
+              connections to the exterior of a PBN or PBBN.";
+          }
+          bit customer-edge-port {
+            position "3";
+            description
+              "Indicates the port can be a C-TAG aware port of a
+              Provider Bridge used for connections to the exterior of
+              a PBN or PBBN.";
+          }
+          bit customer-backbone-port {
+            position "4";
+            description
+              "Indicates the port can be a I-TAG aware port of a
+              Backbone Edge Bridge's B-component.";
+          }
+          bit virtual-instance-port {
+            position "5";
+            description
+              "Indicates the port can be a virtual S-TAG aware port
+              within a Backbone Edge Bridge's I-component which is
+              responsible for handling S-tagged traffic for a specific
+              backbone service instance.";
+          }
+          bit d-bridge-port {
+            position "6";
+            description
+              "Indicates the port can be a VLAN-unaware member of an
+              802.1Q Bridge.";
+          }
+          bit remote-customer-access-port {
+            position "7";
+            description
+              "Indicates the port can be an S-TAG aware port of a
+              Provider Bridge capable of providing Remote Customer
+              Service Interfaces.";
+          }
+          bit station-facing-bridge-port {
+            position "8";
+            description
+              "Indicates the station-facing Bridge Port in a EVB
+              Bridge.";
+          }
+          bit uplink-access-port {
+            position "9";
+            description
+              "Indicates the uplink access port in an EVB Bridge or
+              EVB station.";
+          }
+          bit uplink-relay-port {
+            position "10";
+            description
+              "Indicates the uplink relay port in an EVB station.";
+          }
+        }
+        config false;
+        description
+          "The type of feature capabilities supported with port.
+          Indicates the capabilities of this port.";
+        reference
+          "12.4.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf external {
+        type boolean;
+        config false;
+        description
+          "A boolean indicating whether the port is external. A value
+          of True means the port is external. A value of False means
+          the port is internal.";
+        reference
+          "12.4.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf oper-point-to-point {
+        type boolean;
+        config false;
+        description
+          "For a port running spanning tree, this object represents
+          the operational point-to-point status of the LAN segment
+          attached to this port. It indicates whether a port is
+          considered to have a point-to-point connection.
+          
+          If admin-point-to-point is set to auto(2), then the value of
+          oper-point-to-point is determined in accordance with the
+          specific procedures defined for the MAC entity concerned, as
+          defined in IEEE Std 802.1AC.
+          
+          The value is determined dynamically; that is, it is
+          re-evaluated whenever the value of admin-point-to-point
+          changes, and whenever the specific procedures defined for
+          the MAC entity evaluate a change in its point-to-point
+          status.";
+        reference
+          "IEEE Std 802.1AC
+          12.4.2 of IEEE Std 802.1Q-2018";
+      }
+      leaf media-dependent-overhead {
+        type uint8;
+        units "octets";
+        config false;
+        description
+          "The portMediaDependentOverhead parameter provides the
+          number of additional octets for media-dependent framing. The
+          overhead includes all octets prior the first octet of the
+          Destination Address field and all octets after the last octet
+          of the frame check sequence.";
+        reference
+          "12.4.2 of IEEE Std 802.1Qcr-2020";
+      }
+      container statistics {
+        config false;
+        description
+          "Container of operational state node information associated
+          with the bridge port.";
+        uses dot1qtypes:bridge-port-statistics-grouping;
+        leaf discard-on-ingress-filtering {
+          when "../../component-name != 'd-bridge-component'" {
+            description
+              "Applies to non TPMRs";
+          }
+          if-feature "ingress-filtering";
+          type yang:counter64;
+          description
+            "The number of frames that were discarded as a result of
+            Ingress Filtering being enabled.
+            
+            Discontinuities in the value of this counter can occur at
+            re-initialization of the management system, and at other
+            times as indicated by the value of 'discontinuity-time'.";
+          reference
+            "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+        }
+      }
+      list vid-translations {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        key "local-vid";
+        description
+          "To configure the VID Translation Table (6.9) associated
+          with a Port. This object is not applicable to Ports that do
+          not support a VID Translation Table. The default
+          configuration of the table has the value of the Relay VID
+          equal to the value of the Local VID. If no local VID is
+          configured, then it is assumed that the relay VID is the
+          same value as the local VID.
+          
+          If the port supports an Egress VID translation table, the
+          VID Translation Configuration object configures the Local
+          VID to Relay VID mapping on ingress only. If an Egress VID
+          translation is not supported, the VID Translation
+          Configuration object defines a single bidirectional mapping.
+          In this case, the Bridge should not allow multiple keys
+          ('local-vid') mapped to the same 'relay-vid' value.";
+        leaf local-vid {
+          type dot1qtypes:vlanid;
+          description
+            "The Local VID after translation received at the ISS or
+            EISS.";
+          reference
+            "12.10.1.8 of IEEE Std 802.1Q-2018
+            6.9 of IEEE Std 802.1Q-2018";
+        }
+        leaf relay-vid {
+          type dot1qtypes:vlanid;
+          description
+            "The Relay VID received before translation received at ISS
+            or EISS.";
+          reference
+            "12.10.1.8 of IEEE Std 802.1Q-2018
+            6.9 of IEEE Std 802.1Q-2018";
+        }
+      }
+      list egress-vid-translations {
+        when "../component-name != 'd-bridge-component'" {
+          description
+            "Applies to non TPMRs";
+        }
+        key "relay-vid";
+        description
+          "To configure the Egress VID Translation Table (6.9)
+          associated with a Port. This object is not applicable to
+          Ports that do not support an Egress VID Translation Table.
+          The default configuration of the table has the value of the
+          Local VID equal to the value of the Relay VID. If no Relay
+          VID is configured, then it is assumed that the local VID is
+          the same value as the relay VID.";
+        leaf relay-vid {
+          type dot1qtypes:vlanid;
+          description
+            "The Relay VID received before translation received at ISS
+            or EISS.";
+          reference
+            "12.10.1.9 of IEEE Std 802.1Q-2018
+            6.9 of IEEE Std 802.1Q-2018";
+        }
+        leaf local-vid {
+          type dot1qtypes:vlanid;
+          description
+            "The Local VID after translation received at the ISS or
+            EISS.";
+          reference
+            "12.10.1.9 of IEEE Std 802.1Q-2018
+            6.9 of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+  }
+}

--- a/standard/ieee/draft/802.1/QRev/ieee802-dot1q-types.yang
+++ b/standard/ieee/draft/802.1/QRev/ieee802-dot1q-types.yang
@@ -1,0 +1,1003 @@
+module ieee802-dot1q-types {
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1q-types;
+  prefix dot1q-types;
+  import ietf-yang-types {
+    prefix yang;
+  }
+  organization
+    "IEEE 802.1 Working Group";
+  contact
+    "WG-URL: http://ieee802.org/1/
+    WG-EMail: stds-802-1-l@ieee.org
+    
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+            IEEE Standards Association
+            445 Hoes Lane
+            Piscataway, NJ 08854
+            USA
+   
+    E-mail: stds-802-1-chairs@ieee.org";
+  description
+    "Common types used within dot1Q-bridge modules.";
+  revision 2020-06-04 {
+    description
+      "Published as part of IEEE Std 802.1Qcx-2020.
+      Second version.";
+    reference
+      "IEEE Std 802.1Qcx-2020, Bridges and Bridged Networks -
+      YANG Data Model for Connectivity Fault Management.";
+  }
+  revision 2018-03-07 {
+    description
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
+    reference
+      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+  }
+  
+  identity dot1q-vlan-type {
+    description
+      "Base identity from which all 802.1Q VLAN tag types are derived
+      from.";
+  }
+  identity c-vlan {
+    base dot1q-vlan-type;
+    description
+      "An 802.1Q Customer VLAN, using the 81-00 EtherType";
+    reference
+      "5.5 of IEEE Std 802.1Q-2018";
+  }
+  identity s-vlan {
+    base dot1q-vlan-type;
+    description
+      "An 802.1Q Service VLAN, using the 88-A8 EtherType originally
+      introduced in 802.1ad, and incorporated into 802.1Q (2011)";
+    reference
+      "5.6 of IEEE Std 802.1Q-2018";
+  }
+  identity transmission-selection-algorithm {
+    description
+      "Specify the transmission selection algorithms of IEEE Std
+      802.1Q-2018 Table 8-6";
+  }
+  identity strict-priority {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the strict priority transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  identity credit-based-shaper {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the credit based shaper transmission selection
+      algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  identity enhanced-transmission-selection {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the enhanced transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  identity asynchronous-traffic-shaping {
+    base transmission-selection-algorithm;
+    description
+      "Indicates the asynchronous transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  identity vendor-specific {
+    base transmission-selection-algorithm;
+    description
+      "Indicates a vendor specific transmission selection algorithm.";
+    reference
+      "Table 8-6 of IEEE Std 802.1Q-2018";
+  }
+  typedef name-type {
+    type string {
+      length "0..32";
+    }
+    description
+      "A text string of up to 32 characters, of locally determined
+      significance.";
+  }
+  typedef port-number-type {
+    type uint32 {
+      range "1..65535";
+    }
+    description
+      "The port number of the Bridge port for which this entry
+      contains Bridge management information.";
+  }
+  typedef priority-type {
+    type uint8 {
+      range "0..7";
+    }
+    description
+      "A range of priorities from 0 to 7 (inclusive). The Priority
+      Code Point (PCP) is a 3-bit field that refers to the class of
+      service associated with an 802.1Q VLAN tagged frame. The field
+      specifies a priority value between 0 and 7, these values can be
+      used by quality of service (QoS) to prioritize different classes
+      of traffic.";
+  }
+  typedef vid-range-type {
+    type string {
+      pattern
+        "([1-9]"+
+        "[0-9]{0,3}"+
+        "(-[1-9][0-9]{0,3})?"+
+        "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+    }
+    description
+      "A list of VLAN Ids, or non overlapping VLAN ranges, in
+      ascending order, between 1 and 4094.
+      
+      This type is used to match an ordered list of VLAN Ids, or
+      contiguous ranges of VLAN Ids. Valid VLAN Ids must be in the
+      range 1 to 4094, and included in the list in non overlapping
+      ascending order.
+      
+      For example: 1,10-100,250,500-1000";
+  }
+  typedef vlanid {
+    type uint16 {
+      range "1..4094";
+    }
+    description
+      "The vlanid type uniquely identifies a VLAN. This is the 12-bit
+      VLAN-ID used in the VLAN Tag header. The range is defined by the
+      referenced specification. This type is in the value set and its
+      semantics equivalent to the VlanId textual convention of the
+      SMIv2.";
+  }
+  typedef vlan-index-type {
+    type uint32 {
+      range "1..4094 | 4096..4294967295";
+    }
+    description
+      "A value used to index per-VLAN tables. Values of 0 and 4095 are
+      not permitted. The range of valid VLAN indices. If the value is
+      greater than 4095, then it represents a VLAN with scope local to
+      the particular agent, i.e., one without a global VLAN-ID
+      assigned to it. Such VLANs are outside the scope of IEEE 802.1Q,
+      but it is convenient to be able to manage them in the same way
+      using this YANG module.";
+    reference
+      "9.6 of IEEE Std 802.1Q-2018";
+  }
+  typedef mstid-type {
+    type uint32 {
+      range "1..4094";
+    }
+    description
+      "In an MSTP Bridge, an MSTID, i.e., a value used to identify a
+      spanning tree (or MST) instance";
+    reference
+      "13.8 of IEEE Std 802.1Q-2018";
+  }
+  typedef pcp-selection-type {
+    type enumeration {
+      enum 8P0D {
+        description
+          "8 priorities, 0 drop eligible";
+      }
+      enum 7P1D {
+        description
+          "7 priorities, 1 drop eligible";
+      }
+      enum 6P2D {
+        description
+          "6 priorities, 2 drop eligible";
+      }
+      enum 5P3D {
+        description
+          "5 priorities, 3 drop eligible";
+      }
+    }
+    description
+      "Priority Code Point selection types.";
+    reference
+      "12.6.2.5.3 of IEEE Std 802.1Q-2018
+      6.9.3 of IEEE Std 802.1Q-2018";
+  }
+  typedef protocol-frame-format-type {
+    type enumeration {
+      enum Ethernet {
+        description
+          "Ethernet frame format";
+      }
+      enum rfc1042 {
+        description
+          "RFC 1042 frame format";
+      }
+      enum snap8021H {
+        description
+          "SNAP 802.1H frame format";
+      }
+      enum snapOther {
+        description
+          "Other SNAP frame format";
+      }
+      enum llcOther {
+        description
+          "Other LLC frame format";
+      }
+    }
+    description
+      "A value representing the frame format to be matched.";
+    reference
+      "12.10.1.7.1 of IEEE Std 802.1Q-2018";
+  }
+  typedef ethertype-type {
+    type string {
+      pattern "[0-9a-fA-F]{2}-[0-9a-fA-F]{2}";
+    }
+    description
+      "The EtherType value represented in the canonical order defined
+      by IEEE 802. The canonical representation uses uppercase
+      characters.";
+    reference
+      "9.2 of IEEE Std 802-2014";
+  }
+  typedef dot1q-tag-type {
+    type identityref {
+      base dot1q-vlan-type;
+    }
+    description
+      "Identifies a specific 802.1Q tag type";
+    reference
+      "IEEE Std 802.1Q-2018";
+  }
+  typedef traffic-class-type {
+    type uint8 {
+      range "0..7";
+    }
+    description
+      "This is the numerical value associated with a traffic class in
+      a Bridge. Larger values are associated with higher priority
+      traffic classes.";
+    reference
+      "3.239 of IEEE Std 802.1Q-2018";
+  }
+  grouping dot1q-tag-classifier-grouping {
+    description
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id.";
+    leaf tag-type {
+      type dot1q-tag-type;
+      mandatory true;
+      description
+        "VLAN type";
+    }
+    leaf vlan-id {
+      type vlanid;
+      mandatory true;
+      description
+        "VLAN Id";
+    }
+  }
+  grouping dot1q-tag-or-any-classifier-grouping {
+    description
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id or 'any' to match on any VLAN Id.";
+    leaf tag-type {
+      type dot1q-tag-type;
+      mandatory true;
+      description
+        "VLAN type";
+    }
+    leaf vlan-id {
+      type union {
+        type vlanid;
+        type enumeration {
+          enum any {
+            value 4095;
+            description
+              "Matches 'any' VLAN in the range 1 to 4094 that is not
+              matched by a more specific VLAN Id match";
+          }
+        }
+      }
+      mandatory true;
+      description
+        "VLAN Id or any";
+    }
+  }
+  grouping dot1q-tag-ranges-classifier-grouping {
+    description
+      "A grouping which represents an 802.1Q VLAN that matches a range
+      of VLAN Ids.";
+    leaf tag-type {
+      type dot1q-tag-type;
+      mandatory true;
+      description
+        "VLAN type";
+    }
+    leaf vlan-ids {
+      type vid-range-type;
+      mandatory true;
+      description
+        "VLAN Ids";
+    }
+  }
+  grouping dot1q-tag-ranges-or-any-classifier-grouping {
+    description
+      "A grouping which represents an 802.1Q VLAN, matching both the
+      EtherType and a single VLAN Id, ordered list of ranges, or 'any'
+      to match on any VLAN Id.";
+    leaf tag-type {
+      type dot1q-tag-type;
+      mandatory true;
+      description
+        "VLAN type";
+    }
+    leaf vlan-id {
+      type union {
+        type vid-range-type;
+        type enumeration {
+          enum any {
+            value 4095;
+            description
+              "Matches 'any' VLAN in the range 1 to 4094.";
+          }
+        }
+      }
+      mandatory true;
+      description
+        "VLAN Ids or any";
+    }
+  }
+  grouping priority-regeneration-table-grouping {
+    description
+      "The priority regeneration table provides the ability to map
+      incoming priority values on a per-Port basis, under management
+      control.";
+    reference
+      "6.9.4 of IEEE Std 802.1Q-2018";
+    leaf priority0 {
+      type priority-type;
+      default "0";
+      description
+        "Priority 0";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority1 {
+      type priority-type;
+      default "1";
+      description
+        "Priority 1";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority2 {
+      type priority-type;
+      default "2";
+      description
+        "Priority 2";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority3 {
+      type priority-type;
+      default "3";
+      description
+        "Priority 3";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority4 {
+      type priority-type;
+      default "4";
+      description
+        "Priority 4";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority5 {
+      type priority-type;
+      default "5";
+      description
+        "Priority 5";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority6 {
+      type priority-type;
+      default "6";
+      description
+        "Priority 6";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority7 {
+      type priority-type;
+      default "7";
+      description
+        "Priority 7";
+      reference
+        "12.6.2.3 of IEEE Std 802.1Q-2018
+        6.9.4 of IEEE Std 802.1Q-2018";
+    }
+  }
+  grouping pcp-decoding-table-grouping {
+    description
+      "The Priority Code Point decoding table enables the decoding of
+      the priority and drop-eligible parameters from the PCP.";
+    reference
+      "6.9.3 of IEEE Std 802.1Q-2018";
+    list pcp-decoding-map {
+      key "pcp";
+      description
+        "This map associates the priority code point field found in
+        the VLAN to a priority and drop eligible value based upon the
+        priority code point selection type.";
+      leaf pcp {
+        type pcp-selection-type;
+        description
+          "The priority code point selection type.";
+        reference
+          "12.6.2.7 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
+      }
+      list priority-map {
+        key "priority-code-point";
+        description
+          "This map associated a priority code point value to priority
+          and drop eligible parameters.";
+        leaf priority-code-point {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf priority {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf drop-eligible {
+          type boolean;
+          description
+            "Drop eligible value for pcp";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+  }
+  grouping pcp-encoding-table-grouping {
+    description
+      "The Priority Code Point encoding table encodes the priority and
+      drop-eligible parameters in the PCP field of the VLAN tag.";
+    reference
+      "12.6.2.9 of IEEE Std 802.1Q-2018
+      6.9.3 of IEEE Std 802.1Q-2018";
+    list pcp-encoding-map {
+      key "pcp";
+      description
+        "This map associated the priority and drop-eligible parameters
+        to the priority used to encode the PCP of the VLAN based upon
+        the priority code point selection type.";
+      leaf pcp {
+        type pcp-selection-type;
+        description
+          "The priority code point selection type.";
+        reference
+          "12.6.2.7 of IEEE Std 802.1Q-2018
+          6.9.3 of IEEE Std 802.1Q-2018";
+      }
+      list priority-map {
+        key "priority dei";
+        description
+          "This map associated the priority and drop-eligible
+          parameters to the priority code point field of the VLAN tag.";
+        leaf priority {
+          type priority-type;
+          description
+            "Priority associated with the pcp.";
+          reference
+            "12.6.2.7 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+        leaf dei {
+          type boolean;
+          description
+            "The drop eligible value.";
+          reference
+            "12.6.2 of IEEE Std 802.1Q-2018
+            8.6.6 of IEEE Std 802.1Q-2018";
+        }
+        leaf priority-code-point {
+          type priority-type;
+          description
+            "PCP value for priority when DEI value";
+          reference
+            "12.6.2.9 of IEEE Std 802.1Q-2018
+            6.9.3 of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+  }
+  grouping service-access-priority-table-grouping {
+    description
+      "The Service Access Priority Table associates a received
+      priority with a serice access priority.";
+    reference
+      "12.6.2.17 of IEEE Std 802.1Q-2018
+      6.13.1 of IEEE Std 802.1Q-2018";
+    leaf priority0 {
+      type priority-type;
+      default "0";
+      description
+        "Service access priority value for priority 0";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority1 {
+      type priority-type;
+      default "1";
+      description
+        "Service access priority value for priority 1";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority2 {
+      type priority-type;
+      default "2";
+      description
+        "Service access priority value for priority 2";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority3 {
+      type priority-type;
+      default "3";
+      description
+        "Service access priority value for priority 3";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority4 {
+      type priority-type;
+      default "4";
+      description
+        "Service access priority value for priority 4";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority5 {
+      type priority-type;
+      default "5";
+      description
+        "Service access priority value for priority 5";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority6 {
+      type priority-type;
+      default "6";
+      description
+        "Service access priority value for priority 6";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+    leaf priority7 {
+      type priority-type;
+      default "7";
+      description
+        "Service access priority value for priority 7";
+      reference
+        "12.6.2.17 of IEEE Std 802.1Q-2018
+        6.13.1 of IEEE Std 802.1Q-2018";
+    }
+  }
+  grouping traffic-class-table-grouping {
+    description
+      "The Traffic Class Table models the operations that can be
+      performed on, or inquire about, the current contents of the
+      Traffic Class Table (8.6.6) for a given Port.";
+    reference
+      "12.6.3 of IEEE Std 802.1Q-2018
+      8.6.6 of IEEE Std 802.1Q-2018";
+    list traffic-class-map {
+      key "priority";
+      description
+        "The priority index into the traffic class table.";
+      leaf priority {
+        type priority-type;
+        description
+          "The priority of the traffic class entry.";
+        reference
+          "8.6.6 of IEEE Std 802.1Q-2018";
+      }
+      list available-traffic-class {
+        key "num-traffic-class";
+        description
+          "The traffic class index associated with a given priority
+          within the traffic class table.";
+        reference
+          "8.6.6 of IEEE Std 802.1Q-2018";
+        leaf num-traffic-class {
+          type uint8 {
+            range "1..8";
+          }
+          description
+            "The available number of traffic classes.";
+          reference
+            "8.6.6 of IEEE Std 802.1Q-2018";
+        }
+        leaf traffic-class {
+          type traffic-class-type;
+          description
+            "The traffic class index associated with a given traffic
+            class entry.";
+          reference
+            "8.6.6 of IEEE Std 802.1Q-2018";
+        }
+      }
+    }
+  }
+  grouping transmission-selection-table-grouping {
+    description
+      "The Transmission Selection Algorithm Table models the operations that
+      can be performed on, or inquire about, the current contents of the
+      Transmission Selection Algorithm Table (12.20.2) for a given Port.";
+    reference
+      "12.20.2 of IEEE Std 802.1Q-2018
+      8.6.8 of IEEE Std 802.1Q-2018";
+    list transmission-selection-algorithm-map {
+      key "traffic-class";
+      description
+        "The traffic class to index into the transmission selection table.";
+      leaf traffic-class {
+        type traffic-class-type;
+        description
+          "The traffic class of the entry.";
+        reference
+          "8.6.6 of IEEE Std 802.1Q-2018";
+      }
+      leaf transmission-selection-algorithm {
+        type identityref {
+          base dot1q-types:transmission-selection-algorithm;
+        }
+        description
+          "Transmission selection algorithm";
+        reference
+          "IEEE Std 802.1Q-2018 Clause 8.6.8, Table 8-6";
+      }
+    }
+  }
+  grouping port-map-grouping {
+    description
+      "A set of control indicators, one for each Port. A Port Map,
+      containing a control element for each outbound Port";
+    reference
+      "8.8.1 of IEEE Std 802.1Q-2018
+      8.8.2 of IEEE Std 802.1Q-2018";
+    list port-map {
+      key "port-ref";
+      description
+        "The list of entries composing the port map.";
+      leaf port-ref {
+        type port-number-type;
+        description
+          "The interface port reference associated with this map.";
+        reference
+          "8.8.1 of IEEE Std 802.1Q-2018";
+      }
+      choice map-type {
+        description
+          "Type of port map";
+        container static-filtering-entries {
+          description
+            "Static filtering entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum forward {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+              enum filter {
+                description
+                  "Filtered, independently of any dynamic filtering
+                  information.";
+              }
+              enum forward-filter {
+                description
+                  "Forwarded or filtered on the basis of dynamic
+                  filtering information, or on the basis of the
+                  default Group filtering behavior for the outbound
+                  Port (8.8.6) if no dynamic filtering information is
+                  present specifically for the MAC address.";
+              }
+            }
+            description
+              "containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.1 of IEEE Std 802.1Q-2018";
+          }
+          leaf connection-identifier {
+            type port-number-type;
+            description
+              "A Port MAP may contain a connection identifier (8.8.12)
+              for each outbound port. The connection identifier may be
+              associated with the Bridge Port value maintained in a
+              Dynamic Filtering Entry of the FDB for Bridge Ports.";
+            reference
+              "8.8.1 of IEEE Std 802.1Q-2018
+              8.8.12 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container static-vlan-registration-entries {
+          description
+            "Static VLAN registration entries.";
+          leaf registrar-admin-control {
+            type enumeration {
+              enum fixed-new-ignored {
+                description
+                  "Registration Fixed (New ignored).";
+              }
+              enum fixed-new-propagated {
+                description
+                  "Registration Fixed (New propagated.";
+              }
+              enum forbidden {
+                description
+                  "Registration Forbidden.";
+              }
+              enum normal {
+                description
+                  "Normal Registration.";
+              }
+            }
+            description
+              "The Registrar Administrative Control values for MVRP
+              and MIRP for the VID.";
+            reference
+              "8.8.2 of IEEE Std 802.1Q-2018";
+          }
+          leaf vlan-transmitted {
+            type enumeration {
+              enum tagged {
+                description
+                  "VLAN-tagged";
+              }
+              enum untagged {
+                description
+                  "VLAN-untagged";
+              }
+            }
+            description
+              "Whether frames are to be VLAN-tagged or untagged when
+              transmitted.";
+            reference
+              "8.8.2 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container mac-address-registration-entries {
+          description
+            "MAC address registration entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum registered {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+              enum not-registered {
+                description
+                  "Filtered, independently of any dynamic filtering
+                  information.";
+              }
+            }
+            description
+              "containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.4 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container dynamic-vlan-registration-entries {
+          description
+            "Dynamic VLAN registration entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum registered {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+            }
+            description
+              "containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.5 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container dynamic-reservation-entries {
+          description
+            "Dynamic reservation entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum forward {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+              enum filter {
+                description
+                  "Filtered, independently of any dynamic filtering
+                  information.";
+              }
+            }
+            description
+              "Containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.7 of IEEE Std 802.1Q-2018";
+          }
+        }
+        container dynamic-filtering-entries {
+          description
+            "Dynamic filtering entries attributes.";
+          leaf control-element {
+            type enumeration {
+              enum forward {
+                description
+                  "Forwarded, independently of any dynamic filtering
+                  information held by the FDB.";
+              }
+            }
+            description
+              "Containing a control element for each outbound Port,
+              specifying that a frame with a destination MAC address,
+              and in the case of VLAN Bridge components, VID that
+              meets this specification.";
+            reference
+              "8.8.3 of IEEE Std 802.1Q-2018";
+          }
+        }
+      }
+    }
+  }
+  grouping bridge-port-statistics-grouping {
+    description
+      "Grouping of bridge port statistics.";
+    reference
+      "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    leaf delay-exceeded-discards {
+      type yang:counter64;
+      description
+        "The number of frames discarded by this port due to excessive
+        transit delay through the Bridge. It is incremented by both
+        transparent and source route Bridges.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018
+        8.6.6 of IEEE Std 802.1Q-2018";
+    }
+    leaf mtu-exceeded-discards {
+      type yang:counter64;
+      description
+        "The number of frames discarded by this port due to an
+        excessive size. It is incremented by both transparent and
+        source route Bridges.";
+      reference
+        "12.6.1.1.3, item g) of IEEE Std 802.1Q-2018";
+    }
+    leaf frame-rx {
+      type yang:counter64;
+      description
+        "The number of frames that have been received by this port
+        from its segment. Note that a frame received on the interface
+        corresponding to this port is only counted by this object if
+        and only if it is for a protocol being processed by the local
+        bridging function, including Bridge management frames.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf octets-rx {
+      type yang:counter64;
+      description
+        "The total number of octets in all valid frames received
+        (including BPDUs, frames addressed to the Bridge as an end
+        station, and frames that were submitted to the Forwarding
+        Process).";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf frame-tx {
+      type yang:counter64;
+      description
+        "The number of frames that have been transmitted by this port
+        to its segment. Note that a frame transmitted on the interface
+        corresponding to this port is only counted by this object if
+        and only if it is for a protocol being processed by the local
+        bridging function, including Bridge management frames.";
+    }
+    leaf octets-tx {
+      type yang:counter64;
+      description
+        "The total number of octets that have been transmitted by this
+        port to its segment.";
+    }
+    leaf discard-inbound {
+      type yang:counter64;
+      description
+        "Count of received valid frames that were discarded (i.e.,
+        filtered) by the Forwarding Process.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf forward-outbound {
+      type yang:counter64;
+      description
+        "The number of frames forwarded to the associated MAC Entity
+        (8.5).";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf discard-lack-of-buffers {
+      type yang:counter64;
+      description
+        "The count of frames that were to be transmitted through the
+        associated Port but were discarded due to lack of buffers.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf discard-transit-delay-exceeded {
+      type yang:counter64;
+      description
+        "The number of frames discarded by this port due to excessive
+        transit delay through the Bridge. It is incremented by both
+        transparent and source route Bridges.";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+    leaf discard-on-error {
+      type yang:counter64;
+      description
+        "The number of frames that were to be forwarded on the
+        associated MAC but could not be transmitted (e.g., frame would
+        be too large, 6.5.8).";
+      reference
+        "12.6.1.1.3 of IEEE Std 802.1Q-2018";
+    }
+  }
+}

--- a/standard/ieee/draft/802.1/Qcz/check_pyang_extra_flags
+++ b/standard/ieee/draft/802.1/Qcz/check_pyang_extra_flags
@@ -1,1 +1,1 @@
- -p ../Qcr -p ../ABcu
+ -p ../ABcu

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
@@ -400,6 +400,14 @@ typedef abs-traffic-class-plus-one-type {
           reference
             "98.3.6 of IEEE Std 802.1Qcz-202X";
         }
+        leaf peer-udp-port {
+          type inet:port-number;
+          description
+            "The UDP port number to use when generating a layer-3 CIM for the 
+             peer.";
+          reference
+            "98.3.6 of IEEE Std 802.1Qcz-202X";
+        }
         leaf peer-cim-encap-len {
           type uint16 {
             range "0..512";

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
@@ -40,11 +40,11 @@ module ieee802-dot1q-congestion-isolation {
   description
     "This YANG module augments the configuration and operational state
     data for interfaces for the Congestion Isolation.";
-  revision 2020-08-10 {
+  revision 2021-01-14 {
     description
       "Initial revision from P802.1Qcz.";
     reference
-      "IEEE Std 802.1Qcz-202X";
+      "IEEE Std 802.1Qcz-2021";
   }
   
   /*--------------------*/
@@ -53,73 +53,6 @@ module ieee802-dot1q-congestion-isolation {
   feature congestion-isolation {
     description
       "Feature Congestion Indication";
-  }
-  
-  /*--------------------*/
-  /* Typedefs           */
-  /*--------------------*/
-  typedef abs-traffic-class-plus-one-type {
-    type enumeration {
-      enum monitored-queue-tc-1 {
-        value 1;
-      }
-      enum monitored-queue-tc-2 {
-        value 2;
-      }
-      enum monitored-queue-tc-3 {
-        value 3;
-      }
-      enum monitored-queue-tc-4 {
-        value 4;
-      }
-      enum monitored-queue-tc-5 {
-        value 5;
-      }
-      enum monitored-queue-tc-6 {
-        value 6;
-      }
-      enum monitored-queue-tc-7 {
-        value 7;
-      }
-      enum monitored-queue-tc-8 {
-        value 8;
-      }
-      enum congesting-queue-tc-1 {
-        value -1;
-      }
-      enum congesting-queue-tc-2 {
-        value -2;
-      }
-      enum congesting-queue-tc-3 {
-        value -3;
-      }
-      enum congesting-queue-tc-4 {
-        value -4;
-      }
-      enum congesting-queue-tc-5 {
-        value -5;
-      }
-      enum congesting-queue-tc-6 {
-        value -6;
-      }
-      enum congesting-queue-tc-7 {
-        value -7;
-      }
-      enum congesting-queue-tc-8 {
-        value -8;
-      }
-      enum not-participating-congestion-isolation {
-        value 0;
-      }
-    }
-    description
-      "Specifies a value that can be translated to the numeric value
-      of the traffic class to be used as either the congesting or
-      monitored queue. The absolute value of the enumerated value is
-      the value of the taffic class plus 1. A value of 0 indicates the
-      traffic class is not participating in congestion isolation. For
-      example, the enumerated value congesting-queue-tc-5 specifies
-      that traffic class 4 is used as the congesting queue.";
   }
   
   /*--------------------*/
@@ -221,7 +154,7 @@ module ieee802-dot1q-congestion-isolation {
           "The source MAC address of a CIM, belonging to the system
           transmitting the CIM";
         reference
-          "98.4.1.2.1 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.2.1 of IEEE Std 802.1Qcz-2021";
       }
       leaf cip-ipv4-address {
         type inet:ipv4-address;
@@ -230,7 +163,7 @@ module ieee802-dot1q-congestion-isolation {
           "The source IPv4 address of a CIM, belonging to the system
           transmitting the IPv4 layer-3 CIM.";
         reference
-          "98.4.1.2.2 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.2.2 of IEEE Std 802.1Qcz-2021";
       }
       leaf cip-ipv6-address {
         type inet:ipv6-address;
@@ -239,7 +172,7 @@ module ieee802-dot1q-congestion-isolation {
           "The source IPv6 address of a CIM, belonging to the system
           transmitting the IPv6 layer-3 CIM.";
         reference
-          "98.4.1.2.3 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.2.3 of IEEE Std 802.1Qcz-2021";
       }
       leaf cip-cim-port {
         type inet:port-number;
@@ -249,7 +182,7 @@ module ieee802-dot1q-congestion-isolation {
           layer-3 CIM. This value will be sent to the peer via LLDP in
           the CI TLV";
         reference
-          "98.4.1.2.4 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.2.4 of IEEE Std 802.1Qcz-2021";
       }
       list queue-map {
         key "priority";
@@ -268,7 +201,7 @@ module ieee802-dot1q-congestion-isolation {
           less than the absolute value (e.g. a value of -4 represents
           traffic class 3).";
         reference
-          "98.4.1.2.5 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.2.5 of IEEE Std 802.1Qcz-2021";
         leaf priority {
           type dot1q-types:priority-type;
           description
@@ -277,7 +210,7 @@ module ieee802-dot1q-congestion-isolation {
             value 0 which indicates the traffic class is not used by
             congestion isolation.";
           reference
-            "98.4.1.2.5 of IEEE Std 802.1Qcz-202X";
+            "47.4.1.2.5 of IEEE Std 802.1Qcz-2021";
         }
         leaf abs-traffic-class-plus-one {
           type abs-traffic-class-plus-one-type;
@@ -289,7 +222,7 @@ module ieee802-dot1q-congestion-isolation {
             a monitored queue, and a negative number specifies a
             traffic class for a congesting queue.";
           reference
-            "98.4.1.2.5 of IEEE Std 802.1Qcz-202X";
+            "47.4.1.2.5 of IEEE Std 802.1Qcz-2021";
         }
       }
       leaf min-header-octets {
@@ -298,7 +231,7 @@ module ieee802-dot1q-congestion-isolation {
           "The minimum number of octets to include in the Encapsulated
           MSDU field of each CIM generated. The default value is 48.";
         reference
-          "98.4.1.2.6 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.2.6 of IEEE Std 802.1Qcz-2021";
       }
       leaf max-cim-tx {
         type uint16;
@@ -306,7 +239,7 @@ module ieee802-dot1q-congestion-isolation {
           "The maximum number of times a CIM PDU will be sent for a
           congesting flow. The default value is 3.";
         reference
-          "98.4.1.2.7 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.2.7 of IEEE Std 802.1Qcz-2021";
       }
     }
   }
@@ -317,7 +250,7 @@ module ieee802-dot1q-congestion-isolation {
       description
         "Specifies whether CI is enabled in this system.";
       reference
-        "98.4.1.1.1 of IEEE Std 802.1Qcz-202X";
+        "47.4.1.1.1 of IEEE Std 802.1Qcz-2021";
     }
     leaf ci-cim-tx-priority {
       type dot1q-types:priority-type;
@@ -326,7 +259,7 @@ module ieee802-dot1q-congestion-isolation {
         "Specifies the priority value to be used when transmitting
         CIMs from the system. The default is 6.";
       reference
-        "98.4.1.1.2 of IEEE Std 802.1Qcz-202X";
+        "47.4.1.1.2 of IEEE Std 802.1Qcz-2021";
     }
     leaf ci-max-flow-life {
       type uint32;
@@ -338,7 +271,7 @@ module ieee802-dot1q-congestion-isolation {
         transitioned from congested back to non-congested. The default
         value is 100.";
       reference
-        "98.4.1.1.3 of IEEE Std 802.1Qcz-202X";
+        "47.4.1.1.3 of IEEE Std 802.1Qcz-2021";
     }
     container ci-peers {
       list ci-peer-table {
@@ -348,14 +281,14 @@ module ieee802-dot1q-congestion-isolation {
           provides the information needed to generate a CIM for
           transmission to the peer.";
         reference
-          "98.3.6 of IEEE Std 802.1Qcz-202X";
+          "47.3.6 of IEEE Std 802.1Qcz-2021";
         leaf reception-port {
           type dot1q-types:port-number-type;
           description
             "The port number where the immediate congestion isolaton
             participating peer is attached.";
           reference
-            "98.3.6 of IEEE Std 802.1Qcz-202X";
+            "47.3.6 of IEEE Std 802.1Qcz-2021";
         }
         leaf cim-type {
           type enumeration {
@@ -366,7 +299,7 @@ module ieee802-dot1q-congestion-isolation {
           description
             "The format of the CIM expected by the peer.";
           reference
-            "98.3.6 of IEEE Std 802.1Qcz-202X";
+            "47.3.6 of IEEE Std 802.1Qcz-2021";
         }
         leaf peer-mac-address {
           type ieee:mac-address;
@@ -374,7 +307,7 @@ module ieee802-dot1q-congestion-isolation {
             "The destination MAC address to use when generating a CIM
             for the peer.";
           reference
-            "98.3.6 of IEEE Std 802.1Qcz-202X";
+            "47.3.6 of IEEE Std 802.1Qcz-2021";
         }
         leaf peer-ipv4-address {
           type inet:ipv4-address;
@@ -382,7 +315,7 @@ module ieee802-dot1q-congestion-isolation {
             "The destination IPv4 address to use when generating an
             IPv4 layer-3 CIM for the peer.";
           reference
-            "98.3.6 of IEEE Std 802.1Qcz-202X";
+            "47.3.6 of IEEE Std 802.1Qcz-2021";
         }
         leaf peer-ipv6-address {
           type inet:ipv6-address;
@@ -390,7 +323,7 @@ module ieee802-dot1q-congestion-isolation {
             "The destination IPv6 address to use when generating an
             IPv6 layer-3 CIM for the peer.";
           reference
-            "98.3.6 of IEEE Std 802.1Qcz-202X";
+            "47.3.6 of IEEE Std 802.1Qcz-2021";
         }
         leaf peer-udp-port {
           type inet:port-number;
@@ -398,15 +331,7 @@ module ieee802-dot1q-congestion-isolation {
             "The UDP port number to use when generating a layer-3 CIM
             for the peer.";
           reference
-            "98.3.6 of IEEE Std 802.1Qcz-202X";
-        }
-        leaf peer-udp-port {
-          type inet:port-number;
-          description
-            "The UDP port number to use when generating a layer-3 CIM
-            for the peer.";
-          reference
-            "98.3.6 of IEEE Std 802.1Qcz-202X";
+            "47.3.6 of IEEE Std 802.1Qcz-2021";
         }
         leaf peer-cim-encap-len {
           type uint16 {
@@ -416,7 +341,7 @@ module ieee802-dot1q-congestion-isolation {
             "The number of octets from the MSDU to include in the
             Encapsulated MSDU field of the CIM PDU";
           reference
-            "98.3.6 of IEEE Std 802.1Qcz-202X";
+            "47.3.6 of IEEE Std 802.1Qcz-2021";
         }
       }
       leaf max-ci-peer-entries {
@@ -426,7 +351,7 @@ module ieee802-dot1q-congestion-isolation {
           "Specifies the maximum number of CI peer entries that can be
           stored";
         reference
-          "98.3.6 of IEEE Std 802.1Qcz-202X";
+          "47.3.6 of IEEE Std 802.1Qcz-2021";
       }
     }
     container ci-streams {
@@ -438,7 +363,7 @@ module ieee802-dot1q-congestion-isolation {
           mapping to entries in the IEEE Std 802.1CB Stream Identity
           table.";
         reference
-          "98.3.7 of IEEE Std 802.1Qcz-202X";
+          "47.3.7 of IEEE Std 802.1Qcz-2021";
         leaf stream-handle-id {
           type uint32;
           config false;
@@ -446,7 +371,7 @@ module ieee802-dot1q-congestion-isolation {
             "There is a unique stream handle ID for each congesting
             flow stored in the CI stream table";
           reference
-            "98.4.1.5.1 of IEEE Std 802.1Qcz-202X";
+            "47.4.1.5.1 of IEEE Std 802.1Qcz-2021";
         }
         leaf cim-count {
           type uint16;
@@ -455,7 +380,7 @@ module ieee802-dot1q-congestion-isolation {
             "Contains a count of the number of CIMs sent for a
             congesting flow";
           reference
-            "98.4.1.5.2 of IEEE Std 802.1Qcz-202X";
+            "47.4.1.5.2 of IEEE Std 802.1Qcz-2021";
         }
         leaf create-time {
           type yang:timeticks;
@@ -464,7 +389,7 @@ module ieee802-dot1q-congestion-isolation {
             "The time (SysUpTime, IETF RFC 3418) at which the CI
             stream table entry was created";
           reference
-            "98.4.1.5.3 of IEEE Std 802.1Qcz-202X";
+            "47.4.1.5.3 of IEEE Std 802.1Qcz-2021";
         }
         leaf create-mask {
           type bits {
@@ -490,7 +415,7 @@ module ieee802-dot1q-congestion-isolation {
             indicates that the entry was created or updated because of
             the receipt of a CIM.";
           reference
-            "98.4.1.5.4 of IEEE Std 802.1Qcz-202X";
+            "47.4.1.5.4 of IEEE Std 802.1Qcz-2021";
         }
       }
       leaf queue-key {
@@ -502,7 +427,7 @@ module ieee802-dot1q-congestion-isolation {
           key is calculated by the product of the congesting traffic
           class number plus one and the port number.";
         reference
-          "98.4.1.5.5 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.5.5 of IEEE Std 802.1Qcz-2021";
       }
       leaf dest-mac-address {
         type ieee:mac-address;
@@ -510,7 +435,7 @@ module ieee802-dot1q-congestion-isolation {
         description
           "The destination MAC addresss of a congesting flow.";
         reference
-          "98.4.1.5.6 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.5.6 of IEEE Std 802.1Qcz-2021";
       }
       leaf source-mac-address {
         type ieee:mac-address;
@@ -518,7 +443,7 @@ module ieee802-dot1q-congestion-isolation {
         description
           "The source MAC addresss of a congesting flow.";
         reference
-          "98.4.1.5.7 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.5.7 of IEEE Std 802.1Qcz-2021";
       }
       leaf vid {
         type dot1q-types:vlan-index-type;
@@ -526,7 +451,7 @@ module ieee802-dot1q-congestion-isolation {
         description
           "The VID of a congesting flow.";
         reference
-          "98.4.1.5.8 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.5.8 of IEEE Std 802.1Qcz-2021";
       }
       leaf msdu {
         type yang:hex-string;
@@ -537,7 +462,7 @@ module ieee802-dot1q-congestion-isolation {
           specified by the peer CIM encapsulation length of the CI
           peer table";
         reference
-          "98.4.1.5.9 of IEEE Std 802.1Qcz-202X";
+          "47.4.1.5.9 of IEEE Std 802.1Qcz-2021";
       }
     }
     leaf max-ci-stream-entries {
@@ -547,7 +472,7 @@ module ieee802-dot1q-congestion-isolation {
         "Specifies the maximum number of CI stream entries that can be
         stored";
       reference
-        "98.4.1.5 of IEEE Std 802.1Qcz-202X";
+        "47.4.1.5 of IEEE Std 802.1Qcz-2021";
     }
   }
 }

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
@@ -48,9 +48,17 @@ module ieee802-dot1q-congestion-isolation {
   }
   
   /*--------------------*/
+  /* Feature            */
+  /*--------------------*/
+  feature congestion-isolation {
+    description
+      "Feature Congestion Indication";
+  }
+  
+  /*--------------------*/
   /* Typedefs           */
   /*--------------------*/
-typedef abs-traffic-class-plus-one-type {
+  typedef abs-traffic-class-plus-one-type {
     type enumeration {
       enum monitored-queue-tc-1 {
         value 1;
@@ -105,21 +113,13 @@ typedef abs-traffic-class-plus-one-type {
       }
     }
     description
-      "Specifies a value that can be translated to the numeric value of the
-       traffic class to be used as either the congesting or monitoring queue.
-       The absolute value of the enumerated value is the value of the taffic
-       class plus 1.  A value of 0 indicates the traffic class is not 
-       participating in congestion isolation.  For example, the enumerated 
-       value congesting-queue-tc-5 specifies that traffic class 4 is used 
-       as the congesting queue.";
-  }
-
-  /*--------------------*/
-  /* Feature            */
-  /*--------------------*/
-  feature congestion-isolation {
-    description
-      "Feature Congestion Indication";
+      "Specifies a value that can be translated to the numeric value
+      of the traffic class to be used as either the congesting or
+      monitored queue. The absolute value of the enumerated value is
+      the value of the taffic class plus 1. A value of 0 indicates the
+      traffic class is not participating in congestion isolation. For
+      example, the enumerated value congesting-queue-tc-5 specifies
+      that traffic class 4 is used as the congesting queue.";
   }
   
   /*--------------------*/
@@ -403,8 +403,8 @@ typedef abs-traffic-class-plus-one-type {
         leaf peer-udp-port {
           type inet:port-number;
           description
-            "The UDP port number to use when generating a layer-3 CIM for the 
-             peer.";
+            "The UDP port number to use when generating a layer-3 CIM
+            for the peer.";
           reference
             "98.3.6 of IEEE Std 802.1Qcz-202X";
         }

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-congestion-isolation.yang
@@ -48,6 +48,73 @@ module ieee802-dot1q-congestion-isolation {
   }
   
   /*--------------------*/
+  /* Typedefs           */
+  /*--------------------*/
+typedef abs-traffic-class-plus-one-type {
+    type enumeration {
+      enum monitored-queue-tc-1 {
+        value 1;
+      }
+      enum monitored-queue-tc-2 {
+        value 2;
+      }
+      enum monitored-queue-tc-3 {
+        value 3;
+      }
+      enum monitored-queue-tc-4 {
+        value 4;
+      }
+      enum monitored-queue-tc-5 {
+        value 5;
+      }
+      enum monitored-queue-tc-6 {
+        value 6;
+      }
+      enum monitored-queue-tc-7 {
+        value 7;
+      }
+      enum monitored-queue-tc-8 {
+        value 8;
+      }
+      enum congesting-queue-tc-1 {
+        value -1;
+      }
+      enum congesting-queue-tc-2 {
+        value -2;
+      }
+      enum congesting-queue-tc-3 {
+        value -3;
+      }
+      enum congesting-queue-tc-4 {
+        value -4;
+      }
+      enum congesting-queue-tc-5 {
+        value -5;
+      }
+      enum congesting-queue-tc-6 {
+        value -6;
+      }
+      enum congesting-queue-tc-7 {
+        value -7;
+      }
+      enum congesting-queue-tc-8 {
+        value -8;
+      }
+      enum not-participating-congestion-isolation {
+        value 0;
+      }
+    }
+    description
+      "Specifies a value that can be translated to the numeric value of the
+       traffic class to be used as either the congesting or monitoring queue.
+       The absolute value of the enumerated value is the value of the taffic
+       class plus 1.  A value of 0 indicates the traffic class is not 
+       participating in congestion isolation.  For example, the enumerated 
+       value congesting-queue-tc-5 specifies that traffic class 4 is used 
+       as the congesting queue.";
+  }
+
+  /*--------------------*/
   /* Feature            */
   /*--------------------*/
   feature congestion-isolation {

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-basic-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-basic-tlv.yang
@@ -23,7 +23,7 @@ module ieee802-dot1q-lldp-basic-tlv {
      E-mail: stds-802-1-chairs@ieee.org";
   description
     "IEEE Std 802.1Q extension tlvs for LLDP";
-  revision 2020-08-10 {
+  revision 2021-01-14 {
     description
       "LLDP extension tlvs for the basicSet";
     reference

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-ci-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-ci-tlv.yang
@@ -33,17 +33,17 @@ module ieee802-dot1q-lldp-ci-tlv {
   description
     "IEEE Std 802.1Q extension tlvs for LLDP from the Congestion
     Isolation set (ciSet)";
-  revision 2020-08-10 {
+  revision 2021-01-14 {
     description
       "LLDP extension tlvs for the ciSet";
     reference
-      "Annex D of IEEE Std 802.1Qcz-202X";
+      "Annex D of IEEE Std 802.1Qcz-2021";
   }
   grouping congestion-isolation-tlv {
     description
       "Congestion Isolation TLV";
     reference
-      "Annex D.2.15 of IEEE Std 802.1Qz-202X";
+      "Annex D.2.15 of IEEE Std 802.1Qz-2021";
     list queue-map {
       key "priority";
       description
@@ -61,7 +61,7 @@ module ieee802-dot1q-lldp-ci-tlv {
         is one less than the absolute value (e.g. a value of -4
         represents traffic class 3).";
       reference
-        "D.2.15.3 of IEEE Std 802.1Qcz-202X";
+        "D.2.15.3 of IEEE Std 802.1Qcz-2021";
       leaf priority {
         type dot1q-types:priority-type;
         description
@@ -70,7 +70,7 @@ module ieee802-dot1q-lldp-ci-tlv {
           indicates the traffic class is not used by congestion
           isolation.";
         reference
-          "D.2.15.3 of IEEE Std 802.1Qcz-202X";
+          "D.2.15.3 of IEEE Std 802.1Qcz-2021";
       }
       leaf queue-config {
         type dot1q-ci:abs-traffic-class-plus-one-type;
@@ -82,7 +82,7 @@ module ieee802-dot1q-lldp-ci-tlv {
           queue, and a negative number specifies a traffic class for a
           congesting queue.";
         reference
-          "D.2.15.3 of IEEE Std 802.1Qcz-202X";
+          "D.2.15.3 of IEEE Std 802.1Qcz-2021";
       }
     }
     leaf cim-encap-length {
@@ -91,7 +91,7 @@ module ieee802-dot1q-lldp-ci-tlv {
         "The minimum number of octets to include in the Encapsulated
         MSDU field of each CIM generated. The default value is 48.";
       reference
-        "D.3.15.4 of IEEE Std 802.1Qcz-202X";
+        "D.3.15.4 of IEEE Std 802.1Qcz-2021";
     }
     leaf mac-address {
       type ieee:mac-address;
@@ -100,7 +100,7 @@ module ieee802-dot1q-lldp-ci-tlv {
         "The MAC address to be used as the destination MAC address of
         a CIM sent by the peer to reach this station.";
       reference
-        "D.2.15.5 of IEEE Std 802.1Qcz-202X";
+        "D.2.15.5 of IEEE Std 802.1Qcz-2021";
     }
     leaf udp-port-number {
       type inet:port-number;
@@ -109,7 +109,7 @@ module ieee802-dot1q-lldp-ci-tlv {
         "The UDP port number to be used as the destination port number
         of a layer-3 CIM sent by the peer to reach this station.";
       reference
-        "D.2.15.6 of IEEE Std 802.1Qcz-202X";
+        "D.2.15.6 of IEEE Std 802.1Qcz-2021";
     }
     leaf ip-address {
       type inet:ip-address;
@@ -127,7 +127,7 @@ module ieee802-dot1q-lldp-ci-tlv {
         IP address field is 16 octets representing the IPv6 address.
         No address shall be provided for any other address families.";
       reference
-        "D.2.15.7 and D.2.15.8 of IEEE Std 802.1Qcz-202X";
+        "D.2.15.7 and D.2.15.8 of IEEE Std 802.1Qcz-2021";
     }
   }
   augment "/lldp:lldp/lldp:port" {

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-cn-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-cn-tlv.yang
@@ -20,7 +20,7 @@ module ieee802-dot1q-lldp-cn-tlv {
      E-mail: stds-802-1-chairs@ieee.org";
   description
     "IEEE Std 802.1Q extension tlvs for LLDP";
-  revision 2020-08-10 {
+  revision 2021-01-14 {
     description
       "LLDP extension tlv for congestion notification";
     reference

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-cn-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-cn-tlv.yang
@@ -10,12 +10,12 @@ module ieee802-dot1q-lldp-cn-tlv {
   contact
     "WG-URL: http://ieee802.org/1/
      WG-EMail: stds-802-1-l@ieee.org
-       Contact: IEEE 802.1 Working Group Chair
-       Postal: C/O IEEE 802.1 Working Group
-       IEEE Standards Association
-            445 Hoes Lane
-            Piscataway, NJ 08854
-            USA
+     Contact: IEEE 802.1 Working Group Chair
+     Postal: C/O IEEE 802.1 Working Group
+     IEEE Standards Association
+          445 Hoes Lane
+          Piscataway, NJ 08854
+          USA
     
      E-mail: stds-802-1-chairs@ieee.org";
   description

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
@@ -23,7 +23,7 @@ module ieee802-dot1q-lldp-dcbx-tlv {
      E-mail: stds-802-1-chairs@ieee.org";
   description
     "IEEE Std 802.1Q extension tlvs for LLDP";
-  revision 2020-08-10 {
+  revision 2021-01-14 {
     description
       "LLDP extension tlv for DCBX";
     reference

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
@@ -13,12 +13,12 @@ module ieee802-dot1q-lldp-dcbx-tlv {
   contact
     "WG-URL: http://ieee802.org/1/
      WG-EMail: stds-802-1-l@ieee.org
-       Contact: IEEE 802.1 Working Group Chair
-       Postal: C/O IEEE 802.1 Working Group
-       IEEE Standards Association
-            445 Hoes Lane
-            Piscataway, NJ 08854
-            USA
+     Contact: IEEE 802.1 Working Group Chair
+     Postal: C/O IEEE 802.1 Working Group
+     IEEE Standards Association
+          445 Hoes Lane
+          Piscataway, NJ 08854
+          USA
     
      E-mail: stds-802-1-chairs@ieee.org";
   description

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
@@ -113,7 +113,6 @@ module ieee802-dot1q-lldp-dcbx-tlv {
       802.1Q-2018 Clause D.2.14. Signalled as value 5.";
   }
 
->>>>>>> Initial changes for D1.1 of Qcz
   grouping ets-configuration-tlv {
     description
       "The Enhanced Transmission Selection configuration TLV";

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-dcbx-tlv.yang
@@ -112,6 +112,8 @@ module ieee802-dot1q-lldp-dcbx-tlv {
       Table field of the Application VLAN TLV specified in IEEE Std
       802.1Q-2018 Clause D.2.14. Signalled as value 5.";
   }
+
+>>>>>>> Initial changes for D1.1 of Qcz
   grouping ets-configuration-tlv {
     description
       "The Enhanced Transmission Selection configuration TLV";

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-evb-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-evb-tlv.yang
@@ -10,12 +10,12 @@ module ieee802-dot1q-lldp-evb-tlv {
   contact
     "WG-URL: http://ieee802.org/1/
      WG-EMail: stds-802-1-l@ieee.org
-       Contact: IEEE 802.1 Working Group Chair
-       Postal: C/O IEEE 802.1 Working Group
-       IEEE Standards Association
-            445 Hoes Lane
-            Piscataway, NJ 08854
-            USA
+     Contact: IEEE 802.1 Working Group Chair
+     Postal: C/O IEEE 802.1 Working Group
+     IEEE Standards Association
+          445 Hoes Lane
+          Piscataway, NJ 08854
+          USA
     
      E-mail: stds-802-1-chairs@ieee.org";
   description

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-evb-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-evb-tlv.yang
@@ -20,7 +20,7 @@ module ieee802-dot1q-lldp-evb-tlv {
      E-mail: stds-802-1-chairs@ieee.org";
   description
     "IEEE Std 802.1Q extension tlvs for LLDP";
-  revision 2020-08-10 {
+  revision 2021-01-14 {
     description
       "LLDP extension tlv for EVB";
     reference

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-tr-tlv.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-lldp-tr-tlv.yang
@@ -21,17 +21,17 @@ module ieee802-dot1q-lldp-tr-tlv {
   description
     "IEEE Std 802.1Q extension tlvs for LLDP from the Topology
     Recognition set (trSet)";
-  revision 2020-08-10 {
+  revision 2021-01-14 {
     description
       "LLDP extension tlvs for the trSet";
     reference
-      "Annex D of IEEE Std 802.1Qcz-202X";
+      "Annex D of IEEE Std 802.1Qcz-2021";
   }
   grouping topology-recognition-tlv-lldp {
     description
       "System level components of Topology Recognition TLV";
     reference
-      "Annex D.2.16 of IEEE Std 802.1Qz-202X";
+      "Annex D.2.16 of IEEE Std 802.1Qz-2021";
     leaf device-type {
       type enumeration {
         enum end-station {
@@ -58,7 +58,7 @@ module ieee802-dot1q-lldp-tr-tlv {
       }
       config false;
       reference
-        "D.2.16.3 of IEEE Std 802.1Qcz-202X";
+        "D.2.16.3 of IEEE Std 802.1Qcz-2021";
     }
     leaf topology-level {
       type uint8;
@@ -74,14 +74,14 @@ module ieee802-dot1q-lldp-tr-tlv {
         topology level of their peers the topology level of the
         sending system may change.";
       reference
-        "D.2.16.4 of IEEE Std 802.1Qcz-202X";
+        "D.2.16.4 of IEEE Std 802.1Qcz-2021";
     }
   }
   grouping topology-recognition-tlv-port {
     description
       "Port level components of Topology Recognition TLV";
     reference
-      "Annex D.2.16 of IEEE Std 802.1Qz-202X";
+      "Annex D.2.16 of IEEE Std 802.1Qz-2021";
     leaf port-orientation {
       type enumeration {
         enum uplink {
@@ -116,7 +116,7 @@ module ieee802-dot1q-lldp-tr-tlv {
         type and topology level of their peers the port orientation of
         the sending system may change.";
       reference
-        "D.2.16.5 of IEEE Std 802.1Qcz-202X";
+        "D.2.16.5 of IEEE Std 802.1Qcz-2021";
     }
   }
   augment "/lldp:lldp" {
@@ -124,7 +124,7 @@ module ieee802-dot1q-lldp-tr-tlv {
       "Augments lldp with information at the system level needed to
       construct Topology Recognition TLVs";
     reference
-      "Annex D.2.16 of IEEE Std 802.1Qz-202X";
+      "Annex D.2.16 of IEEE Std 802.1Qz-2021";
     container topology-recognition-tlv-extension {
       uses topology-recognition-tlv-lldp;
     }

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
@@ -9,22 +9,34 @@ module ieee802-dot1q-types {
   contact
     "WG-URL: http://ieee802.org/1/
      WG-EMail: stds-802-1-l@ieee.org
+<<<<<<< b1c50c4e66d79aaf31986a1175f65c02945734f8
      Contact: IEEE 802.1 Working Group Chair
      Postal: C/O IEEE 802.1 Working Group
      IEEE Standards Association
           445 Hoes Lane
           Piscataway, NJ 08854
           USA
+=======
+       Contact: IEEE 802.1 Working Group Chair
+       Postal: C/O IEEE 802.1 Working Group
+       IEEE Standards Association
+            445 Hoes Lane
+            Piscataway, NJ 08854
+            USA
+>>>>>>> Reformtting, new header and changes for d1-3
     
      E-mail: stds-802-1-chairs@ieee.org";
   description
     "Common types used within dot1Q-bridge modules.";
+<<<<<<< b1c50c4e66d79aaf31986a1175f65c02945734f8
   revision 2020-10-23 {
     description
       "New revision date because Qcx project finished.";
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
+=======
+>>>>>>> Reformtting, new header and changes for d1-3
   revision 2018-08-10 {
     description
       "Published as part of IEEE Std 802.1Q-2018. Initial version.";

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
@@ -9,12 +9,12 @@ module ieee802-dot1q-types {
   contact
     "WG-URL: http://ieee802.org/1/
      WG-EMail: stds-802-1-l@ieee.org
-       Contact: IEEE 802.1 Working Group Chair
-       Postal: C/O IEEE 802.1 Working Group
-       IEEE Standards Association
-            445 Hoes Lane
-            Piscataway, NJ 08854
-            USA
+     Contact: IEEE 802.1 Working Group Chair
+     Postal: C/O IEEE 802.1 Working Group
+     IEEE Standards Association
+          445 Hoes Lane
+          Piscataway, NJ 08854
+          USA
     
      E-mail: stds-802-1-chairs@ieee.org";
   description

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
@@ -15,7 +15,6 @@ module ieee802-dot1q-types {
              445 Hoes Lane
              Piscataway, NJ 08854
              USA
-    
      E-mail: stds-802-1-chairs@ieee.org";
   description
     "Common types used within dot1Q-bridge modules.";

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
@@ -11,10 +11,10 @@ module ieee802-dot1q-types {
      WG-EMail: stds-802-1-l@ieee.org
      Contact: IEEE 802.1 Working Group Chair
      Postal: C/O IEEE 802.1 Working Group
-     IEEE Standards Association
-          445 Hoes Lane
-          Piscataway, NJ 08854
-          USA
+             IEEE Standards Association
+             445 Hoes Lane
+             Piscataway, NJ 08854
+             USA
     
      E-mail: stds-802-1-chairs@ieee.org";
   description
@@ -23,11 +23,21 @@ module ieee802-dot1q-types {
     description
       "Published as part of IEEE Std 802.1Qcz-2021.";
     reference
-      "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
+      "IEEE Std 802.1Qcz-2021, Bridges and Bridged Networks -
+      Congestion Isolation. Third version";
   }
-  revision 2018-08-10 {
+  revision 2020-06-04 {
     description
-      "Published as part of IEEE Std 802.1Q-2018. Initial version.";
+      "Published as part of IEEE Std 802.1Qcx-2020.
+      Second version.";
+    reference
+      "IEEE Std 802.1Qcx-2020, Bridges and Bridged Networks -
+      YANG Data Model for Connectivity Fault Management.";
+  }
+  revision 2018-03-07 {
+    description
+      "Published as part of IEEE Std 802.1Q-2018.
+      Initial version.";
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }

--- a/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
+++ b/standard/ieee/draft/802.1/Qcz/ieee802-dot1q-types.yang
@@ -9,34 +9,22 @@ module ieee802-dot1q-types {
   contact
     "WG-URL: http://ieee802.org/1/
      WG-EMail: stds-802-1-l@ieee.org
-<<<<<<< b1c50c4e66d79aaf31986a1175f65c02945734f8
      Contact: IEEE 802.1 Working Group Chair
      Postal: C/O IEEE 802.1 Working Group
      IEEE Standards Association
           445 Hoes Lane
           Piscataway, NJ 08854
           USA
-=======
-       Contact: IEEE 802.1 Working Group Chair
-       Postal: C/O IEEE 802.1 Working Group
-       IEEE Standards Association
-            445 Hoes Lane
-            Piscataway, NJ 08854
-            USA
->>>>>>> Reformtting, new header and changes for d1-3
     
      E-mail: stds-802-1-chairs@ieee.org";
   description
     "Common types used within dot1Q-bridge modules.";
-<<<<<<< b1c50c4e66d79aaf31986a1175f65c02945734f8
-  revision 2020-10-23 {
+  revision 2021-01-14 {
     description
-      "New revision date because Qcx project finished.";
+      "Published as part of IEEE Std 802.1Qcz-2021.";
     reference
       "IEEE Std 802.1Q-2018, Bridges and Bridged Networks.";
   }
-=======
->>>>>>> Reformtting, new header and changes for d1-3
   revision 2018-08-10 {
     description
       "Published as part of IEEE Std 802.1Q-2018. Initial version.";


### PR DESCRIPTION
Updated revision numbers and some formatting to prepare for initial SA ballot.  Check.sh script has been run and verified. The PR now includes the changes needed to support the QRev project as well.