### PR TITLE
CBcv D2.1

### DIFF
--- a/standard/ieee/check.sh
+++ b/standard/ieee/check.sh
@@ -11,7 +11,7 @@ to_check="draft/802 draft/802.1 draft/802.1/ABcu draft/802.1/AEdk draft/802.1/CB
 
 # relax constraint for now
 # add --ietf if you want to do strict IETF checking
-ietf_dir_flag="--path $cwd/$ietf_dir/RFC/"
+ietf_dir_flag="$cwd/$ietf_dir/RFC/"
 
 checkDir() {
     local dir="$ieee_dir/$1"

--- a/standard/ieee/draft/802.1/CBcv/ieee802-dot1cb-frer-types.yang
+++ b/standard/ieee/draft/802.1/CBcv/ieee802-dot1cb-frer-types.yang
@@ -1,0 +1,86 @@
+module ieee802-dot1cb-frer-types {
+  yang-version "1.1";
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1cb-frer-types;
+  prefix dot1cb-frer-types;
+  organization
+    "Institute of Electrical and Electronics Engineers";
+  contact
+    "WG-URL: http://ieee802.org/1/
+    WG-EMail: stds-802-1-l@ieee.org
+    
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+        IEEE Standards Association
+        445 Hoes Lane
+        Piscataway, NJ 08854
+        USA
+    
+    E-mail: stds-802-1-chairs@ieee.org";
+  description
+    "Management objects that control the frame replication and
+    elimination from IEEE Std 802.1CB-2017. This YANG data model conforms
+    to the Network Management Datastore Architecture defined in RFC 8342.
+    Copyright (C) IEEE (2021). This version of this YANG module is part
+    of IEEE Std 802.1CBcv; see the draft itself for full legal notices.";
+  revision 2021-05-06 {
+    description
+      "Published as part of IEEE Std 802.1CBcv-2021. Initial version.";
+    reference
+      "IEEE Std 802.1CBcv-2021, Frame Replication and Elimination for
+      Reliability - FRER YANG Data Model and Management Information Base
+      Module.";
+  }
+  typedef seq-rcvy-algorithm {
+    type enumeration {
+      enum vector {
+        value 0;
+        description
+          "The sequence recovery type used for the Vector Recovery
+          Algorithm.";
+      }
+      enum match {
+        value 1;
+        description
+          "The sequence recovery type used for the Match Recovery
+          Algorithm.";
+      }
+    }
+    description
+      "An enumerated value specifying which sequence recovery algorithm
+      is to be used for an instance of the Sequence recovery function.";
+    reference
+      "10.4.1.5 of IEEE Std 802.1CB-2017";
+  }
+  typedef seq-encaps-method {
+    type enumeration {
+      enum reserved {
+        value 0;
+        description
+          "Reserved value.";
+      }
+      enum r-tag {
+        value 1;
+        description
+          "The sequence encode decode type used for the R_TAG
+          encode/decode method.";
+      }
+      enum hsr-seq-tag {
+        value 2;
+        description
+          "The sequence encode decode type used for the HSR encode/decode
+          method.";
+      }
+      enum prp-seq-trailer {
+        value 3;
+        description
+          "The sequence encode decode type used for the PRP encode/decode
+          method.";
+      }
+    }
+    description
+      "An enumerated value indicating the type of encapsulation used for
+      an instance of the Sequence encode/ decode function.";
+    reference
+      "10.5.1.5 of IEEE Std 802.1CB-2017";
+  }
+}

--- a/standard/ieee/draft/802.1/CBcv/ieee802-dot1cb-frer.yang
+++ b/standard/ieee/draft/802.1/CBcv/ieee802-dot1cb-frer.yang
@@ -8,6 +8,9 @@ module ieee802-dot1cb-frer {
   import ieee802-dot1cb-stream-identification-types {
     prefix dot1cb-sid-types;
   }
+  import ieee802-dot1cb-frer-types {
+    prefix dot1cb-frer-types;
+  }
   import ieee802-dot1q-types {
     prefix dot1qtypes;
   }
@@ -18,86 +21,49 @@ module ieee802-dot1cb-frer {
     "Institute of Electrical and Electronics Engineers";
   contact
     "WG-URL: http://ieee802.org/1/
-     WG-EMail: stds-802-1-l@ieee.org
+    WG-EMail: stds-802-1-l@ieee.org
     
-     Contact: IEEE 802.1 Working Group Chair
-              Postal: C/O IEEE 802.1 Working Group
-              IEEE Standards Association
-              445 Hoes Lane
-              Piscataway, NJ 08854
-              USA
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+        IEEE Standards Association
+        445 Hoes Lane
+        Piscataway, NJ 08854
+        USA
     
-     E-mail: stds-802-1-chairs@ieee.org";
+    E-mail: stds-802-1-chairs@ieee.org";
   description
     "Management objects that control the frame replication and
     elimination from IEEE Std 802.1CB-2017. This YANG data model conforms
-    to the Network Management Datastore Architecture defined in RFC
-    8342.";
-  revision 2020-11-27 {
+    to the Network Management Datastore Architecture defined in RFC 8342.
+    Copyright (C) IEEE (2021). This version of this YANG module is part
+    of IEEE Std 802.1CBcv; see the draft itself for full legal notices.";
+  revision 2021-05-06 {
     description
-      "D1.0 revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
+      "Published as part of IEEE Std 802.1CBcv-2021. Initial version.";
     reference
-      "Clause 10 of IEEE Std 802.1CB-2017";
-  }
-  revision 2020-04-29 {
-    description
-      "D0.3 revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
-    reference
-      "Clause 10 of IEEE Std 802.1CB-2017";
-  }
-  revision 2019-09-01 {
-    description
-      "Initial revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
-    reference
-      "Clause 10 of IEEE Std 802.1CB-2017";
+      "IEEE Std 802.1CBcv-2021, Frame Replication and Elimination for
+      Reliability - FRER YANG Data Model and Management Information Base
+      Module.";
   }
   feature auto-configuration {
     description
       "Autoconfiguration of entries in the tables for stream identity
-      table (9.1), sequence recovery table (10.4) and sequence
-      identification table (10.5)";
+      table, sequence recovery table and sequence identification table.";
     reference
-      "Clause 7.11, 10.7 of IEEE Std 802.1CB-2017";
+      "7.11 of IEEE Std 802.1CB-2017
+      10.7 of IEEE Std 802.1CB-2017";
   }
   typedef lan-path-id {
     type int8;
     description
       "An integer specifying a path or LAN. If and only if a packet
-      matches an entry in the Sequence identification table (10.5) that
-      specifies HSR or PRP in its frerSeqEncEncapsType (10.5.1.5) object,
+      matches an entry in the Sequence identification table that
+      specifies HSR or PRP in its frerSeqEncEncapsType object,
       tsnStreamIdLanPathId specifies the LanId or PathId value that must
       be matched for this tsnStreamIdEntry to apply. A value of –1
       indicates that the LanId or PathId are to be ignored.";
     reference
-      "Clause 10.22 of IEEE Std 802.1CB-2017";
-  }
-  typedef sequence-recovery-algorithm {
-    type enumeration {
-      enum vector {
-        value 0;
-        description
-          "Vector Recovery Algorithm";
-        reference
-          "Clause 7.4.3.4 of IEEE Std 802.1CB-2017";
-      }
-      enum match {
-        value 1;
-        description
-          "Match Recovery Algorithm";
-        reference
-          "Clause 7.4.3.5 of IEEE Std 802.1CB-2017";
-      }
-    }
-    description
-      "This object is an enumerated value specifying which sequence
-      recovery algorithm is to be used for this instance of the Sequence
-      recovery function (7.4.2). The enumeration uses an OUI or CID as
-      shown in Table 10-1.";
-    reference
-      "Clause 10.4.1.5 of IEEE Std 802.1CB-2017";
+      "10.22 of IEEE Std 802.1CB-2017";
   }
   typedef sequence-history-length {
     type uint32 {
@@ -105,68 +71,283 @@ module ieee802-dot1cb-frer {
     }
     description
       "An integer specifying how many bits of the SequenceHistory
-      variable (7.4.3.2.2) are to be used.";
+      variable are to be used.";
     reference
-      "Clause 7.4.3.2.2 of IEEE Std 802.1CB-2017";
+      "7.4.3.2.2 of IEEE Std 802.1CB-2017";
   }
-  typedef sequence-encode-decode-types {
-    type enumeration {
-      enum r-tag {
-        value 1;
+  grouping sequence-encode-decode {
+    description
+      "The sequence-encode-decode grouping indicates the type of
+      encapsulation used for this instance of the Sequence encode/decode
+      function.";
+    reference
+      "10.5.1.5 of IEEE Std 802.1CB-2017";
+    choice encapsulation {
+      description
+        "This choice indicates the type of encapsulation used for this
+        instance of the Sequence encode/decode function. The
+        encapsulation includes an Organizationally Unique Identifier
+        (OUI) or Company ID (CID) to identify the organization defining
+        the sequence encode/decode method.";
+      reference
+        "10.5.1.5 of IEEE Std 802.1CB-2017";
+      container r-tag {
+        presence "true";
         description
           "R-TAG";
         reference
-          "Clause 7.8 of IEEE Std 802.1CB-2017";
+          "7.8 of IEEE Std 802.1CB-2017";
+        leaf type-number {
+          type dot1cb-frer-types:seq-encaps-method;
+          default "r-tag";
+          config false;
+          description
+            "The type number used for the R-TAG encode/decode method.";
+          reference
+            "10.5.1.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf oui-cid {
+          type string {
+            pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+          }
+          default "00-80-C2";
+          config false;
+          description
+            "The Organizationally Unique Identifier (OUI) or Company ID
+            (CID) to identify the organization defining the encode/decode
+            method. For encode/decode methods defined in IEEE Std
+            802.1CB-2017 the OUI/CID is always 00-80-C2.";
+          reference
+            "10.5.1.5 of IEEE Std 802.1CB-2017";
+        }
       }
-      enum hsr-sequence-tag {
-        value 2;
+      container hsr-sequence-tag {
+        presence "true";
         description
           "HSR sequence tag";
         reference
-          "Clause 7.9 of IEEE Std 802.1CB-2017";
+          "7.9 of IEEE Std 802.1CB-2017";
+        leaf type-number {
+          type dot1cb-frer-types:seq-encaps-method;
+          default "hsr-seq-tag";
+          config false;
+          description
+            "The type number used for the HSR sequence tag encode/decode
+            method.";
+          reference
+            "10.5.1.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf oui-cid {
+          type string {
+            pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+          }
+          default "00-80-C2";
+          config false;
+          description
+            "The Organizationally Unique Identifier (OUI) or Company ID
+            (CID) to identify the organization defining the encode/decode
+            method. For encode/decode methods defined in IEEE Std
+            802.1CB-2017 the OUI/CID is always 00-80-C2.";
+          reference
+            "10.5.1.5 of IEEE Std 802.1CB-2017";
+        }
       }
-      enum prp-sequence-trailer {
-        value 3;
+      container prp-sequence-tag {
+        presence "true";
         description
           "PRP sequence trailer";
         reference
-          "Clause 7.10 of IEEE Std 802.1CB-2017";
+          "7.10 of IEEE Std 802.1CB-2017";
+        leaf type-number {
+          type dot1cb-frer-types:seq-encaps-method;
+          default "prp-seq-trailer";
+          config false;
+          description
+            "The type number used for the PRP sequence trailer
+            encode/decode method.";
+          reference
+            "10.5.1.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf oui-cid {
+          type string {
+            pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+          }
+          default "00-80-C2";
+          config false;
+          description
+            "The Organizationally Unique Identifier (OUI) or Company ID
+            (CID) to identify the organization defining the encode/decode
+            method. For encode/decode methods defined in IEEE Std
+            802.1CB-2017 the OUI/CID is always 00-80-C2.";
+          reference
+            "10.5.1.5 of IEEE Std 802.1CB-2017";
+        }
+      }
+      container organization-specific {
+        presence "true";
+        description
+          "This container allows to select sequence encode/decode types
+          that are defined by entities outside of IEEE 802.1.";
+        reference
+          "10.5.1.5 of IEEE Std 802.1CB-2017";
+        leaf type-number {
+          type int32 {
+            range "256..max";
+          }
+          description
+            "The type number used for an encode/decode method defined by
+            an entity owning the OUI or CID for this encapsulation type.";
+          reference
+            "10.5.1.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf oui-cid {
+          type string {
+            pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+          }
+          description
+            "The Organizationally Unique Identifier (OUI) or Company ID
+            (CID) to identify the organization defining the encode/decode
+            method.";
+          reference
+            "10.5.1.5 of IEEE Std 802.1CB-2017";
+        }
       }
     }
-    description
-      "There is one Sequence identification table per system, and one
-      entry in the Sequence identification table for each port and
-      direction for which an instance of the Sequence encode/decode
-      function (7.6) is to be created.";
-    reference
-      "Table 10-2 of IEEE Std 802.1CB-2017";
   }
-  container frame-replication-and-elimination {
+  grouping sequence-recovery-algorithm {
+    description
+      "The sequence-recovery-algorithm grouping specifies which sequence
+      recovery algorithm is to be used for this instance of the Sequence
+      recovery function.";
+    reference
+      "10.4.1.5 of IEEE Std 802.1CB-2017";
+    choice algorithm {
+      description
+        "This choice indicates the sequence recovery algorithm used for
+        this instance of the Sequence recovery function. It includes an
+        Organizationally Unique Identifier (OUI) or Company ID (CID) to
+        identify the organization defining the sequence recovery
+        algorithm.";
+      reference
+        "10.4.1.5 of IEEE Std 802.1CB-2017";
+      container vector {
+        presence "true";
+        description
+          "Vector Recovery Algorithm.";
+        reference
+          "10.4.1.5 of IEEE Std 802.1CB-2017";
+        leaf type-number {
+          type dot1cb-frer-types:seq-rcvy-algorithm;
+          default "vector";
+          config false;
+          description
+            "The type number used for the VectorRecoveryAlgorithm.";
+          reference
+            "10.4.1.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf oui-cid {
+          type string {
+            pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+          }
+          default "00-80-C2";
+          config false;
+          description
+            "The Organizationally Unique Identifier (OUI) or Company ID
+            (CID) to identify the organization defining the sequence
+            recovery algorithm. For sequence recovery algorithms defined
+            in IEEE Std 802.1CB-2017 the OUI/CID is always 00-80-C2.";
+          reference
+            "10.4.1.5 of IEEE Std 802.1CB-2017";
+        }
+      }
+      container match {
+        presence "true";
+        description
+          "Match Recovery Algorithm.";
+        reference
+          "10.4.1.5 of IEEE Std 802.1CB-2017";
+        leaf type-number {
+          type dot1cb-frer-types:seq-rcvy-algorithm;
+          default "match";
+          config false;
+          description
+            "The type number used for the MatchRecoveryAlgorithm.";
+          reference
+            "10.4.1.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf oui-cid {
+          type string {
+            pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+          }
+          default "00-80-C2";
+          config false;
+          description
+            "The Organizationally Unique Identifier (OUI) or Company ID
+            (CID) to identify the organization defining the sequence
+            recovery algorithm. For sequence recovery algorithms defined
+            in IEEE Std 802.1CB-2017 the OUI/CID is always 00-80-C2.";
+          reference
+            "10.4.1.5 of IEEE Std 802.1CB-2017";
+        }
+      }
+      container organization-specific {
+        presence "true";
+        description
+          "This container allows to select sequence recovery algorithms
+          that are defined by entities outside of IEEE 802.1.";
+        reference
+          "10.4.1.5 of IEEE Std 802.1CB-2017";
+        leaf type-number {
+          type int32 {
+            range "256..max";
+          }
+          description
+            "The type number used for a sequence recovery algorithm
+            defined by an entity owning the OUI or CID for this algorithm
+            type.";
+          reference
+            "10.4.1.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf oui-cid {
+          type string {
+            pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+          }
+          description
+            "The Organizationally Unique Identifier (OUI) or Company ID
+            (CID) to identify the organization defining the sequence
+            recovery algorithm.";
+          reference
+            "10.4.1.5 of IEEE Std 802.1CB-2017";
+        }
+      }
+    }
+  }
+  container frer {
     description
       "The managed objects that control Stream identification are
-      described in Clause 9. The managed objects that control FRER are
-      described in this Clause 10 as follows:
+      described in Clause 9 of IEEE Std 802.1CB-2017. The managed objects
+      that control FRER are described in Clause 10 of IEEE Std
+      802.1CB-2017as follows:
       
        a) General requirements on the behavior of counters are in 10.1.
        b) The various tables of managed objects that can manage, in
           detail, each individual Stream, are described in five
           subclauses, including:
-         1) Additions (10.2) to the Stream identity table (9.1) required
-            for Autoconfiguration (7.11, 10.7).
-         2) The Sequence generation table (10.3) that configures
-            instances of the Sequence generation function (7.4.1);
-         3) The Sequence recovery table (10.4) that configures instances
-            of the Individual recovery function (7.5), the Sequence
-            recovery function (7.4.2), and the Latent error detection
-            function (7.4.4);
-         4) The Sequence identification table (10.5) that configures
-            instances of the Sequence encode/decode function (7.6); and
-         5) The Stream split table (10.6) that configures instances of
-            the Stream splitting function (7.7).
+         1) Additions to the Stream identity table required for
+            Autoconfiguration.
+         2) The Sequence generation table that configures instances of
+            the Sequence generation function;
+         3) The Sequence recovery table that configures instances of the
+            Individual recovery function, the Sequence recovery function,
+            and the Latent error detection function;
+         4) The Sequence identification table that configures instances
+            of the Sequence encode/decode function; and
+         5) The Stream split table that configures instances of the
+            Stream splitting function.
        c) The managed objects that support the automatic configuration,
           upon receipt of a packet, of entries in the first four of the
-          preceding tables (10.2 through 10.5), are described in the
-          subclause on Autoconfiguration (10.7).
+          preceding tables, are described in the subclause on
+          Autoconfiguration.
        d) The per-port, per-Stream packet counters that are kept by FRER
           functions for inspection by network management entities are
           described in 10.8, and the per-port (totaled over all Streams)
@@ -176,26 +357,25 @@ module ieee802-dot1cb-frer {
       configure more than one encapsulation for the same stream_handle
       subparameter on the same port. Similarly, the managed objects in
       the subclauses under 10.3 and 10.4 make it possible to configure
-      more than one Sequence encode/decode function (7.6) or more than
-      one Sequence generation function (7.4.1) for the same stream_handle
+      more than one Sequence encode/decode function or more than one
+      Sequence generation function for the same stream_handle
       subparameter. [The same value of stream_handle can be in the
-      frerSeqGenStreamList (10.3.1.1) of more than one frerSeqGenEntry
-      (10.3.1) or in the frerSeqRcvyStreamList (10.4.1.1) of more than
-      one frerSeqRcvyEntry (10.4.1).] A system shall return an error if
-      an attempt is made to configure conflicting requirements upon that
-      system.";
+      frerSeqGenStreamList of more than one frerSeqGenEntry or in the
+      frerSeqRcvyStreamList of more than one frerSeqRcvyEntry.] A system
+      shall return an error if an attempt is made to configure
+      conflicting requirements upon that system.";
     reference
       "Clause 10 of IEEE Std 802.1CB-2017";
-    list sequence-generation-list {
+    list sequence-generation {
       key "index";
       description
         "There is one Sequence generation table in a system, and one
         entry in the Sequence generation table for each Sequence
-        generation function (7.4.1). Each frerSeqGenEntry lists the
-        Streams and direction for which a single instance of the Sequence
-        generation function is to be placed.";
+        generation function. Each frerSeqGenEntry lists the Streams and
+        direction for which a single instance of the Sequence generation
+        function is to be placed.";
       reference
-        "Clause 10.3 of IEEE Std 802.1CB-2017";
+        "10.3 of IEEE Std 802.1CB-2017";
       leaf index {
         type uint32;
         description
@@ -204,59 +384,59 @@ module ieee802-dot1cb-frer {
           table. Therefore this index leaf is being used to uniquely
           identify an entry in the sequence generation table.";
       }
-      leaf-list stream-list {
+      leaf-list stream {
         type leafref {
-          path '/dot1cb-sid:stream-identity-list/dot1cb-sid:handle';
+          path '/dot1cb-sid:stream-identity/dot1cb-sid:handle';
         }
         min-elements 1;
         description
           "A list of stream_handle values, corresponding to the values of
-          the tsnStreamIdHandle objects (9.1.1.1) in the Stream identity
-          table (9.1), on which this instance of the Sequence generation
-          function (7.4.1) is to operate. The single instance of the
-          Sequence generation function created by this frerSeqGenEntry
-          operates every packet belonging to this Stream, regardless of
-          the port on which it is received.";
+          the tsnStreamIdHandle objects in the Stream identity table, on
+          which this instance of the Sequence generation function is to
+          operate. The single instance of the Sequence generation
+          function created by this frerSeqGenEntry operates every packet
+          belonging to this Stream, regardless of the port on which it is
+          received.";
         reference
-          "Clause 10.3.1.1 of IEEE Std 802.1CB-2017";
+          "10.3.1.1 of IEEE Std 802.1CB-2017";
       }
-      leaf direction {
+      leaf direction-out-facing {
         type dot1cb-sid-types:direction;
         description
           "An object indicating whether the Sequence generation function
-          (7.4.1) is to be placed on the out-facing (True) or in-facing
-          (False) side of the port (Figure 6-6).";
+          is to be placed on the out-facing (True) or in-facing (False)
+          side of the port.";
         reference
-          "Clause 10.3.1.2 of IEEE Std 802.1CB-2017";
+          "10.3.1.2 of IEEE Std 802.1CB-2017";
       }
       leaf reset {
         type boolean;
         description
           "A Boolean object indicating that the Sequence generation
-          function (7.4.1) is to be reset by calling its corresponding
-          SequenceGenerationReset function (7.4.1.3). Writing the value
-          True to frerSeqGenReset triggers a reset; writing the value
-          False has no effect. When read, frerSeqGenReset always returns
-          the value False.";
+          function is to be reset by calling its corresponding
+          SequenceGenerationReset function. Writing the value True to
+          frerSeqGenReset triggers a reset; writing the value False has
+          no effect. When read, frerSeqGenReset always returns the value
+          False.";
         reference
-          "Clause 10.3.1.3 of IEEE Std 802.1CB-2017";
+          "10.3.1.3 of IEEE Std 802.1CB-2017";
       }
     }
-    list sequence-recovery-list {
+    list sequence-recovery {
       key "index";
       description
         "There is one Sequence recovery table in a system, and one entry
         in the Sequence recovery table for each Sequence recovery
-        function (7.4.2) or Individual recovery function (7.5) that can
-        also be present. The entry describes a set of managed objects for
-        the single instance of a Base recovery function (7.4.3) and
-        Latent error detection function (7.4.4) included in the Sequence
-        recovery function or Individual recovery function. Each
-        frerSeqRcvyEntry lists the Streams, ports, and direction for
-        which instances of a Sequence recovery function or Individual
-        recovery function are to be instantiated.";
+        function or Individual recovery function that can also be
+        present. The entry describes a set of managed objects for the
+        single instance of a Base recovery function and Latent error
+        detection function included in the Sequence recovery function or
+        Individual recovery function. Each frerSeqRcvyEntry lists the
+        Streams, ports, and direction for which instances of a Sequence
+        recovery function or Individual recovery function are to be
+        instantiated.";
       reference
-        "Clause 10.4 of IEEE Std 802.1CB-2017";
+        "10.4 of IEEE Std 802.1CB-2017";
       leaf index {
         type uint32;
         description
@@ -265,99 +445,93 @@ module ieee802-dot1cb-frer {
           table. Therefore this index leaf is being used to uniquely
           identify an entry in the sequence recovery table.";
       }
-      leaf-list stream-list {
+      leaf-list stream {
         type leafref {
-          path '/dot1cb-sid:stream-identity-list/dot1cb-sid:handle';
+          path '/dot1cb-sid:stream-identity/dot1cb-sid:handle';
         }
         min-elements 1;
         description
           "A list of the stream_handle values, corresponding to the
-          values of the tsnStreamIdHandle objects (9.1.1.1) in the Stream
-          identity table (9.1), to which the system is to apply the
-          instance of the Sequence recovery function (7.4.2) or
-          Individual recovery function (7.5).";
+          values of the tsnStreamIdHandle objects in the Stream identity
+          table, to which the system is to apply the instance of the
+          Sequence recovery function or Individual recovery function.";
         reference
-          "Clause 10.4.1.1 of IEEE Std 802.1CB-2017";
+          "10.4.1.1 of IEEE Std 802.1CB-2017";
       }
-      leaf-list port-list {
+      leaf-list port {
         type if:interface-ref;
         min-elements 1;
         description
           "The list of ports on each of which the system is to
-          instantiate the Sequence recovery function (7.4.2), or from
-          which received packets are to be fed to a single instance of
-          the Individual recovery function (7.5).";
+          instantiate the Sequence recovery function, or from which
+          received packets are to be fed to a single instance of the
+          Individual recovery function.";
         reference
-          "Clause 10.4.1.2 of IEEE Std 802.1CB-2017";
+          "10.4.1.2 of IEEE Std 802.1CB-2017";
       }
-      leaf direction {
+      leaf direction-out-facing {
         type dot1cb-sid-types:direction;
         description
-          "An object indicating whether the Sequence recovery function
-          (7.4.2) or Individual recovery function (7.5) is to be placed
-          on the out-facing (True) or in-facing (False) side of the port
-          (Figure 6-6).";
+          "An object indicating whether the Sequence recovery function or
+          Individual recovery function is to be placed on the out-facing
+          (True) or in-facing (False) side of the port.";
         reference
-          "Clause 10.4.1.3 of IEEE Std 802.1CB-2017";
+          "10.4.1.3 of IEEE Std 802.1CB-2017";
       }
       leaf reset {
         type boolean;
         default "false";
         description
           "A Boolean object indicating that the Sequence recovery
-          function (7.4.2) or Individual recovery function (7.5) is to be
-          reset by calling its corresponding SequenceGenerationReset
-          function (7.4.1.3). Writing the value True to frerSeqRcvyReset
-          triggers a reset; writing the value False has no effect. When
-          read, frerSeqRcvyReset always returns the value False.";
+          function or Individual recovery function is to be reset by
+          calling its corresponding SequenceGenerationReset function.
+          Writing the value True to frerSeqRcvyReset triggers a reset;
+          writing the value False has no effect. When read,
+          frerSeqRcvyReset always returns the value False.";
         reference
-          "Clause 10.4.1.4 of IEEE Std 802.1CB-2017";
+          "10.4.1.4 of IEEE Std 802.1CB-2017";
       }
-      leaf algorithm {
-        type sequence-recovery-algorithm;
-        default "vector";
+      container algorithm {
         description
           "This object is an enumerated value specifying which sequence
           recovery algorithm is to be used for this instance of the
-          Sequence recovery function (7.4.2). The enumeration uses an OUI
-          or CID as shown in Table 10-1. The default value for
+          Sequence recovery function. The enumeration uses an OUI or CID
+          as shown in Table 10-1. The default value for
           frerSeqRcvyAlgorithm is Vector_Alg (00-80-C2, 0).";
         reference
-          "Clause 10.4.1.5 of IEEE Std 802.1CB-2017";
+          "10.4.1.5 of IEEE Std 802.1CB-2017";
+        uses sequence-recovery-algorithm;
       }
       leaf history-length {
-        when
-          "../algorithm != 'match'";
         type sequence-history-length;
         default "2";
         description
           "An integer specifying how many bits of the SequenceHistory
-          variable (7.4.3.2.2) are to be used. The minimum and the
-          default value is 2, maximum is the maximum allowed by the
-          implementation. [Not used if frerSeqRcvyAlgorithm (10.4.1.5) =
-          Match_Alg (00-80-C2, 1).]";
+          variable are to be used. The minimum and the default value is
+          2, maximum is the maximum allowed by the implementation. [Not
+          used if frerSeqRcvyAlgorithm = Match_Alg (00-80-C2, 1).]";
         reference
-          "Clause 10.4.1.6 of IEEE Std 802.1CB-2017";
+          "10.4.1.6 of IEEE Std 802.1CB-2017";
       }
       leaf reset-timeout {
         type uint32;
+        units "ms";
         description
           "An unsigned integer specifying the timeout period in
-          milliseconds for the RECOVERY_TIMEOUT event (item c in
-          7.4.3.1).";
+          milliseconds for the RECOVERY_TIMEOUT event.";
         reference
-          "Clause 10.4.1.7 of IEEE Std 802.1CB-2017";
+          "10.4.1.7 of IEEE Std 802.1CB-2017";
       }
       leaf invalid-sequence-value {
         type uint32;
         config false;
         description
           "A read-only unsigned integer value that cannot be encoded in a
-          packet as a value for the sequence_number subparameter (item b
-          in 6.1), i.e., frerSeqRcvyInvalidSequenceValue is larger than
-          or equal to RecovSeqSpace (7.4.3.2.1).";
+          packet as a value for the sequence_number subparameter, i.e.,
+          frerSeqRcvyInvalidSequenceValue is larger than or equal to
+          RecovSeqSpace.";
         reference
-          "Clause 10.4.1.8 of IEEE Std 802.1CB-2017";
+          "10.4.1.8 of IEEE Std 802.1CB-2017";
       }
       leaf take-no-sequence {
         type boolean;
@@ -365,145 +539,136 @@ module ieee802-dot1cb-frer {
         description
           "A Boolean value specifying whether packets with no
           sequence_number subparameter are to be accepted (True) or not
-          (False). Default value False. See item i in 7.1.1.";
+          (False). Default value False.";
         reference
-          "Clause 10.4.1.9 of IEEE Std 802.1CB-2017";
+          "10.4.1.9 of IEEE Std 802.1CB-2017";
       }
       leaf individual-recovery {
         type boolean;
         description
           "A Boolean value specifying whether this entry describes a
-          Sequence recovery function (7.4.2) or Individual recovery
-          function (7.5).
-           a) True: The entry describes an Individual recovery function
-              (7.5). Packets discarded by the SequenceGenerationAlgorithm
-              (7.4.1.4) will cause the variable RemainingTicks
-              (7.4.3.2.4) to be reset. There is no Latent error detection
-              function (7.4.4) associated with this entry, so
-              frerSeqRcvyLatentErrorDetection (10.4.1.11) cannot also be
-              True.
-           b) False: The entry describes a Sequence recovery function
-              (7.4.2). Packets discarded by the
-              SequenceGenerationAlgorithm (7.4.1.4) will not cause the
-              variable RemainingTicks (7.4.3.2.4) to be reset.";
+          Sequence recovery function or Individual recovery function.
+           a) True: The entry describes an Individual recovery function.
+              Packets discarded by the SequenceGenerationAlgorithm will
+              cause the variable RemainingTicks to be reset. There is no
+              Latent error detection function associated with this entry,
+              so frerSeqRcvyLatentErrorDetection cannot also be True.
+           b) False: The entry describes a Sequence recovery function.
+              Packets discarded by the SequenceGenerationAlgorithm will
+              not cause the variable RemainingTicks to be reset.";
         reference
-          "Clause 10.4.1.10 of IEEE Std 802.1CB-2017";
+          "10.4.1.10 of IEEE Std 802.1CB-2017";
       }
       leaf latent-error-detection {
-        when
-          "../individual-recovery = 'false'";
         type boolean;
         description
           "A Boolean value indicating whether an instance of the Latent
-          error detection function (7.4.4) is to be instantiated along
-          with the Base recovery function (7.4.3) in this Sequence
-          recovery function (7.4.2) or Individual recovery function
-          (7.5). frerSeqRcvyLatentErrorDetection cannot be set True if
-          frerSeqRcvyIndividualRecovery (10.4.1.10) is also True; an
-          Individual recovery function does not include a Latent error
-          detection function.";
+          error detection function is to be instantiated along with the
+          Base recovery function in this Sequence recovery function or
+          Individual recovery function. frerSeqRcvyLatentErrorDetection
+          cannot be set True if frerSeqRcvyIndividualRecovery is also
+          True; an Individual recovery function does not include a Latent
+          error detection function.";
         reference
-          "Clause 10.4.1.11 of IEEE Std 802.1CB-2017";
+          "10.4.1.11 of IEEE Std 802.1CB-2017";
       }
       container latent-error-detection-parameters {
-        when
-          "../individual-recovery = 'false'";
         description
           "The objects in the following subclauses are present if and
-          only if frerSeqRcvyIndividualRecovery (10.4.1.10) is False.";
+          only if frerSeqRcvyIndividualRecovery is False.";
         reference
-          "Clause 10.4.1.12 of IEEE Std 802.1CB-2017";
+          "10.4.1.12 of IEEE Std 802.1CB-2017";
         leaf difference {
           type int32;
           description
             "An integer specifying the maximum difference between
-            frerCpsSeqRcvyDiscardedPackets (10.8.6), and the product of
-            frerCpsSeqRcvyPassedPackets (10.8.5) and
-            (frerSeqRcvyLatentErrorPaths – 1) (10.4.1.12.3) that is
-            allowed. Any larger difference will trigger the detection of
-            a latent error by the LatentErrorTest function (7.4.4.4).";
+            frerCpsSeqRcvyDiscardedPackets, and the product of
+            frerCpsSeqRcvyPassedPackets and (frerSeqRcvyLatentErrorPaths
+            – 1) that is allowed. Any larger difference will trigger the
+            detection of a latent error by the LatentErrorTest function.";
           reference
-            "Clause 10.4.1.12.1 of IEEE Std 802.1CB-2017";
+            "10.4.1.12.1 of IEEE Std 802.1CB-2017";
         }
         leaf period {
           type uint32;
+          units "ms";
           default "2000";
           description
             "The integer number of milliseconds that are to elapse
-            between instances of running the LatentErrorTest function
-            (7.4.4.4). An implementation can have a minimum value for
+            between instances of running the LatentErrorTest function. An
+            implementation can have a minimum value for
             frerSeqRcvyLatentErrorPeriod, below which it cannot be set,
             but this minimum shall be no larger than 1000 ms (1 s).
             Default value 2000 (2 s).";
           reference
-            "Clause 10.4.1.12.2 of IEEE Std 802.1CB-2017";
+            "10.4.1.12.2 of IEEE Std 802.1CB-2017";
         }
         leaf paths {
           type uint16;
           description
             "The integer number of paths over which FRER is operating for
-            this instance of the Base recovery function (7.4.3) and
-            Latent error detection function (7.4.4).";
+            this instance of the Base recovery function and Latent error
+            detection function.";
           reference
-            "Clause 10.4.1.12.3 of IEEE Std 802.1CB-2017";
+            "10.4.1.12.3 of IEEE Std 802.1CB-2017";
         }
         leaf reset-period {
           type uint32;
+          units "ms";
           default "30000";
           description
             "The integer number of milliseconds that are to elapse
-            between instances of running the LatentErrorReset function
-            (7.4.4.3). An implementation can have a minimum value for
+            between instances of running the LatentErrorReset function.
+            An implementation can have a minimum value for
             LatentErrorReset, below which it cannot be set, but this
             minimum shall be no larger than 1000 ms (1 s). Default value
             30000 (30 s).";
           reference
-            "Clause 10.4.1.12.4 of IEEE Std 802.1CB-2017";
+            "10.4.1.12.4 of IEEE Std 802.1CB-2017";
         }
       }
     }
-    list sequence-identification-list {
-      key "port direction";
+    list sequence-identification {
+      key "port direction-out-facing";
       description
         "There is one Sequence identification table per system, and one
         entry in the Sequence identification table for each port and
         direction for which an instance of the Sequence encode/decode
-        function (7.6) is to be created. Each entry in the Sequence
+        function is to be created. Each entry in the Sequence
         identification table specifies a port and direction on which an
         instance of the Sequence encode/decode function is to be
         instantiated for a list of Streams.";
       reference
-        "Clause 10.5 of IEEE Std 802.1CB-2017";
-      leaf-list stream-list {
+        "10.5 of IEEE Std 802.1CB-2017";
+      leaf-list stream {
         type leafref {
-          path '/dot1cb-sid:stream-identity-list/dot1cb-sid:handle';
+          path '/dot1cb-sid:stream-identity/dot1cb-sid:handle';
         }
         min-elements 1;
         description
           "A list of stream_handles, corresponding to the values of the
-          tsnStreamIdHandle objects (9.1.1.1) in the Stream identity
-          table (9.1), for which the system is to use the same
-          encapsulation (10.5.1.5) for the Sequence encode/decode
-          function.";
+          tsnStreamIdHandle objects in the Stream identity table, for
+          which the system is to use the same encapsulation for the
+          Sequence encode/decode function.";
         reference
-          "Clause 10.5.1.1 of IEEE Std 802.1CB-2017";
+          "10.5.1.1 of IEEE Std 802.1CB-2017";
       }
       leaf port {
         type if:interface-ref;
         description
           "The port on which the system is to place an instance of the
-          Sequence encode/decode function (7.6).";
+          Sequence encode/decode function.";
         reference
-          "Clause 10.5.1.2 of IEEE Std 802.1CB-2017";
+          "10.5.1.2 of IEEE Std 802.1CB-2017";
       }
-      leaf direction {
+      leaf direction-out-facing {
         type dot1cb-sid-types:direction;
         description
           "An object indicating whether the Sequence encode/decode
-          function (7.6) is to be placed on the out-facing (True) or
-          in-facing (False) side of the port (Figure 6-6).";
+          function is to be placed on the out-facing (True) or in-facing
+          (False) side of the port.";
         reference
-          "Clause 10.5.1.3 of IEEE Std 802.1CB-2017";
+          "10.5.1.3 of IEEE Std 802.1CB-2017";
       }
       leaf active {
         type boolean;
@@ -515,87 +680,84 @@ module ieee802-dot1cb-frer {
           input packets and for encoding output packets being passed down
           the protocol stack.";
         reference
-          "Clause 10.5.1.4 of IEEE Std 802.1CB-2017";
+          "10.5.1.4 of IEEE Std 802.1CB-2017";
       }
-      leaf encapsulation {
-        type sequence-encode-decode-types;
+      container encapsulation {
         description
           "An enumerated value indicating the type of encapsulation used
-          for this instance of the Sequence encode/decode function (7.6).
-          The type includes an OUI or CID. The values defined by this
-          standard are shown in Table 10-2.";
+          for this instance of the Sequence encode/decode function. The
+          type includes an OUI or CID.";
         reference
-          "Clause 10.5.1.5 of IEEE Std 802.1CB-2017";
+          "10.5.1.5 of IEEE Std 802.1CB-2017";
+        uses sequence-encode-decode;
       }
       leaf path-id-lan-id {
         type lan-path-id;
         description
           "A 4-bit integer value to be placed in the PathId field of an
-          HSR sequence tag (7.9) or the LanId field of a PRP sequence
-          trailer (7.10) added to an output packet. This managed object
-          is used only if:
+          HSR sequence tag or the LanId field of a PRP sequence trailer
+          added to an output packet. This managed object is used only if:
            a) The HSR sequence tag or the PRP sequence trailer is
-              selected by the frerSeqEncEncapsType object (10.5.1.5); and
-           b) frerSeqEncActive (10.5.1.4) is False (passive)";
+              selected by the frerSeqEncEncapsType object; and
+           b) frerSeqEncActive is False (passive)";
         reference
-          "Clause 10.5.1.6 of IEEE Std 802.1CB-2017";
+          "10.5.1.6 of IEEE Std 802.1CB-2017";
       }
     }
-    list stream-split-list {
-      key "port direction";
+    list stream-split {
+      key "port direction-out-facing";
       description
         "There is one Stream split table per system, with one
-        frerSplitEntry (10.6.1) per Stream splitting function (7.7) per
-        set of stream_handle values. Each entry in the Stream split table
+        frerSplitEntry per Stream splitting function per set of
+        stream_handle values. Each entry in the Stream split table
         specifies a port and direction on which an instance of the Stream
         splitting function is to be instantiated, and the list of
         stream_handles specifying its operation.";
       reference
-        "Clause 10.6 of IEEE Std 802.1CB-2017";
+        "10.6 of IEEE Std 802.1CB-2017";
       leaf port {
         type if:interface-ref;
         description
           "The port on which the system is to place an instance of the
-          Stream splitting function (7.7) performing the stream_handle
+          Stream splitting function performing the stream_handle
           translations specified by frerSplitInputIdList and
-          frerSplitOutputIdList (10.6.1.3, 10.6.1.4) is to be placed.";
+          frerSplitOutputIdList is to be placed.";
         reference
-          "Clause 10.6.1.1 of IEEE Std 802.1CB-2017";
+          "10.6.1.1 of IEEE Std 802.1CB-2017";
       }
-      leaf direction {
+      leaf direction-out-facing {
         type dot1cb-sid-types:direction;
         description
           "An object indicating whether the instance of the Stream
-          splitting function (7.7) performing the stream_handle
-          translations specified by frerSplitInputIdList and
-          frerSplitOutputIdList (10.6.1.3, 10.6.1.4) is to be placed on
-          the out-facing (True) or in-facing (False) side of the port
-          (Figure 6-6).";
+          splitting function performing the stream_handle translations
+          specified by frerSplitInputIdList and frerSplitOutputIdList is
+          to be placed on the out-facing (True) or in-facing (False) side
+          of the port.";
         reference
-          "Clause 10.6.1.2 of IEEE Std 802.1CB-2017";
+          "10.6.1.2 of IEEE Std 802.1CB-2017";
       }
-      leaf-list input-id-list {
+      leaf-list input-id {
         type leafref {
-          path '/dot1cb-sid:stream-identity-list/dot1cb-sid:handle';
+          path '/dot1cb-sid:stream-identity/dot1cb-sid:handle';
         }
         min-elements 1;
         description
-          "A list of stream_handles (tsnStreamIdHandle values, 9.1.1.1)
-          that are to be split.";
+          "A list of stream_handles (tsnStreamIdHandle values) that are
+          to be split.";
         reference
-          "Clause 10.6.1.3 of IEEE Std 802.1CB-2017";
+          "10.6.1.3 of IEEE Std 802.1CB-2017";
       }
-      leaf-list output-id-list {
+      leaf-list output-id {
         type leafref {
-          path '/dot1cb-sid:stream-identity-list/dot1cb-sid:handle';
+          path '/dot1cb-sid:stream-identity/dot1cb-sid:handle';
         }
         min-elements 1;
         description
-          "A list of stream_handles (tsnStreamIdHandle values, 9.1.1.1)
-          into which the input packet is to be split, one copy per item
-          in the frerSplitOutputIdList.";
+          "A list of stream_handles (tsnStreamIdHandle values) into which
+          the input packet is to be split, one copy per item in the
+          frerSplitOutputIdList.";
         reference
-          "Clause 10.6.1.4 of IEEE Std 802.1CB-2017";
+          "10.6.1.4 of IEEE Std 802.1CB-2017";
       }
     }
     container autoconfiguration {
@@ -603,47 +765,45 @@ module ieee802-dot1cb-frer {
       description
         "Container for autoconfiguration managed objects.";
       reference
-        "Clause 10.7 of IEEE Std 802.1CB-2017";
-      list sequence-list {
+        "10.7 of IEEE Std 802.1CB-2017";
+      list sequence {
         key "index";
         description
           "There is one Sequence autoconfiguration table per system. It
-          contains any number of table entries (10.7.1.1). No two (or
-          more) entries in the Sequence autoconfiguration table can have
-          the same values for frerAutSeqSeqEncaps (10.7.1.1.1),
-          frerAutSeqTagged (10.7.1.1.3), and frerAutSeqVlan (10.7.1.1.4)
-          on any given port (10.7.1.1.2). Each frerAutSeqEntry objects
+          contains any number of table entries. No two (or more) entries
+          in the Sequence autoconfiguration table can have the same
+          values for frerAutSeqSeqEncaps, frerAutSeqTagged, and
+          frerAutSeqVlan on any given port. Each frerAutSeqEntry objects
           relates to a single class of Streams, and specifies how entries
           are created (and destroyed) in the Stream identity table, the
           Sequence recovery table, and the Sequence identification table.";
         reference
-          "Clause 10.7.1 of IEEE Std 802.1CB-2017";
+          "10.7.1 of IEEE Std 802.1CB-2017";
         leaf index {
           type uint32;
           description
             "Entry in the sequence list referencing to a single class of
             streams.";
         }
-        leaf sequence-encapsulation {
-          type sequence-encode-decode-types;
+        container sequence-encapsulation {
           description
-            "An enumerated value from Table 10-2, specifying which
-            Sequence encode/decode function, and therefore, which type
-            sequence_number encoding, is to be recognized for the
-            purposes of Autoconfiguration.";
+            "An enumerated value, specifying which Sequence encode/decode
+            function, and therefore, which type sequence_number encoding,
+            is to be recognized for the purposes of Autoconfiguration.";
           reference
-            "Clause 10.7.1.1.1 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.1 of IEEE Std 802.1CB-2017";
+          uses sequence-encode-decode;
         }
-        leaf-list receive-port-list {
+        leaf-list receive-port {
           type if:interface-ref;
           min-elements 1;
           description
             "The list of ports to which this frerAutSeqEntry applies, and
-            on which Stream identification functions (6.2), Sequence
-            encode/decode functions (7.6), and Individual recovery
-            functions (7.5) are to be autocreated.";
+            on which Stream identification functions, Sequence
+            encode/decode functions, and Individual recovery functions
+            are to be autocreated.";
           reference
-            "Clause 10.7.1.1.2 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.2 of IEEE Std 802.1CB-2017";
         }
         leaf tagged {
           type enumeration {
@@ -668,27 +828,28 @@ module ieee802-dot1cb-frer {
             "An enumerated value indicating whether packets to be matched
             by this frerAutSeqEntry are permitted to have a VLAN tag.";
           reference
-            "Clause 10.7.1.1.3 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.3 of IEEE Std 802.1CB-2017";
         }
-        leaf-list vlan-list {
+        leaf-list vlan {
           type dot1qtypes:vlanid;
           description
             "A list of vlan_identifiers for the packet to match. A null
             list matches all vlan_identifiers.";
           reference
-            "Clause 10.7.1.1.4 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.4 of IEEE Std 802.1CB-2017";
         }
-        leaf-list recovery-port-list {
+        leaf-list recovery-port {
           type if:interface-ref;
           min-elements 1;
           description
-            "The list of ports on which Sequence recovery functions
-            (7.4.2) are to be autocreated by this frerAutSeqEntry.";
+            "The list of ports on which Sequence recovery functions are
+            to be autocreated by this frerAutSeqEntry.";
           reference
-            "Clause 10.7.1.1.5 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.5 of IEEE Std 802.1CB-2017";
         }
         leaf destruction-interval {
           type uint64;
+          units "ms";
           default "86400000";
           description
             "An integer number of milliseconds after which an idle set of
@@ -697,35 +858,33 @@ module ieee802-dot1cb-frer {
             not to be destroyed. Default value is 86 400 000 decimal (one
             day).";
           reference
-            "Clause 10.7.1.1.6 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.6 of IEEE Std 802.1CB-2017";
         }
         leaf reset-interval {
           type uint64;
+          units "ms";
           description
-            "The value used to fill frerSeqRcvyResetMSec (10.4.1.7) when
+            "The value used to fill frerSeqRcvyResetMSec when
             autoconfiguring entries in the Sequence recovery table.";
           reference
-            "Clause 10.7.1.1.7 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.7 of IEEE Std 802.1CB-2017";
         }
-        leaf algorithm {
-          type sequence-recovery-algorithm;
-          default "vector";
+        container algorithm {
           description
-            "The value used to fill frerSeqRcvyAlgorithm (10.4.1.5) when
+            "The value used to fill frerSeqRcvyAlgorithm when
             autoconfiguring entries in the Sequence recovery table.";
           reference
-            "Clause 10.7.1.1.8 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.8 of IEEE Std 802.1CB-2017";
+          uses sequence-recovery-algorithm;
         }
         leaf history-length {
-          when
-            "../algorithm != 'match'";
           type sequence-history-length;
           default "2";
           description
-            "The value used to fill frerSeqRcvyHistoryLength (10.4.1.6)
-            when autoconfiguring entries in the Sequence recovery table.";
+            "The value used to fill frerSeqRcvyHistoryLength when
+            autoconfiguring entries in the Sequence recovery table.";
           reference
-            "Clause 10.7.1.1.9 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.9 of IEEE Std 802.1CB-2017";
         }
         leaf create-individual {
           type boolean;
@@ -735,7 +894,7 @@ module ieee802-dot1cb-frer {
             triggers the instantiation of a frerSeqRcvyEntry for an
             Individual recovery function.";
           reference
-            "Clause 10.7.1.1.10 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.10 of IEEE Std 802.1CB-2017";
         }
         leaf create-recovery {
           type boolean;
@@ -745,7 +904,7 @@ module ieee802-dot1cb-frer {
             also trigger the instantiation of a frerSeqRcvyEntry for a
             Sequence recovery function.";
           reference
-            "Clause 10.7.1.1.11 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.11 of IEEE Std 802.1CB-2017";
         }
         leaf latent-error-detection {
           type boolean;
@@ -754,325 +913,324 @@ module ieee802-dot1cb-frer {
             Sequence recovery function also creates an associated Latent
             Error Detection function.";
           reference
-            "Clause 10.7.1.1.12 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.12 of IEEE Std 802.1CB-2017";
         }
         leaf latent-error-difference {
           type int32;
           description
-            "The value used to fill frerSeqRcvyLatentErrorDifference
-            (10.4.1.12.1) when autoconfiguring entries in the Sequence
-            recovery table.";
+            "The value used to fill frerSeqRcvyLatentErrorDifference when
+            autoconfiguring entries in the Sequence recovery table.";
           reference
-            "Clause 10.7.1.1.13 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.13 of IEEE Std 802.1CB-2017";
         }
         leaf latent-error-period {
           type uint32;
+          units "ms";
           default "2000";
           description
-            "The value used to fill frerSeqRcvyLatentErrorPeriod
-            (10.4.1.12.2) when autoconfiguring entries in the Sequence
-            recovery table.";
+            "The value used to fill frerSeqRcvyLatentErrorPeriod when
+            autoconfiguring entries in the Sequence recovery table.";
           reference
-            "Clause 10.7.1.1.14 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.14 of IEEE Std 802.1CB-2017";
         }
         leaf latent-error-reset-period {
           type uint32;
+          units "ms";
           default "30000";
           description
-            "The value used to fill frerSeqRcvyLatentResetPeriod
-            (10.4.1.12.4) when autoconfiguring entries in the Sequence
-            recovery table.";
+            "The value used to fill frerSeqRcvyLatentResetPeriod when
+            autoconfiguring entries in the Sequence recovery table.";
           reference
-            "Clause 10.7.1.1.15 of IEEE Std 802.1CB-2017";
+            "10.7.1.1.15 of IEEE Std 802.1CB-2017";
         }
       }
-      list output-list {
+      list output {
         key "index";
         description
           "There is one Output autoconfiguration table per system. It
-          contains any number of frerAutOutEntry objects (10.7.2.1), each
-          relating to a single class of Streams specifying how active
-          entries are created in the Sequence identification table
-          (10.5). No two (or more) entries in the Output
-          autoconfiguration table can include the same port in their
-          frerAutSeqReceivePortList objects.";
+          contains any number of frerAutOutEntry objects, each relating
+          to a single class of Streams specifying how active entries are
+          created in the Sequence identification table. No two (or more)
+          entries in the Output autoconfiguration table can include the
+          same port in their frerAutSeqReceivePortList objects.";
         reference
-          "Clause 10.7.2 of IEEE Std 802.1CB-2017";
+          "10.7.2 of IEEE Std 802.1CB-2017";
         leaf index {
           type uint32;
           description
             "Entry in the output list referencing to a single class of
             streams.";
         }
-        leaf-list port-list {
+        leaf-list port {
           type if:interface-ref;
           min-elements 1;
           description
             "The list of ports to which this frerAutOutEntry applies, and
-            on which active Sequence encode/decode functions (7.6) are to
-            be autocreated.";
+            on which active Sequence encode/decode functions are to be
+            autocreated.";
           reference
-            "Clause 10.7.2.1.1 of IEEE Std 802.1CB-2017";
+            "10.7.2.1.1 of IEEE Std 802.1CB-2017";
         }
-        leaf encapsulation {
-          type sequence-encode-decode-types;
+        container encapsulation {
           description
-            "An enumerated value from Table 10-2, specifying which
-            Sequence encode/decode function, and therefore, which type
-            sequence_number encoding, is to be used for autoconfigured
-            Streams on the ports in frerAutSeqReceivePortList
-            (10.7.1.1.2).";
+            "An enumerated value, specifying which Sequence encode/decode
+            function, and therefore, which type sequence_number encoding,
+            is to be used for autoconfigured Streams on the ports in
+            frerAutSeqReceivePortList.";
           reference
-            "Clause 10.7.2.1.2 of IEEE Std 802.1CB-2017";
+            "10.7.2.1.2 of IEEE Std 802.1CB-2017";
+          uses sequence-encode-decode;
         }
         leaf lan-path-id {
           type lan-path-id;
           description
             "An integer specifying a path or LAN. If and only if
-            frerAutOutEncaps (10.7.2.1.2) specifies HSR or PRP
-            frerAutOutLanPathId specifies the LanId or PathId value to be
-            inserted into the HSR sequence tag or PRP sequence trailer of
-            autoconfigured packets transmitted on the ports in
-            frerAutSeqReceivePortList (10.7.1.1.2).";
+            frerAutOutEncaps specifies HSR or PRP frerAutOutLanPathId
+            specifies the LanId or PathId value to be inserted into the
+            HSR sequence tag or PRP sequence trailer of autoconfigured
+            packets transmitted on the ports in
+            frerAutSeqReceivePortList.";
           reference
-            "Clause 10.7.2.1.3 of IEEE Std 802.1CB-2017";
+            "10.7.2.1.3 of IEEE Std 802.1CB-2017";
         }
       }
     }
   }
-  augment "/dot1cb-sid:stream-identity-list" {
+  augment "/dot1cb-sid:stream-identity" {
     if-feature "auto-configuration";
     description
-      "Two managed objects augment each tsnStreamIdEntry (9.1.1) in the
-      Stream identity table (9.1) when Managed objects for
-      autoconfiguration (7.11, 10.7) is implemented.";
+      "Two managed objects augment each tsnStreamIdEntry in the Stream
+      identity table when Managed objects for autoconfiguration is
+      implemented.";
     reference
-      "Clause 10.2 of IEEE Std 802.1CB-2017";
+      "10.2 of IEEE Std 802.1CB-2017";
     leaf auto-configured {
       type boolean;
       config false;
       description
         "A read-only Boolean value, supplied by the system, specifying
         whether this entry was created explicitly (False) or via the
-        Sequence autoconfiguration table (10.7.1, True).";
+        Sequence autoconfiguration table.";
       reference
-        "Clause 10.2.1 of IEEE Std 802.1CB-2017";
+        "10.2.1 of IEEE Std 802.1CB-2017";
     }
     leaf lan-path-id {
       type lan-path-id;
       description
         "An integer specifying a path or LAN. If and only if a packet
-        matches an entry in the Sequence identification table (10.5) that
-        specifies HSR or PRP in its frerSeqEncEncapsType (10.5.1.5)
-        object, tsnStreamIdLanPathId specifies the LanId or PathId value
-        that must be matched for this tsnStreamIdEntry to apply. A value
-        of –1 indicates that the LanId or PathId are to be ignored.";
+        matches an entry in the Sequence identification table that
+        specifies HSR or PRP in its frerSeqEncEncapsType object,
+        tsnStreamIdLanPathId specifies the LanId or PathId value that
+        must be matched for this tsnStreamIdEntry to apply. A value of –1
+        indicates that the LanId or PathId are to be ignored.";
       reference
-        "Clause 10.2.2 of IEEE Std 802.1CB-2017";
+        "10.2.2 of IEEE Std 802.1CB-2017";
     }
   }
   augment "/if:interfaces/if:interface/if:statistics" {
     description
-      "The following counters are instantiated for each port on which any
-      of the Stream identification function (6.2), Sequencing function
-      (7.4), or Sequence encode/decode function (7.6) is configured. The
-      counters are indexed by port number, facing (in-facing or
-      out-facing), and stream_handle value (tsnStreamIdHandle, 9.1.1.1).
-      All counters are unsigned integers. If used on links faster than
-      650 000 000 bits per second, they shall be 64 bits in length to
-      ensure against excessively short wrap times.
+      "The following counters are the counters for frame replication and
+      elimination for reliability. All counters are unsigned integers. If
+      used on links faster than 650 000 000 bits per second, they shall
+      be 64 bits in length to ensure against excessively short wrap
+      times.
       
-      A Stream identification component (5.3) shall implement the first
-      two counters tsnCpsSidInputPackets (9.2.1) and
-      tsnCpsSidOutputPackets (9.2.2); the remainder of the counters in
-      10.8 are optional for such a system.";
+      A Stream identification component shall implement the first two
+      counters provided in the stream-identification YANG module per-port
+      counters, input-packets and output-packets; the remainder of the
+      counters in the frer YANG module module are optional for such a
+      system.";
     reference
-      "Clause 10.8  of IEEE Std 802.1CB-2017";
-    list frame-replication-and-elimination-per-port-per-stream-counters {
-      key "direction handle";
-      config false;
+      "10.8 of IEEE Std 802.1CB-2017
+      10.9 of IEEE Std 802.1CB-2017";
+    container frer {
       description
-        "Contains the per-port-per-stream counters for frame replication
-        and elimination. The following counters are instantiated for each
-        port on which any of the Stream identification function,
-        Sequencing function, or Sequence encode/decode function is
-        configured. The counters are indexed by port number, facing
-        (in-facing or out-facing), and stream_handle value.";
+        "This container contains the per-port as well as the
+        per-port-per-stream counters for frame replication and
+        elimination for reliability.";
       reference
-        "Clause 10.8 of IEEE Std 802.1CB-2017";
-      leaf direction {
-        type dot1cb-sid-types:direction;
+        "10.8 of IEEE Std 802.1CB-2017
+        10.9 of IEEE Std 802.1CB-2017";
+      container per-port-counters {
+        config false;
         description
-          "An object indicating whether the counters apply to out-facing
-          (True) or in-facing (False).";
-      }
-      leaf handle {
-        type leafref {
-          path '/dot1cb-sid:stream-identity-list/dot1cb-sid:handle';
+          "Contains the per-port counters for frame replication and
+          elimination for reliability. The following counters are
+          instantiated for each port on which any of the Stream
+          identification function, Sequencing function, or Sequence
+          encode/decode function is configured. The counters are indexed
+          by port number.";
+        leaf rx-passed-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpSeqRcvyPassedPackets counter is incremented once
+            for each packet passed up the stack by the
+            VectorRecoveryAlgorithm or MatchRecoveryAlgorithm. Its value
+            equals the sum (modulo the size of the counters) of all of
+            the frerCpsSeqRcvyPassedPackets counters on this same port.";
+          reference
+            "10.9.1 of IEEE Std 802.1CB-2017";
         }
-        description
-          "The according tsnStreamIdHandle for the counters.";
+        leaf rx-discarded-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpSeqRcvyDiscardPackets counter is incremented once
+            for each packet discarded due to a duplicate sequence number
+            or for being a rogue packet by any VectorRecoveryAlgorithm or
+            MatchRecoveryAlgorithm on this port. Its value equals the sum
+            (modulo the size of the counters) of all of the
+            frerCpsSeqRcvyRoguePackets and frerCpsSeqRcvyDiscardedPackets
+            counters on this same port.";
+          reference
+            "10.9.2 of IEEE Std 802.1CB-2017";
+        }
+        leaf encode-errored-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpSeqEncErroredPackets counter is incremented once
+            each time the Sequence encode/decode function receives a
+            packet that it is unable to decode successfully. Its value
+            equals the sum (modulo the size of the counters) of all of
+            the frerCpsSeqEncErroredPackets counters on this same port.";
+          reference
+            "10.9.2 of IEEE Std 802.1CB-2017";
+        }
       }
-      leaf generation-reset {
-        type uint64;
+      list per-port-per-stream-counters {
+        key "direction-out-facing handle";
         config false;
         description
-          "The frerCpsSeqGenResets counter is incremented each time the
-          SequenceGenerationReset function (7.4.1.3) is called.";
+          "Contains the per-port-per-stream counters for frame
+          replication and elimination for reliability. The following
+          counters are instantiated for each port on which any of the
+          Stream identification function, Sequencing function, or
+          Sequence encode/decode function is configured. The counters are
+          indexed by port number, facing (in-facing or out-facing), and
+          stream_handle value.";
         reference
-          "Clause 10.8.2 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-out-of-order-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqRcvyOutOfOrderPackets counter is incremented
-          once for each packet accepted out-of-order by the
-          VectorRecoveryAlgorithm (7.4.3.4) or MatchRecoveryAlgorithm
-          (7.4.3.5). Out-of-order means that the packet’s sequence number
-          is not one more than the previous packet received. (See item m
-          in 7.1.1.)";
-        reference
-          "Clause 10.8.3 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-rouge-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqRcvyRoguePackets counter is incremented once for
-          each packet discarded by the VectorRecoveryAlgorithm (7.4.3.4)
-          because its sequence_number subparameter is more than
-          frerSeqRcvyHistoryLength (10.4.1.6) from RecovSeqNum
-          (7.4.3.2.3).";
-        reference
-          "Clause 10.8.4 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-passed-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqRcvyPassedPackets counter is incremented once
-          for each packet passed up the stack by the
-          VectorRecoveryAlgorithm (7.4.3.4) or MatchRecoveryAlgorithm
-          (7.4.3.5).";
-        reference
-          "Clause 10.8.5 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-discarded-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqRcvyDiscardedPackets counter is incremented once
-          for each packet discarded due to a duplicate sequence number by
-          the VectorRecoveryAlgorithm (7.4.3.4) or MatchRecoveryAlgorithm
-          (7.4.3.5).";
-        reference
-          "Clause 10.8.6 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-lost-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqRcvyLostPackets counter is incremented once for
-          each packet lost by the VectorRecoveryAlgorithm (7.4.3.4). A
-          packet is counted as lost if its sequence number is not
-          received on any ingress port.
-          
-          NOTE—If per-source sequence numbering is used,
-          frerCpsSeqRcvyLostPackets can count, as lost, packets that were
-          sent to another destination, but not lost. See B.2.";
-        reference
-          "Clause 10.8.7 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-tagless-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqRcvyTaglessPackets counter is incremented once
-          for each packet received by the VectorRecoveryAlgorithm
-          (7.4.3.4) that has no sequence_number subparameter (item b in
-          6.1).";
-        reference
-          "Clause 10.8.8 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-resets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqRcvyResets counter is incremented once each time
-          the SequenceRecoveryReset function (7.4.3.3) is called.";
-        reference
-          "Clause 10.8.9 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-latent-error-resets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqRcvyLatentErrorResets counter is incremented
-          once each time the LatentErrorReset function (7.4.4.3) is
-          called.";
-        reference
-          "Clause 10.8.10 of IEEE Std 802.1CB-2017";
-      }
-      leaf encode-errored-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpsSeqEncErroredPackets counter is incremented once
-          each time the Sequence encode/decode function (7.6) receives a
-          packet that it is unable to decode successfully.";
-        reference
-          "Clause 10.8.11 of IEEE Std 802.1CB-2017";
-      }
-    }
-    container frame-replication-and-elimination-per-port-counters {
-      config false;
-      description
-        "Contains the per-port counters for frame replication and
-        elimination. The following counters are instantiated for each
-        port on which any of the Stream identification function,
-        Sequencing function, or Sequence encode/decode function is
-        configured. The counters are indexed by port number.";
-      leaf receive-passed-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpSeqRcvyPassedPackets counter is incremented once for
-          each packet passed up the stack by the VectorRecoveryAlgorithm
-          (7.4.3.4) or MatchRecoveryAlgorithm (7.4.3.5). Its value equals
-          the sum (modulo the size of the counters) of all of the
-          frerCpsSeqRcvyPassedPackets (10.8.5) counters on this same
-          port.";
-        reference
-          "Clause 10.9.1 of IEEE Std 802.1CB-2017";
-      }
-      leaf receive-discarded-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpSeqRcvyDiscardPackets counter is incremented once
-          for each packet discarded due to a duplicate sequence number or
-          for being a rogue packet by any VectorRecoveryAlgorithm
-          (7.4.3.4) or MatchRecoveryAlgorithm (7.4.3.5) on this port. Its
-          value equals the sum (modulo the size of the counters) of all
-          of the frerCpsSeqRcvyRoguePackets (10.8.4) and
-          frerCpsSeqRcvyDiscardedPackets (10.8.6) counters on this same
-          port.";
-        reference
-          "Clause 10.9.2 of IEEE Std 802.1CB-2017";
-      }
-      leaf encode-errored-packets {
-        type uint64;
-        config false;
-        description
-          "The frerCpSeqEncErroredPackets counter is incremented once
-          each time the Sequence encode/decode function (7.6) receives a
-          packet that it is unable to decode successfully. Its value
-          equals the sum (modulo the size of the counters) of all of the
-          frerCpsSeqEncErroredPackets (10.8.11) counters on this same
-          port.";
-        reference
-          "Clause 10.9.2 of IEEE Std 802.1CB-2017";
+          "10.8 of IEEE Std 802.1CB-2017";
+        leaf direction-out-facing {
+          type dot1cb-sid-types:direction;
+          description
+            "An object indicating whether the counters apply to
+            out-facing (True) or in-facing (False).";
+        }
+        leaf handle {
+          type leafref {
+            path '/dot1cb-sid:stream-identity/dot1cb-sid:handle';
+          }
+          description
+            "The according tsnStreamIdHandle for the counters.";
+        }
+        leaf generation-reset {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqGenResets counter is incremented each time the
+            SequenceGenerationReset function is called.";
+          reference
+            "10.8.2 of IEEE Std 802.1CB-2017";
+        }
+        leaf rx-out-of-order-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqRcvyOutOfOrderPackets counter is incremented
+            once for each packet accepted out-of-order by the
+            VectorRecoveryAlgorithm or MatchRecoveryAlgorithm.
+            Out-of-order means that the packet’s sequence number is not
+            one more than the previous packet received.";
+          reference
+            "10.8.3 of IEEE Std 802.1CB-2017";
+        }
+        leaf rx-rogue-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqRcvyRoguePackets counter is incremented once
+            for each packet discarded by the VectorRecoveryAlgorithm
+            because its sequence_number subparameter is more than
+            frerSeqRcvyHistoryLength from RecovSeqNum.";
+          reference
+            "10.8.4 of IEEE Std 802.1CB-2017";
+        }
+        leaf rx-passed-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqRcvyPassedPackets counter is incremented once
+            for each packet passed up the stack by the
+            VectorRecoveryAlgorithm or MatchRecoveryAlgorithm.";
+          reference
+            "10.8.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf rx-discarded-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqRcvyDiscardedPackets counter is incremented
+            once for each packet discarded due to a duplicate sequence
+            number by the VectorRecoveryAlgorithm or
+            MatchRecoveryAlgorithm.";
+          reference
+            "10.8.6 of IEEE Std 802.1CB-2017";
+        }
+        leaf rx-lost-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqRcvyLostPackets counter is incremented once
+            for each packet lost by the VectorRecoveryAlgorithm. A packet
+            is counted as lost if its sequence number is not received on
+            any ingress port.
+            
+            NOTE—If per-source sequence numbering is used,
+            frerCpsSeqRcvyLostPackets can count, as lost, packets that
+            were sent to another destination, but not lost.";
+          reference
+            "10.8.7 of IEEE Std 802.1CB-2017";
+        }
+        leaf rx-tagless-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqRcvyTaglessPackets counter is incremented once
+            for each packet received by the VectorRecoveryAlgorithm that
+            has no sequence_number subparameter.";
+          reference
+            "10.8.8 of IEEE Std 802.1CB-2017";
+        }
+        leaf rx-resets {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqRcvyResets counter is incremented once each
+            time the SequenceRecoveryReset function is called.";
+          reference
+            "10.8.9 of IEEE Std 802.1CB-2017";
+        }
+        leaf rx-latent-error-resets {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqRcvyLatentErrorResets counter is incremented
+            once each time the LatentErrorReset function is called.";
+          reference
+            "10.8.10 of IEEE Std 802.1CB-2017";
+        }
+        leaf encode-errored-pkts {
+          type uint64;
+          config false;
+          description
+            "The frerCpsSeqEncErroredPackets counter is incremented once
+            each time the Sequence encode/decode function receives a
+            packet that it is unable to decode successfully.";
+          reference
+            "10.8.11 of IEEE Std 802.1CB-2017";
+        }
       }
     }
   }

--- a/standard/ieee/draft/802.1/CBcv/ieee802-dot1cb-stream-identification-types.yang
+++ b/standard/ieee/draft/802.1/CBcv/ieee802-dot1cb-stream-identification-types.yang
@@ -7,47 +7,33 @@ module ieee802-dot1cb-stream-identification-types {
     "Institute of Electrical and Electronics Engineers";
   contact
     "WG-URL: http://ieee802.org/1/
-     WG-EMail: stds-802-1-l@ieee.org
+    WG-EMail: stds-802-1-l@ieee.org
     
-     Contact: IEEE 802.1 Working Group Chair
-              Postal: C/O IEEE 802.1 Working Group
-              IEEE Standards Association
-              445 Hoes Lane
-              Piscataway, NJ 08854
-              USA
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+        IEEE Standards Association
+        445 Hoes Lane
+        Piscataway, NJ 08854
+        USA
     
-     E-mail: stds-802-1-chairs@ieee.org";
+    E-mail: stds-802-1-chairs@ieee.org";
   description
     "Management objects that control the stream identification from IEEE
     Std 802.1CB-2017. This YANG data model conforms to the Network
-    Management Datastore Architecture defined in RFC 8342.";
-  revision 2020-11-27 {
+    Management Datastore Architecture defined in RFC 8342. Copyright (C)
+    IEEE (2021). This version of this YANG module is part of IEEE Std
+    802.1CBcv; see the draft itself for full legal notices.";
+  revision 2021-05-06 {
     description
-      "D1.0 revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
+      "Published as part of IEEE Std 802.1CBcv-2021. Initial version.";
     reference
-      "Clause 10 of IEEE Std 802.1CB-2017";
+      "IEEE Std 802.1CBcv-2021, Frame Replication and Elimination for
+      Reliability - FRER YANG Data Model and Management Information Base
+      Module.";
   }
-  revision 2020-08-05 {
+  identity strid-idty {
     description
-      "D0.4 revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
-    reference
-      "Clause 9 of IEEE Std 802.1CB-2017";
-  }
-  revision 2020-04-29 {
-    description
-      "D0.3 revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
-    reference
-      "Clause 10 of IEEE Std 802.1CB-2017";
-  }
-  revision 2019-09-01 {
-    description
-      "Initial revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
-    reference
-      "Clause 9 of IEEE Std 802.1CB-2017";
+      "Root identity for all stream identification types";
   }
   typedef direction {
     type boolean;
@@ -55,6 +41,44 @@ module ieee802-dot1cb-stream-identification-types {
       "A boolean object indicating whether the direction is out-facing
       (True) or in-facing (False).";
     reference
-      "Clause 10.4.1.3 of IEEE Std 802.1CB-2017";
+      "10.4.1.3 of IEEE Std 802.1CB-2017";
+  }
+  typedef stream-id-function {
+    type enumeration {
+      enum reserved {
+        value 0;
+        description
+          "Reserved value.";
+      }
+      enum null-stream {
+        value 1;
+        description
+          "The stream identification type used for the Null Stream
+          identification method.";
+      }
+      enum smac-vlan {
+        value 2;
+        description
+          "The stream identification type used for the Source MAC and
+          VLAN Stream identification method.";
+      }
+      enum dmac-vlan {
+        value 3;
+        description
+          "The stream identification type used for the Active Destination
+          MAC and VLAN Stream identification method.";
+      }
+      enum ip {
+        value 4;
+        description
+          "The stream identification type used for the IP Stream
+          identification method.";
+      }
+    }
+    description
+      "An enumerated value indicating the method used to identify packets
+      belonging to a Stream.";
+    reference
+      "9.1.1.6 of IEEE Std 802.1CB-2017";
   }
 }

--- a/standard/ieee/draft/802.1/CBcv/ieee802-dot1cb-stream-identification.yang
+++ b/standard/ieee/draft/802.1/CBcv/ieee802-dot1cb-stream-identification.yang
@@ -21,62 +21,47 @@ module ieee802-dot1cb-stream-identification {
     "Institute of Electrical and Electronics Engineers";
   contact
     "WG-URL: http://ieee802.org/1/
-     WG-EMail: stds-802-1-l@ieee.org
+    WG-EMail: stds-802-1-l@ieee.org
     
-     Contact: IEEE 802.1 Working Group Chair
-              Postal: C/O IEEE 802.1 Working Group
-              IEEE Standards Association
-              445 Hoes Lane
-              Piscataway, NJ 08854
-              USA
+    Contact: IEEE 802.1 Working Group Chair
+    Postal: C/O IEEE 802.1 Working Group
+        IEEE Standards Association
+        445 Hoes Lane
+        Piscataway, NJ 08854
+        USA
     
-     E-mail: stds-802-1-chairs@ieee.org";
+    E-mail: stds-802-1-chairs@ieee.org";
   description
     "Management objects that control the stream identification from IEEE
     Std 802.1CB-2017. This YANG data model conforms to the Network
-    Management Datastore Architecture defined in RFC 8342.";
-  revision 2020-11-27 {
+    Management Datastore Architecture defined in RFC 8342. Copyright (C)
+    IEEE (2021). This version of this YANG module is part of IEEE Std
+    802.1CBcv; see the draft itself for full legal notices.";
+  revision 2021-05-06 {
     description
-      "D1.0 revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
+      "Published as part of IEEE Std 802.1CBcv-2021. Initial version.";
     reference
-      "Clause 10 of IEEE Std 802.1CB-2017";
-  }
-  revision 2020-04-29 {
-    description
-      "D0.3 revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
-    reference
-      "Clause 10 of IEEE Std 802.1CB-2017";
-  }
-  revision 2019-09-01 {
-    description
-      "Initial revision. Note that this module might change in backward
-      incompatible ways until approved as a standard.";
-    reference
-      "Clause 9 of IEEE Std 802.1CB-2017";
-  }
-  identity strid-idty {
-    description
-      "Root identity for all stream identification types";
+      "IEEE Std 802.1CBcv-2021, Frame Replication and Elimination for
+      Reliability - FRER YANG Data Model and Management Information Base
+      Module.";
   }
   identity null-stream-identification {
-    base strid-idty;
+    base dot1cb-sid-types:strid-idty;
     description
       "Null Stream Identification";
   }
   identity smac-vlan-stream-identification {
-    base strid-idty;
+    base dot1cb-sid-types:strid-idty;
     description
       "Source MAC and VLAN Stream Identification";
   }
   identity dmac-vlan-stream-identification {
-    base strid-idty;
+    base dot1cb-sid-types:strid-idty;
     description
       "Active Destination MAC and VLAN Stream Identification";
   }
   identity ip-stream-identification {
-    base strid-idty;
+    base dot1cb-sid-types:strid-idty;
     description
       "IP Stream Identification";
   }
@@ -111,26 +96,26 @@ module ieee802-dot1cb-stream-identification {
     }
     description
       "Specifies the vlan_identifier. A value of 0 indicates that the
-      vlan_identifier parameter is ignored.";
+      vlan_identifier carries a special meaning.";
   }
-  list stream-identity-list {
+  list stream-identity {
     key "index";
     description
       "The Stream identity table consists of a set of tsnStreamIdEntry
-      objects (9.1.1), each relating to a single Stream, specifying the
-      points in the system where Stream identification functions (6.2)
-      are to be instantiated. Each entry in the Stream identity table has
-      a tsnStreamIdHandle object (9.1.1.1) specifying a stream_handle
-      value and one or more tsnStreamIdEntry objects (9.1.1) describing
-      one identification method for that Stream. If a single Stream has
-      multiple identification methods, perhaps (but not necessarily) on
-      different ports, then there can be multiple tsnStreamIdEntry
-      objects with the same value for the tsnStreamIdHandle. If the HSR
-      or PRP method or the Sequence encode/decode function is applied to
-      a packet, then the LanId or PathId fields are also used to identify
-      the Stream to which the packet belongs.";
+      objects, each relating to a single Stream, specifying the points in
+      the system where Stream identification functions are to be
+      instantiated. Each entry in the Stream identity table has a
+      tsnStreamIdHandle object specifying a stream_handle value and one
+      or more tsnStreamIdEntry objects describing one identification
+      method for that Stream. If a single Stream has multiple
+      identification methods, perhaps (but not necessarily) on different
+      ports, then there can be multiple tsnStreamIdEntry objects with the
+      same value for the tsnStreamIdHandle. If the HSR or PRP method or
+      the Sequence encode/decode function is applied to a packet, then
+      the LanId or PathId fields are also used to identify the Stream to
+      which the packet belongs.";
     reference
-      "Clause 9.1. of IEEE Std 802.1CB-2017";
+      "9.1. of IEEE Std 802.1CB-2017";
     leaf index {
       type uint32;
       description
@@ -150,102 +135,128 @@ module ieee802-dot1cb-stream-identification {
         system; they are used only to relate the various management
         objects in Clause 9 and Clause 10.";
       reference
-        "Clause 9.1.1.1 of IEEE Std 802.1CB-2017";
+        "9.1.1.1 of IEEE Std 802.1CB-2017";
     }
     container in-facing {
       description
         "Container for in-facing Stream identification functions.";
-      leaf-list input-port-list {
+      leaf-list input-port {
         type if:interface-ref;
         description
           "The list of ports on which an in-facing Stream identification
-          function (6.2) using this identification method (9.1.1.6,
-          9.1.1.7) is to be placed for this Stream (9.1.1.1) in the input
-          (coming from the system forwarding function) direction. Any
-          number of tsnStreamIdEntry objects can list the same port for
-          the same tsnStreamIdHandle in its
+          function using this identification method is to be placed for
+          this Stream in the input (coming from the system forwarding
+          function) direction. Any number of tsnStreamIdEntry objects can
+          list the same port for the same tsnStreamIdHandle in its
           tsnStreamIdInFacInputPortList.";
         reference
-          "Clause 9.1.1.4 of IEEE Std 802.1CB-2017";
+          "9.1.1.4 of IEEE Std 802.1CB-2017";
       }
-      leaf-list output-port-list {
+      leaf-list output-port {
         type if:interface-ref;
         description
           "The list of ports on which an in-facing Stream identification
-          function (6.2) using this identification method (9.1.1.6,
-          9.1.1.7) is to be placed for this Stream (9.1.1.1) in the
-          output (towards the system forwarding function) direction. At
-          most one tsnStreamIdEntry can list a given port for a given
-          tsnStreamIdHandle in its tsnStreamIdInFacOutputPortList.";
+          function using this identification method is to be placed for
+          this Stream in the output (towards the system forwarding
+          function) direction. At most one tsnStreamIdEntry can list a
+          given port for a given tsnStreamIdHandle in its
+          tsnStreamIdInFacOutputPortList.";
         reference
-          "Clause 9.1.1.2 of IEEE Std 802.1CB-2017";
+          "9.1.1.2 of IEEE Std 802.1CB-2017";
       }
     }
     container out-facing {
       description
         "Container for out-facing Stream identification functions.";
-      leaf-list input-port-list {
+      leaf-list input-port {
         type if:interface-ref;
         description
           "The list of ports on which an out-facing Stream identification
-          function (6.2) using this identification method (9.1.1.6,
-          9.1.1.7) is to be placed for this Stream (9.1.1.1) in the input
-          (coming from the physical interface) direction. Any number of
-          tsnStreamIdEntry objects can list the same port for the same
-          tsnStreamIdHandle in its tsnStreamIdOutFacInputPortList.";
+          function using this identification method is to be placed for
+          this Stream in the input (coming from the physical interface)
+          direction. Any number of tsnStreamIdEntry objects can list the
+          same port for the same tsnStreamIdHandle in its
+          tsnStreamIdOutFacInputPortList.";
         reference
-          "Clause 9.1.1.5 of IEEE Std 802.1CB-2017";
+          "9.1.1.5 of IEEE Std 802.1CB-2017";
       }
-      leaf-list output-port-list {
+      leaf-list output-port {
         type if:interface-ref;
         description
           "The list of ports on which an out-facing Stream identification
-          function (6.2) using this identification method (9.1.1.6,
-          9.1.1.7) is to be placed for this Stream (9.1.1.1) in the
-          output (towards the physical interface) direction. At most one
-          tsnStreamIdEntry can list a given port for a given
-          tsnStreamIdHandle in its tsnStreamIdOutFacOutputPortList.";
+          function using this identification method is to be placed for
+          this Stream in the output (towards the physical interface)
+          direction. At most one tsnStreamIdEntry can list a given port
+          for a given tsnStreamIdHandle in its
+          tsnStreamIdOutFacOutputPortList.";
         reference
-          "Clause 9.1.1.3 of IEEE Std 802.1CB-2017";
+          "9.1.1.3 of IEEE Std 802.1CB-2017";
       }
-    }
-    leaf identification-type {
-      type identityref {
-        base strid-idty;
-      }
-      description
-        "An enumerated value indicating the method used to identify
-        packets belonging to the Stream. The enumeration includes an
-        Organizationally Unique Identifier (OUI) or Company ID (CID) to
-        identify the organization defining the enumerated type.";
-      reference
-        "Clause 9.1.1.6 of IEEE Std 802.1CB-2017";
     }
     choice parameters {
       mandatory true;
       description
         "The number of controlling parameters for a Stream identification
         method, their types and values, are specific to the
-        tsnStreamIdIdentificationType (9.1.1.6) and are referenced in
-        Table 9-1.";
+        tsnStreamIdIdentificationType.";
       reference
-        "Clause 9.1.1.7 of IEEE Std 802.1CB-2017";
+        "9.1.1.7 of IEEE Std 802.1CB-2017";
       container null-stream-identification {
         description
           "When instantiating an instance of the Null Stream
-          identification function (6.4) for a particular input Stream,
-          the managed objects in the following subclauses serve as the
-          tsnStreamIdParameters managed object (9.1.1.7).";
+          identification function for a particular input Stream, the
+          managed objects in this container serve as the
+          tsnStreamIdParameters managed object.";
         reference
-          "Clause 9.1.2 of IEEE Std 802.1CB-2017";
+          "9.1.2 of IEEE Std 802.1CB-2017";
+        container identification-type {
+          config false;
+          description
+            "The identification type indicating the method used to
+            identify packets belonging to the Stream. The identification
+            type contains a type number and an Organizationally Unique
+            Identifier (OUI) or Company ID (CID) to identify the
+            organization defining the identification method.";
+          reference
+            "9.1.1.6 of IEEE Std 802.1CB-2017";
+          leaf type-number {
+            type dot1cb-sid-types:stream-id-function;
+            default "null-stream";
+            description
+              "The stream identification type used for the Null Stream
+              identification method.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+          leaf oui-cid {
+            type string {
+              pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+            }
+            default "00-80-C2";
+            description
+              "The Organizationally Unique Identifier (OUI) or Company ID
+              (CID) to identify the organization defining the
+              identification method. For identification methods defined
+              in IEEE Std 802.1CB-2017 the OUI/CID is always 00-80-C2.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+        }
         leaf destination-mac {
           type ieee:mac-address;
           description
             "Specifies the destination_address that identifies a packet
             in an EISS indication primitive, to the Null Stream
-            identification function";
+            identification function. The ieee:mac-address type has a
+            pattern that allows upper and lower case letters. To avoid
+            issues with string comparison, it is suggested to only use
+            Upper Case for the letters in the hexadecimal numbers. There
+            is still an issue with a difference between the IETF
+            mac-address definition and the IEEE mac-address definition,
+            so consider that if implementing code that compares
+            mac-addresses.";
           reference
-            "Clause 9.1.2.1 of IEEE Std 802.1CB-2017";
+            "9.1.2.1 of IEEE Std 802.1CB-2017";
         }
         leaf tagged {
           type vlan-tag-identification-type;
@@ -254,7 +265,7 @@ module ieee802-dot1cb-stream-identification {
             indication primitive to the Null Stream identification
             function is permitted to have a VLAN tag.";
           reference
-            "Clause 9.1.2.2 of IEEE Std 802.1CB-2017";
+            "9.1.2.2 of IEEE Std 802.1CB-2017";
         }
         leaf vlan {
           type vlan-identifier-type;
@@ -265,25 +276,65 @@ module ieee802-dot1cb-stream-identification {
             vlan_identifier parameter is ignored on EISS indication
             primitives.";
           reference
-            "Clause 9.1.2.3 of IEEE Std 802.1CB-2017";
+            "9.1.2.3 of IEEE Std 802.1CB-2017";
         }
       }
       container smac-vlan-stream-identification {
         description
           "When instantiating an instance of the Source MAC and VLAN
-          Stream identification function (6.5) for a particular input
-          Stream, the managed objects in the following subclauses serve
-          as the tsnStreamIdParameters managed object (9.1.1.7).";
+          Stream identification function for a particular input Stream,
+          the managed objects in the following subclauses serve as the
+          tsnStreamIdParameters managed object.";
         reference
-          "Clause 9.1.3 of IEEE Std 802.1CB-2017";
+          "9.1.3 of IEEE Std 802.1CB-2017";
+        container identification-type {
+          config false;
+          description
+            "The identification type indicating the method used to
+            identify packets belonging to the Stream. The identification
+            type contains a type number and an Organizationally Unique
+            Identifier (OUI) or Company ID (CID) to identify the
+            organization defining the identification method.";
+          reference
+            "9.1.1.6 of IEEE Std 802.1CB-2017";
+          leaf type-number {
+            type dot1cb-sid-types:stream-id-function;
+            default "smac-vlan";
+            description
+              "The stream identification type used for the Source MAC and
+              VLAN Stream identification method.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+          leaf oui-cid {
+            type string {
+              pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+            }
+            default "00-80-C2";
+            description
+              "The Organizationally Unique Identifier (OUI) or Company ID
+              (CID) to identify the organization defining the
+              identification method. For identification methods defined
+              in IEEE Std 802.1CB-2017 the OUI/CID is always 00-80-C2.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+        }
         leaf source-mac {
           type ieee:mac-address;
           description
             "Specifies the source_address that identifies a packet in an
             EISS indication primitive, to the Source MAC and VLAN Stream
-            identification function.";
+            identification function. The ieee:mac-address type has a
+            pattern that allows upper and lower case letters. To avoid
+            issues with string comparison, it is suggested to only use
+            Upper Case for the letters in the hexadecimal numbers. There
+            is still an issue with a difference between the IETF
+            mac-address definition and the IEEE mac-address definition,
+            so consider that if implementing code that compares
+            mac-addresses.";
           reference
-            "Clause 9.1.3.1 of IEEE Std 802.1CB-2017";
+            "9.1.3.1 of IEEE Std 802.1CB-2017";
         }
         leaf tagged {
           type vlan-tag-identification-type;
@@ -292,7 +343,7 @@ module ieee802-dot1cb-stream-identification {
             indication primitive to the Source MAC and VLAN Stream
             identification function is permitted to have a VLAN tag.";
           reference
-            "Clause 9.1.3.2 of IEEE Std 802.1CB-2017";
+            "9.1.3.2 of IEEE Std 802.1CB-2017";
         }
         leaf vlan {
           type vlan-identifier-type;
@@ -303,18 +354,51 @@ module ieee802-dot1cb-stream-identification {
             that the vlan_identifier parameter is ignored on EISS
             indication primitives.";
           reference
-            "Clause 9.1.3.3 of IEEE Std 802.1CB-2017";
+            "9.1.3.3 of IEEE Std 802.1CB-2017";
         }
       }
       container dmac-vlan-stream-identification {
         description
           "When instantiating an instance of the Active Destination MAC
-          and VLAN Stream identification function (6.6) for a particular
-          output Stream, the managed objects in the following subclauses,
-          along with those listed in 9.1.2, serve as the
-          tsnStreamIdParameters managed object (9.1.1.7).";
+          and VLAN Stream identification function for a particular output
+          Stream, the managed objects in the following subclauses, along
+          with those listed in 9.1.2, serve as the tsnStreamIdParameters
+          managed object.";
         reference
-          "Clause 9.1.4 of IEEE Std 802.1CB-2017";
+          "9.1.4 of IEEE Std 802.1CB-2017";
+        container identification-type {
+          config false;
+          description
+            "The identification type indicating the method used to
+            identify packets belonging to the Stream. The identification
+            type contains a type number and an Organizationally Unique
+            Identifier (OUI) or Company ID (CID) to identify the
+            organization defining the identification method.";
+          reference
+            "9.1.1.6 of IEEE Std 802.1CB-2017";
+          leaf type-number {
+            type dot1cb-sid-types:stream-id-function;
+            default "dmac-vlan";
+            description
+              "The stream identification type used for the Active
+              Destination MAC and VLAN Stream identification method.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+          leaf oui-cid {
+            type string {
+              pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+            }
+            default "00-80-C2";
+            description
+              "The Organizationally Unique Identifier (OUI) or Company ID
+              (CID) to identify the organization defining the
+              identification method. For identification methods defined
+              in IEEE Std 802.1CB-2017 the OUI/CID is always 00-80-C2.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+        }
         container down {
           description
             "Container for all parameters which are sent to lower layers.";
@@ -327,9 +411,16 @@ module ieee802-dot1cb-stream-identification {
               identification function, and the destination_address that
               identifies an input packet in an EISS indication primitive
               to the Active Destination MAC and VLAN Stream
-              identification function.";
+              identification function. The ieee:mac-address type has a
+              pattern that allows upper and lower case letters. To avoid
+              issues with string comparison, it is suggested to only use
+              Upper Case for the letters in the hexadecimal numbers.
+              There is still an issue with a difference between the IETF
+              mac-address definition and the IEEE mac-address definition,
+              so consider that if implementing code that compares
+              mac-addresses.";
             reference
-              "Clause 9.1.4.1 of IEEE Std 802.1CB-2017";
+              "9.1.4.1 of IEEE Std 802.1CB-2017";
           }
           leaf tagged {
             type vlan-tag-identification-type;
@@ -340,7 +431,7 @@ module ieee802-dot1cb-stream-identification {
               the lower layers is to have a VLAN tag. This variable is
               not used in an FRER C-component. See 8.4.";
             reference
-              "Clause 9.1.4.2 of IEEE Std 802.1CB-2017";
+              "9.1.4.2 of IEEE Std 802.1CB-2017";
           }
           leaf vlan {
             type vlan-identifier-type;
@@ -355,7 +446,7 @@ module ieee802-dot1cb-stream-identification {
               vlan_identifier parameter is ignored on EISS indication
               primitives.";
             reference
-              "Clause 9.1.4.3 of IEEE Std 802.1CB-2017";
+              "9.1.4.3 of IEEE Std 802.1CB-2017";
           }
           leaf priority {
             type dot1qtypes:priority-type;
@@ -366,7 +457,7 @@ module ieee802-dot1cb-stream-identification {
               identification function for all packets in a particular
               Stream.";
             reference
-              "Clause 9.1.4.4 of IEEE Std 802.1CB-2017";
+              "9.1.4.4 of IEEE Std 802.1CB-2017";
           }
         }
         container up {
@@ -381,9 +472,16 @@ module ieee802-dot1cb-stream-identification {
               upper layers by the Active Destination MAC and VLAN Stream
               identification layer. This address replaces the address
               that was used to identify the packet
-              (tsnCpeDmacVlanDownDestMac, 9.1.4.1).";
+              (tsnCpeDmacVlanDownDestMac). The ieee:mac-address type has
+              a pattern that allows upper and lower case letters. To
+              avoid issues with string comparison, it is suggested to
+              only use Upper Case for the letters in the hexadecimal
+              numbers. There is still an issue with a difference between
+              the IETF mac-address definition and the IEEE mac-address
+              definition, so consider that if implementing code that
+              compares mac-addresses.";
             reference
-              "Clause 9.1.4.5 of IEEE Std 802.1CB-2017";
+              "9.1.4.5 of IEEE Std 802.1CB-2017";
           }
           leaf tagged {
             type vlan-tag-identification-type;
@@ -392,10 +490,9 @@ module ieee802-dot1cb-stream-identification {
               indication or request primitive between the Active
               Destination MAC and VLAN Stream identification function and
               the upper layers is to have a VLAN tag. This variable is
-              used only by an end system and not by a relay system. See
-              8.4.";
+              used only by an end system and not by a relay system.";
             reference
-              "Clause 9.1.4.6 of IEEE Std 802.1CB-2017";
+              "9.1.4.6 of IEEE Std 802.1CB-2017";
           }
           leaf vlan {
             type vlan-identifier-type;
@@ -405,9 +502,9 @@ module ieee802-dot1cb-stream-identification {
               or the VLAN ID field for an IEEE 802.1Q tag in an ISS
               mac_service_data_unit. This address replaces the VLAN ID
               that was used to identify the packet
-              (tsnCpeDmacVlanDownVlan, 9.1.4.3).";
+              (tsnCpeDmacVlanDownVlan).";
             reference
-              "Clause 9.1.4.7 of IEEE Std 802.1CB-2017";
+              "9.1.4.7 of IEEE Std 802.1CB-2017";
           }
           leaf priority {
             type dot1qtypes:priority-type;
@@ -415,24 +512,64 @@ module ieee802-dot1cb-stream-identification {
               "Specifies the priority parameter to use in the EISS
               indication primitive for packets offered to upper layers.";
             reference
-              "Clause 9.1.4.8 of IEEE Std 802.1CB-2017";
+              "9.1.4.8 of IEEE Std 802.1CB-2017";
           }
         }
       }
       container ip-stream-identification {
         description
           "When instantiating an instance of the IP Stream identification
-          function (6.7), the parameters in the following subclauses
-          replace the tsnStreamIdParameters managed object (9.1.1.7).";
+          function, the parameters in the following subclauses replace
+          the tsnStreamIdParameters managed object.";
         reference
-          "Clause 9.1.5 of IEEE Std 802.1CB-2017";
+          "9.1.5 of IEEE Std 802.1CB-2017";
+        container identification-type {
+          config false;
+          description
+            "The identification type indicating the method used to
+            identify packets belonging to the Stream. The identification
+            type contains a type number and an Organizationally Unique
+            Identifier (OUI) or Company ID (CID) to identify the
+            organization defining the identification method.";
+          reference
+            "9.1.1.6 of IEEE Std 802.1CB-2017";
+          leaf type-number {
+            type dot1cb-sid-types:stream-id-function;
+            default "ip";
+            description
+              "The stream identification type used for the IP Stream
+              identification method.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+          leaf oui-cid {
+            type string {
+              pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+            }
+            default "00-80-C2";
+            description
+              "The Organizationally Unique Identifier (OUI) or Company ID
+              (CID) to identify the organization defining the
+              identification method. For identification methods defined
+              in IEEE Std 802.1CB-2017 the OUI/CID is always 00-80-C2.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+        }
         leaf destination-mac {
           type ieee:mac-address;
           description
             "Specifies the destination_address parameter that identifies
-            a packet in an EISS indication primitive.";
+            a packet in an EISS indication primitive. The
+            ieee:mac-address type has a pattern that allows upper and
+            lower case letters. To avoid issues with string comparison,
+            it is suggested to only use Upper Case for the letters in the
+            hexadecimal numbers. There is still an issue with a
+            difference between the IETF mac-address definition and the
+            IEEE mac-address definition, so consider that if implementing
+            code that compares mac-addresses.";
           reference
-            "Clause 9.1.5.1 of IEEE Std 802.1CB-2017";
+            "9.1.5.1 of IEEE Std 802.1CB-2017";
         }
         leaf tagged {
           type vlan-tag-identification-type;
@@ -441,7 +578,7 @@ module ieee802-dot1cb-stream-identification {
             indication or request primitive to the IP Stream
             identification function is to have a VLAN tag.";
           reference
-            "Clause 9.1.5.2 of IEEE Std 802.1CB-2017";
+            "9.1.5.2 of IEEE Std 802.1CB-2017";
         }
         leaf vlan {
           type vlan-identifier-type;
@@ -450,7 +587,7 @@ module ieee802-dot1cb-stream-identification {
             packet in an EISS indication primitive. A value of 0
             indicates that the frame is not to have a VLAN tag.";
           reference
-            "Clause 9.1.5.3 of IEEE Std 802.1CB-2017";
+            "9.1.5.3 of IEEE Std 802.1CB-2017";
         }
         leaf ip-source {
           type inet:ip-address;
@@ -461,7 +598,7 @@ module ieee802-dot1cb-stream-identification {
             that the IP source address is to be ignored on packets
             received from lower layers.";
           reference
-            "Clause 9.1.5.4 of IEEE Std 802.1CB-2017";
+            "9.1.5.4 of IEEE Std 802.1CB-2017";
         }
         leaf ip-destination {
           type inet:ip-address;
@@ -470,7 +607,7 @@ module ieee802-dot1cb-stream-identification {
             address parameter that must be matched to identify packets
             coming up from lower layers.";
           reference
-            "Clause 9.1.5.5 of IEEE Std 802.1CB-2017";
+            "9.1.5.5 of IEEE Std 802.1CB-2017";
         }
         leaf dscp {
           type inet:dscp;
@@ -481,7 +618,7 @@ module ieee802-dot1cb-stream-identification {
             layers. A value of 64 decimal indicates that the DSCP is to
             be ignored on packets received from lower layers.";
           reference
-            "Clause 9.1.5.6 of IEEE Std 802.1CB-2017";
+            "9.1.5.6 of IEEE Std 802.1CB-2017";
         }
         leaf next-protocol {
           type enumeration {
@@ -513,10 +650,10 @@ module ieee802-dot1cb-stream-identification {
             matched to identify packets coming up from lower layers. The
             value of this parameter must specify either none, UDP (RFC
             768), TCP (RFC 793), or SCTP (RFC 4960). If “none,” then the
-            tsnCpeIpIdSourcePort (9.1.5.8) and tsnCpeIpIdDestinationPort
-            (9.1.5.9) managed objects are not used.";
+            tsnCpeIpIdSourcePort and tsnCpeIpIdDestinationPort managed
+            objects are not used.";
           reference
-            "Clause 9.1.5.7 of IEEE Std 802.1CB-2017";
+            "9.1.5.7 of IEEE Std 802.1CB-2017";
         }
         leaf source-port {
           type inet:port-number;
@@ -527,7 +664,7 @@ module ieee802-dot1cb-stream-identification {
             packet is to be ignored on packets received from lower
             layers.";
           reference
-            "Clause 9.1.5.8 of IEEE Std 802.1CB-2017";
+            "9.1.5.8 of IEEE Std 802.1CB-2017";
         }
         leaf destination-port {
           type inet:port-number;
@@ -538,97 +675,142 @@ module ieee802-dot1cb-stream-identification {
             number of the packet is to be ignored on packets received
             from lower layers.";
           reference
-            "Clause 9.1.5.9 of IEEE Std 802.1CB-2017";
+            "9.1.5.9 of IEEE Std 802.1CB-2017";
+        }
+      }
+      container organization-specific {
+        description
+          "This container allows to select stream identification methods
+          that are defined by entities outside of IEEE 802.1.";
+        reference
+          "9.1.1.6 of IEEE Std 802.1CB-2017";
+        container identification-type {
+          description
+            "The identification type indicating the method used to
+            identify packets belonging to the Stream. The identification
+            type contains a type number and an Organizationally Unique
+            Identifier (OUI) or Company ID (CID) to identify the
+            organization defining the identification method.";
+          reference
+            "9.1.1.6 of IEEE Std 802.1CB-2017";
+          leaf type-number {
+            type int32 {
+              range "256..max";
+            }
+            description
+              "The type number used for an identification method defined
+              by an entity owning the OUI or CID for this identification
+              type.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
+          leaf oui-cid {
+            type string {
+              pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+            }
+            description
+              "The Organizationally Unique Identifier (OUI) or Company ID
+              (CID) to identify the organization defining the
+              identification method.";
+            reference
+              "9.1.1.6 of IEEE Std 802.1CB-2017";
+          }
         }
       }
     }
   }
   augment "/if:interfaces/if:interface/if:statistics" {
     description
-      "The per-port, per-Stream packet counters that are kept by Stream
-      identification functions for inspection by network management
-      entities are described in 9.2, and the per-port (totaled over all
-      Streams) counters in 9.3";
+      "The following counters are the counters for stream identification.
+      All counters are unsigned integers. If used on links faster than
+      650 000 000 bits per second, they shall be 64 bits in length to
+      ensure against excessively short wrap times.";
     reference
-      "Clause 9 of IEEE Std 802.1CB-2017";
-    list stream-identification-per-port-per-stream-counters {
-      key "direction handle";
-      config false;
+      "9.2 of IEEE Std 802.1CB-2017
+      9.3 of IEEE Std 802.1CB-2017";
+    container stream-id {
       description
-        "The following counters are instantiated for each port on which
-        the Stream identification function (6.2) is configured. The
-        counters are indexed by port number, facing (in-facing or
-        out-facing), and stream_handle value (tsnStreamIdHandle,
-        9.1.1.1). All counters are unsigned integers. If used on links
-        faster than 650 000 000 bits per second, they shall be 64 bits in
-        length to ensure against excessively short wrap times.";
+        "This container contains the per-port as well as the
+        per-port-per-stream counters for stream identification.";
       reference
-        "Clause 9.2 of IEEE Std 802.1CB-2017";
-      leaf direction {
-        type dot1cb-sid-types:direction;
+        "9.2 of IEEE Std 802.1CB-2017
+        9.3 of IEEE Std 802.1CB-2017";
+      container per-port-counters {
+        config false;
         description
-          "An object indicating whether the counters apply to out-facing
-          (True) or in-facing (False).";
-      }
-      leaf handle {
-        type leafref {
-          path '/stream-identity-list/handle';
+          "Contains the per-port counters for stream identification. The
+          following counters are instantiated for each port on which the
+          Stream identification function is configured. The counters are
+          indexed by port number.";
+        reference
+          "9.3 of IEEE Std 802.1CB-2017";
+        leaf input-pkts {
+          type uint64;
+          config false;
+          description
+            "The tsnCpSidInputPackets counter is incremented once for
+            each packet identified by any Stream identification function
+            on this port. Its value equals the sum (modulo the size of
+            the counters) of all of the tsnCpsSidInputPackets counters on
+            this same port.";
+          reference
+            "9.3.1 of IEEE Std 802.1CB-2017";
         }
-        description
-          "The according tsnStreamIdHandle for these counters.";
+        leaf output-pkts {
+          type uint64;
+          config false;
+          description
+            "The tsnCpSidOutputPackets counter is incremented once for
+            each packet passed down the stack by any Stream
+            identification function on this port. Its value equals the
+            sum (modulo the size of the counters) of all of the
+            tsnCpsSidOutputPackets counters on this same port.";
+          reference
+            "9.3.2 of IEEE Std 802.1CB-2017";
+        }
       }
-      leaf input-packets {
-        type uint64;
-        description
-          "The tsnCpsSidInputPackets counter is incremented once for each
-          packet identified by the Stream identification function (6.2).";
-        reference
-          "Clause 9.2.1 of IEEE Std 802.1CB-2017";
-      }
-      leaf output-packets {
-        type uint64;
-        description
-          "The tsnCpsSidOutputPackets counter is incremented once for
-          each packet passed down the stack by the Stream identification
-          function (6.2).";
-        reference
-          "Clause 9.2.2 of IEEE Std 802.1CB-2017";
-      }
-    }
-    container stream-identification-per-port-counters {
-      config false;
-      description
-        "The following counters are instantiated for each port on which
-        the Stream identification function (6.2) is configured. The
-        counters are indexed by port number. All counters are unsigned
-        integers. If used on links faster than 650 000 000 bits per
-        second, they shall be 64 bits in length to ensure against
-        excessively short wrap times.";
-      reference
-        "Clause 9.2 of IEEE Std 802.1CB-2017";
-      leaf input-packets {
-        type uint64;
+      list per-port-per-stream-counters {
+        key "direction-out-facing handle";
         config false;
         description
-          "The tsnCpSidInputPackets counter is incremented once for each
-          packet identified by any Stream identification function (6.2)
-          on this port. Its value equals the sum (modulo the size of the
-          counters) of all of the tsnCpsSidInputPackets (9.2.1) counters
-          on this same port.";
+          "Contains the per-port-per-stream counters for stream
+          identification. The following counters are instantiated for
+          each port on which the Stream identification function is
+          configured. The counters are indexed by port number, facing
+          (in-facing or out-facing), and stream_handle value
+          (tsnStreamIdHandle).";
         reference
-          "Clause 9.3.1 of IEEE Std 802.1CB-2017";
-      }
-      leaf output-packets {
-        type uint64;
-        config false;
-        description
-          "The tsnCpSidOutputPackets counter is incremented once for each
-          packet passed down the stack by any Stream identification
-          function (6.2) on this port. Its value equals the sum (modulo
-          the size of the counters) of all of the tsnCpsSidOutputPackets
-          (9.2.2) counters on this same port.";
-        reference
-          "Clause 9.3.2 of IEEE Std 802.1CB-2017";
+          "9.2 of IEEE Std 802.1CB-2017";
+        leaf direction-out-facing {
+          type dot1cb-sid-types:direction;
+          description
+            "An object indicating whether the counters apply to
+            out-facing (True) or in-facing (False).";
+        }
+        leaf handle {
+          type leafref {
+            path '/stream-identity/handle';
+          }
+          description
+            "The according tsnStreamIdHandle for these counters.";
+        }
+        leaf input-pkts {
+          type uint64;
+          description
+            "The tsnCpsSidInputPackets counter is incremented once for
+            each packet identified by the Stream identification function.";
+          reference
+            "9.2.1 of IEEE Std 802.1CB-2017";
+        }
+        leaf output-pkts {
+          type uint64;
+          description
+            "The tsnCpsSidOutputPackets counter is incremented once for
+            each packet passed down the stack by the Stream
+            identification function.";
+          reference
+            "9.2.2 of IEEE Std 802.1CB-2017";
+        }
       }
     }
   }

--- a/standard/ieee/draft/802.1/CBdb/ieee802-dot1cb-stream-identification.yang
+++ b/standard/ieee/draft/802.1/CBdb/ieee802-dot1cb-stream-identification.yang
@@ -1,0 +1,641 @@
+module ieee802-dot1cb-stream-identification {
+  yang-version "1.1";
+  namespace urn:ieee:std:802.1Q:yang:ieee802-dot1cb-stream-identification;
+  prefix dot1cb-sid;
+  import ieee802-types {
+    prefix ieee;
+  }
+  import ieee802-dot1q-types {
+    prefix dot1qtypes;
+  }
+  import ietf-inet-types {
+    prefix inet;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
+  import ieee802-dot1cb-stream-identification-types {
+    prefix dot1cb-sid-types;
+  }
+  organization
+    "Institute of Electrical and Electronics Engineers";
+  contact
+    "WG-URL: http://ieee802.org/1/
+     WG-EMail: stds-802-1-l@ieee.org
+    
+     Contact: IEEE 802.1 Working Group Chair
+              Postal: C/O IEEE 802.1 Working Group
+              IEEE Standards Association
+              445 Hoes Lane
+              Piscataway, NJ 08854
+              USA
+    
+     E-mail: stds-802-1-chairs@ieee.org";
+  description
+    "Management objects that control the stream identification from IEEE
+    Std 802.1CB-2017. This YANG data model conforms to the Network
+    Management Datastore Architecture defined in RFC 8342.";
+  revision 2021-10-06 {
+    description
+      "Revision to satisfy the check script.";
+    reference
+      "Clause 10 of IEEE Std 802.1CB-2017";
+  }
+  revision 2020-11-27 {
+    description
+      "D1.0 revision. Note that this module might change in backward
+      incompatible ways until approved as a standard.";
+    reference
+      "Clause 10 of IEEE Std 802.1CB-2017";
+  }
+  revision 2020-04-29 {
+    description
+      "D0.3 revision. Note that this module might change in backward
+      incompatible ways until approved as a standard.";
+    reference
+      "Clause 10 of IEEE Std 802.1CB-2017";
+  }
+  revision 2019-09-01 {
+    description
+      "Initial revision. Note that this module might change in backward
+      incompatible ways until approved as a standard.";
+    reference
+      "Clause 9 of IEEE Std 802.1CB-2017";
+  }
+  identity strid-idty {
+    description
+      "Root identity for all stream identification types";
+  }
+  identity null-stream-identification {
+    base strid-idty;
+    description
+      "Null Stream Identification";
+  }
+  identity smac-vlan-stream-identification {
+    base strid-idty;
+    description
+      "Source MAC and VLAN Stream Identification";
+  }
+  identity dmac-vlan-stream-identification {
+    base strid-idty;
+    description
+      "Active Destination MAC and VLAN Stream Identification";
+  }
+  identity ip-stream-identification {
+    base strid-idty;
+    description
+      "IP Stream Identification";
+  }
+  typedef vlan-tag-identification-type {
+    type enumeration {
+      enum tagged {
+        value 1;
+        description
+          "A frame must have a VLAN tag to be recognized as belonging to
+          the Stream.";
+      }
+      enum priority {
+        value 2;
+        description
+          "A frame must be untagged, or have a VLAN tag with a VLAN ID =
+          0 to be recognized as belonging to the Stream.";
+      }
+      enum all {
+        value 3;
+        description
+          "A frame is recognized as belonging to the Stream whether
+          tagged or not.";
+      }
+    }
+    description
+      "Enumeration describing how a Stream can be identified using the
+      VLAN tag.";
+  }
+  typedef vlan-identifier-type {
+    type uint16 {
+      range "0 .. 4095";
+    }
+    description
+      "Specifies the vlan_identifier. A value of 0 indicates that the
+      vlan_identifier parameter is ignored.";
+  }
+  list stream-identity-list {
+    key "index";
+    description
+      "The Stream identity table consists of a set of tsnStreamIdEntry
+      objects (9.1.1), each relating to a single Stream, specifying the
+      points in the system where Stream identification functions (6.2)
+      are to be instantiated. Each entry in the Stream identity table has
+      a tsnStreamIdHandle object (9.1.1.1) specifying a stream_handle
+      value and one or more tsnStreamIdEntry objects (9.1.1) describing
+      one identification method for that Stream. If a single Stream has
+      multiple identification methods, perhaps (but not necessarily) on
+      different ports, then there can be multiple tsnStreamIdEntry
+      objects with the same value for the tsnStreamIdHandle. If the HSR
+      or PRP method or the Sequence encode/decode function is applied to
+      a packet, then the LanId or PathId fields are also used to identify
+      the Stream to which the packet belongs.";
+    reference
+      "Clause 9.1. of IEEE Std 802.1CB-2017";
+    leaf index {
+      type uint32;
+      description
+        "If a single Stream has multiple identification methods, perhaps
+        (but not necessarily) on different ports, then there can be
+        multiple tsnStreamIdEntry objects with the same value for the
+        tsnStreamIdHandle";
+    }
+    leaf handle {
+      type uint32;
+      mandatory true;
+      description
+        "The objects in a given entry of the Stream identity table are
+        used to control packets whose stream_handle subparameter is equal
+        to the entry’s tsnStreamIdHandle object. The specific values used
+        in the tsnStreamIdHandle object are not necessarily used in the
+        system; they are used only to relate the various management
+        objects in Clause 9 and Clause 10.";
+      reference
+        "Clause 9.1.1.1 of IEEE Std 802.1CB-2017";
+    }
+    container in-facing {
+      description
+        "Container for in-facing Stream identification functions.";
+      leaf-list input-port-list {
+        type if:interface-ref;
+        description
+          "The list of ports on which an in-facing Stream identification
+          function (6.2) using this identification method (9.1.1.6,
+          9.1.1.7) is to be placed for this Stream (9.1.1.1) in the input
+          (coming from the system forwarding function) direction. Any
+          number of tsnStreamIdEntry objects can list the same port for
+          the same tsnStreamIdHandle in its
+          tsnStreamIdInFacInputPortList.";
+        reference
+          "Clause 9.1.1.4 of IEEE Std 802.1CB-2017";
+      }
+      leaf-list output-port-list {
+        type if:interface-ref;
+        description
+          "The list of ports on which an in-facing Stream identification
+          function (6.2) using this identification method (9.1.1.6,
+          9.1.1.7) is to be placed for this Stream (9.1.1.1) in the
+          output (towards the system forwarding function) direction. At
+          most one tsnStreamIdEntry can list a given port for a given
+          tsnStreamIdHandle in its tsnStreamIdInFacOutputPortList.";
+        reference
+          "Clause 9.1.1.2 of IEEE Std 802.1CB-2017";
+      }
+    }
+    container out-facing {
+      description
+        "Container for out-facing Stream identification functions.";
+      leaf-list input-port-list {
+        type if:interface-ref;
+        description
+          "The list of ports on which an out-facing Stream identification
+          function (6.2) using this identification method (9.1.1.6,
+          9.1.1.7) is to be placed for this Stream (9.1.1.1) in the input
+          (coming from the physical interface) direction. Any number of
+          tsnStreamIdEntry objects can list the same port for the same
+          tsnStreamIdHandle in its tsnStreamIdOutFacInputPortList.";
+        reference
+          "Clause 9.1.1.5 of IEEE Std 802.1CB-2017";
+      }
+      leaf-list output-port-list {
+        type if:interface-ref;
+        description
+          "The list of ports on which an out-facing Stream identification
+          function (6.2) using this identification method (9.1.1.6,
+          9.1.1.7) is to be placed for this Stream (9.1.1.1) in the
+          output (towards the physical interface) direction. At most one
+          tsnStreamIdEntry can list a given port for a given
+          tsnStreamIdHandle in its tsnStreamIdOutFacOutputPortList.";
+        reference
+          "Clause 9.1.1.3 of IEEE Std 802.1CB-2017";
+      }
+    }
+    leaf identification-type {
+      type identityref {
+        base strid-idty;
+      }
+      description
+        "An enumerated value indicating the method used to identify
+        packets belonging to the Stream. The enumeration includes an
+        Organizationally Unique Identifier (OUI) or Company ID (CID) to
+        identify the organization defining the enumerated type.";
+      reference
+        "Clause 9.1.1.6 of IEEE Std 802.1CB-2017";
+    }
+    choice parameters {
+      mandatory true;
+      description
+        "The number of controlling parameters for a Stream identification
+        method, their types and values, are specific to the
+        tsnStreamIdIdentificationType (9.1.1.6) and are referenced in
+        Table 9-1.";
+      reference
+        "Clause 9.1.1.7 of IEEE Std 802.1CB-2017";
+      container null-stream-identification {
+        description
+          "When instantiating an instance of the Null Stream
+          identification function (6.4) for a particular input Stream,
+          the managed objects in the following subclauses serve as the
+          tsnStreamIdParameters managed object (9.1.1.7).";
+        reference
+          "Clause 9.1.2 of IEEE Std 802.1CB-2017";
+        leaf destination-mac {
+          type ieee:mac-address;
+          description
+            "Specifies the destination_address that identifies a packet
+            in an EISS indication primitive, to the Null Stream
+            identification function";
+          reference
+            "Clause 9.1.2.1 of IEEE Std 802.1CB-2017";
+        }
+        leaf tagged {
+          type vlan-tag-identification-type;
+          description
+            "An enumerated value indicating whether a packet in an EISS
+            indication primitive to the Null Stream identification
+            function is permitted to have a VLAN tag.";
+          reference
+            "Clause 9.1.2.2 of IEEE Std 802.1CB-2017";
+        }
+        leaf vlan {
+          type vlan-identifier-type;
+          description
+            "Specifies the vlan_identifier parameter that identifies a
+            packet in an EISS indication primitive to the Null Stream
+            identification function. A value of 0 indicates that the
+            vlan_identifier parameter is ignored on EISS indication
+            primitives.";
+          reference
+            "Clause 9.1.2.3 of IEEE Std 802.1CB-2017";
+        }
+      }
+      container smac-vlan-stream-identification {
+        description
+          "When instantiating an instance of the Source MAC and VLAN
+          Stream identification function (6.5) for a particular input
+          Stream, the managed objects in the following subclauses serve
+          as the tsnStreamIdParameters managed object (9.1.1.7).";
+        reference
+          "Clause 9.1.3 of IEEE Std 802.1CB-2017";
+        leaf source-mac {
+          type ieee:mac-address;
+          description
+            "Specifies the source_address that identifies a packet in an
+            EISS indication primitive, to the Source MAC and VLAN Stream
+            identification function.";
+          reference
+            "Clause 9.1.3.1 of IEEE Std 802.1CB-2017";
+        }
+        leaf tagged {
+          type vlan-tag-identification-type;
+          description
+            "An enumerated value indicating whether a packet in an EISS
+            indication primitive to the Source MAC and VLAN Stream
+            identification function is permitted to have a VLAN tag.";
+          reference
+            "Clause 9.1.3.2 of IEEE Std 802.1CB-2017";
+        }
+        leaf vlan {
+          type vlan-identifier-type;
+          description
+            "Specifies the vlan_identifier parameter that identifies a
+            packet in an EISS indication primitive to the Source MAC and
+            VLAN Stream identification function. A value of 0 indicates
+            that the vlan_identifier parameter is ignored on EISS
+            indication primitives.";
+          reference
+            "Clause 9.1.3.3 of IEEE Std 802.1CB-2017";
+        }
+      }
+      container dmac-vlan-stream-identification {
+        description
+          "When instantiating an instance of the Active Destination MAC
+          and VLAN Stream identification function (6.6) for a particular
+          output Stream, the managed objects in the following subclauses,
+          along with those listed in 9.1.2, serve as the
+          tsnStreamIdParameters managed object (9.1.1.7).";
+        reference
+          "Clause 9.1.4 of IEEE Std 802.1CB-2017";
+        container down {
+          description
+            "Container for all parameters which are sent to lower layers.";
+          leaf destination-mac {
+            type ieee:mac-address;
+            description
+              "Specifies the destination_address parameter to use in the
+              EISS request primitive for output packets sent to lower
+              layers by the Active Destination MAC and VLAN Stream
+              identification function, and the destination_address that
+              identifies an input packet in an EISS indication primitive
+              to the Active Destination MAC and VLAN Stream
+              identification function.";
+            reference
+              "Clause 9.1.4.1 of IEEE Std 802.1CB-2017";
+          }
+          leaf tagged {
+            type vlan-tag-identification-type;
+            description
+              "An enumerated value indicating whether a packet in an EISS
+              indication or request primitive between the Active
+              Destination MAC and VLAN Stream identification function and
+              the lower layers is to have a VLAN tag. This variable is
+              not used in an FRER C-component. See 8.4.";
+            reference
+              "Clause 9.1.4.2 of IEEE Std 802.1CB-2017";
+          }
+          leaf vlan {
+            type vlan-identifier-type;
+            description
+              "Specifies the vlan_identifier parameter to use in the EISS
+              request primitive for output packets sent to lower layers
+              by the Active Destination MAC and VLAN Stream
+              identification function, and the vlan_identifier that
+              identifies an input packet in an EISS indication primitive
+              to the Active Destination MAC and VLAN Stream
+              identification function. A value of 0 indicates that the
+              vlan_identifier parameter is ignored on EISS indication
+              primitives.";
+            reference
+              "Clause 9.1.4.3 of IEEE Std 802.1CB-2017";
+          }
+          leaf priority {
+            type dot1qtypes:priority-type;
+            description
+              "Specifies the priority parameter to use in the EISS
+              request primitive for output packets sent to lower layers
+              by the Active Destination MAC and VLAN Stream
+              identification function for all packets in a particular
+              Stream.";
+            reference
+              "Clause 9.1.4.4 of IEEE Std 802.1CB-2017";
+          }
+        }
+        container up {
+          description
+            "Container for all parameters which are offered to higher
+            layers.";
+          leaf destination-mac {
+            type ieee:mac-address;
+            description
+              "Specifies the destination_address parameter to use in the
+              EISS indication primitive for input packets offered to
+              upper layers by the Active Destination MAC and VLAN Stream
+              identification layer. This address replaces the address
+              that was used to identify the packet
+              (tsnCpeDmacVlanDownDestMac, 9.1.4.1).";
+            reference
+              "Clause 9.1.4.5 of IEEE Std 802.1CB-2017";
+          }
+          leaf tagged {
+            type vlan-tag-identification-type;
+            description
+              "An enumerated value indicating whether a packet in an EISS
+              indication or request primitive between the Active
+              Destination MAC and VLAN Stream identification function and
+              the upper layers is to have a VLAN tag. This variable is
+              used only by an end system and not by a relay system. See
+              8.4.";
+            reference
+              "Clause 9.1.4.6 of IEEE Std 802.1CB-2017";
+          }
+          leaf vlan {
+            type vlan-identifier-type;
+            description
+              "Specifies the vlan_identifier parameter to use in the EISS
+              indication primitive for packets offered to upper layers,
+              or the VLAN ID field for an IEEE 802.1Q tag in an ISS
+              mac_service_data_unit. This address replaces the VLAN ID
+              that was used to identify the packet
+              (tsnCpeDmacVlanDownVlan, 9.1.4.3).";
+            reference
+              "Clause 9.1.4.7 of IEEE Std 802.1CB-2017";
+          }
+          leaf priority {
+            type dot1qtypes:priority-type;
+            description
+              "Specifies the priority parameter to use in the EISS
+              indication primitive for packets offered to upper layers.";
+            reference
+              "Clause 9.1.4.8 of IEEE Std 802.1CB-2017";
+          }
+        }
+      }
+      container ip-stream-identification {
+        description
+          "When instantiating an instance of the IP Stream identification
+          function (6.7), the parameters in the following subclauses
+          replace the tsnStreamIdParameters managed object (9.1.1.7).";
+        reference
+          "Clause 9.1.5 of IEEE Std 802.1CB-2017";
+        leaf destination-mac {
+          type ieee:mac-address;
+          description
+            "Specifies the destination_address parameter that identifies
+            a packet in an EISS indication primitive.";
+          reference
+            "Clause 9.1.5.1 of IEEE Std 802.1CB-2017";
+        }
+        leaf tagged {
+          type vlan-tag-identification-type;
+          description
+            "An enumerated value indicating whether a packet in an EISS
+            indication or request primitive to the IP Stream
+            identification function is to have a VLAN tag.";
+          reference
+            "Clause 9.1.5.2 of IEEE Std 802.1CB-2017";
+        }
+        leaf vlan {
+          type vlan-identifier-type;
+          description
+            "Specifies the vlan_identifier parameter that identifies a
+            packet in an EISS indication primitive. A value of 0
+            indicates that the frame is not to have a VLAN tag.";
+          reference
+            "Clause 9.1.5.3 of IEEE Std 802.1CB-2017";
+        }
+        leaf ip-source {
+          type inet:ip-address;
+          description
+            "Specifies the IPv4 (RFC 791) or IPv6 (RFC 2460) source
+            address parameter that must be matched to identify packets
+            coming up from lower layers. An address of all 0 indicates
+            that the IP source address is to be ignored on packets
+            received from lower layers.";
+          reference
+            "Clause 9.1.5.4 of IEEE Std 802.1CB-2017";
+        }
+        leaf ip-destination {
+          type inet:ip-address;
+          description
+            "Specifies the IPv4 (RFC 791) or IPv6 (RFC 2460) destination
+            address parameter that must be matched to identify packets
+            coming up from lower layers.";
+          reference
+            "Clause 9.1.5.5 of IEEE Std 802.1CB-2017";
+        }
+        leaf dscp {
+          type inet:dscp;
+          description
+            "Specifies the IPv4 (RFC 791) or IPv6 (RFC 2460)
+            differentiated services codepoint (DSCP, RFC 2474) that must
+            be matched to identify packets coming up from the lower
+            layers. A value of 64 decimal indicates that the DSCP is to
+            be ignored on packets received from lower layers.";
+          reference
+            "Clause 9.1.5.6 of IEEE Std 802.1CB-2017";
+        }
+        leaf next-protocol {
+          type enumeration {
+            enum none {
+              description
+                "No protocol is specified";
+            }
+            enum udp {
+              description
+                "UDP is specified as the next protocol.";
+              reference
+                "RFC 768";
+            }
+            enum tcp {
+              description
+                "TCP is specified as the next protocol.";
+              reference
+                "RFC 793";
+            }
+            enum sctp {
+              description
+                "SCTP is specified as the next protocol.";
+              reference
+                "RFC 4960";
+            }
+          }
+          description
+            "Specifies the IP next protocol parameter that must be
+            matched to identify packets coming up from lower layers. The
+            value of this parameter must specify either none, UDP (RFC
+            768), TCP (RFC 793), or SCTP (RFC 4960). If “none,” then the
+            tsnCpeIpIdSourcePort (9.1.5.8) and tsnCpeIpIdDestinationPort
+            (9.1.5.9) managed objects are not used.";
+          reference
+            "Clause 9.1.5.7 of IEEE Std 802.1CB-2017";
+        }
+        leaf source-port {
+          type inet:port-number;
+          description
+            "Specifies the TCP or UDP Source Port parameter that must be
+            matched to identify packets coming up from lower layers. A
+            value of 0 indicates that the Source Port number of the
+            packet is to be ignored on packets received from lower
+            layers.";
+          reference
+            "Clause 9.1.5.8 of IEEE Std 802.1CB-2017";
+        }
+        leaf destination-port {
+          type inet:port-number;
+          description
+            "Specifies the TCP or UDP Destination Port parameter that
+            must be matched to identify packets coming up from lower
+            layers. A value of 0 indicates that the Destination Port
+            number of the packet is to be ignored on packets received
+            from lower layers.";
+          reference
+            "Clause 9.1.5.9 of IEEE Std 802.1CB-2017";
+        }
+      }
+    }
+  }
+  augment "/if:interfaces/if:interface/if:statistics" {
+    description
+      "The per-port, per-Stream packet counters that are kept by Stream
+      identification functions for inspection by network management
+      entities are described in 9.2, and the per-port (totaled over all
+      Streams) counters in 9.3";
+    reference
+      "Clause 9 of IEEE Std 802.1CB-2017";
+    list stream-identification-per-port-per-stream-counters {
+      key "direction handle";
+      config false;
+      description
+        "The following counters are instantiated for each port on which
+        the Stream identification function (6.2) is configured. The
+        counters are indexed by port number, facing (in-facing or
+        out-facing), and stream_handle value (tsnStreamIdHandle,
+        9.1.1.1). All counters are unsigned integers. If used on links
+        faster than 650 000 000 bits per second, they shall be 64 bits in
+        length to ensure against excessively short wrap times.";
+      reference
+        "Clause 9.2 of IEEE Std 802.1CB-2017";
+      leaf direction {
+        type dot1cb-sid-types:direction;
+        description
+          "An object indicating whether the counters apply to out-facing
+          (True) or in-facing (False).";
+      }
+      leaf handle {
+        type leafref {
+          path '/stream-identity-list/handle';
+        }
+        description
+          "The according tsnStreamIdHandle for these counters.";
+      }
+      leaf input-packets {
+        type uint64;
+        description
+          "The tsnCpsSidInputPackets counter is incremented once for each
+          packet identified by the Stream identification function (6.2).";
+        reference
+          "Clause 9.2.1 of IEEE Std 802.1CB-2017";
+      }
+      leaf output-packets {
+        type uint64;
+        description
+          "The tsnCpsSidOutputPackets counter is incremented once for
+          each packet passed down the stack by the Stream identification
+          function (6.2).";
+        reference
+          "Clause 9.2.2 of IEEE Std 802.1CB-2017";
+      }
+    }
+    container stream-identification-per-port-counters {
+      config false;
+      description
+        "The following counters are instantiated for each port on which
+        the Stream identification function (6.2) is configured. The
+        counters are indexed by port number. All counters are unsigned
+        integers. If used on links faster than 650 000 000 bits per
+        second, they shall be 64 bits in length to ensure against
+        excessively short wrap times.";
+      reference
+        "Clause 9.2 of IEEE Std 802.1CB-2017";
+      leaf input-packets {
+        type uint64;
+        config false;
+        description
+          "The tsnCpSidInputPackets counter is incremented once for each
+          packet identified by any Stream identification function (6.2)
+          on this port. Its value equals the sum (modulo the size of the
+          counters) of all of the tsnCpsSidInputPackets (9.2.1) counters
+          on this same port.";
+        reference
+          "Clause 9.3.1 of IEEE Std 802.1CB-2017";
+      }
+      leaf output-packets {
+        type uint64;
+        config false;
+        description
+          "The tsnCpSidOutputPackets counter is incremented once for each
+          packet passed down the stack by any Stream identification
+          function (6.2) on this port. Its value equals the sum (modulo
+          the size of the counters) of all of the tsnCpsSidOutputPackets
+          (9.2.2) counters on this same port.";
+        reference
+          "Clause 9.3.2 of IEEE Std 802.1CB-2017";
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Updated files for IEEE P802.1CBcv/D2.1.
- Added outdated ieee802-dot1cb-stream-identification.yang to satisfy imports in current IEEE P802.1CBdb.
- Fixed bug in checksrcipt.sh that prevented it form catching errors.
