### PR TITLE
Fix: Juniper submodule accidental removal  - reverted

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,7 +19,9 @@
 [submodule "vendor/nokia"]
 	path = vendor/nokia
 	url = https://github.com/nokia/YangModels.git
-
+[submodule "vendor/juniper"]
+	path = vendor/juniper
+	url = https://github.com/Juniper/yang
 [submodule "vendor/huawei"]
 	path = vendor/huawei
 	url = https://github.com/Huawei/yang.git


### PR DESCRIPTION
Juniper submodule accidentally removed in #916.
This resolves #991 

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>