### PR TITLE
Paths fixed for Cisco XR platform-metadata.json files

### DIFF
--- a/vendor/cisco/xr/702/platform-metadata.json
+++ b/vendor/cisco/xr/702/platform-metadata.json
@@ -4,7 +4,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l",

--- a/vendor/cisco/xr/712/platform-metadata.json
+++ b/vendor/cisco/xr/712/platform-metadata.json
@@ -76,7 +76,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs2k.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs2k.xml",
           "repository": "yang.git"
         },
         "name": "ncs2k",
@@ -112,7 +112,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l",

--- a/vendor/cisco/xr/721/platform-metadata.json
+++ b/vendor/cisco/xr/721/platform-metadata.json
@@ -4,7 +4,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-8000.xml",
+          "path": "vendor/cisco/xr/capabilities-8000.xml",
           "repository": "yang.git"
         },
         "name": "8000",
@@ -112,7 +112,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l",

--- a/vendor/cisco/xr/722/platform-metadata.json
+++ b/vendor/cisco/xr/722/platform-metadata.json
@@ -94,7 +94,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l",

--- a/vendor/cisco/xr/731/platform-metadata.json
+++ b/vendor/cisco/xr/731/platform-metadata.json
@@ -4,7 +4,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-8000.xml",
+          "path": "vendor/cisco/xr/capabilities-8000.xml",
           "repository": "yang.git"
         },
         "name": "8000",
@@ -130,7 +130,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l",
@@ -166,7 +166,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs5700.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs5700.xml",
           "repository": "yang.git"
         },
         "name": "ncs5700",

--- a/vendor/cisco/xr/732/platform-metadata.json
+++ b/vendor/cisco/xr/732/platform-metadata.json
@@ -4,7 +4,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-8000.xml",
+          "path": "vendor/cisco/xr/capabilities-8000.xml",
           "repository": "yang.git"
         },
         "name": "8000",
@@ -112,7 +112,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l",
@@ -130,7 +130,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l-aarch64.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l-aarch64.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l-aarch64",
@@ -202,7 +202,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs5700.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs5700.xml",
           "repository": "yang.git"
         },
         "name": "ncs5700",

--- a/vendor/cisco/xr/741/platform-metadata.json
+++ b/vendor/cisco/xr/741/platform-metadata.json
@@ -58,7 +58,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l",
@@ -76,7 +76,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l-aarch64.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l-aarch64.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l-aarch64",
@@ -148,7 +148,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs5700.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs5700.xml",
           "repository": "yang.git"
         },
         "name": "ncs5700",

--- a/vendor/cisco/xr/751/platform-metadata.json
+++ b/vendor/cisco/xr/751/platform-metadata.json
@@ -4,7 +4,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-8000.xml",
+          "path": "vendor/cisco/xr/capabilities-8000.xml",
           "repository": "yang.git"
         },
         "name": "8000",
@@ -112,7 +112,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs5700.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs5700.xml",
           "repository": "yang.git"
         },
         "name": "ncs5700",
@@ -184,7 +184,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l-aarch64.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l-aarch64.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l-aarch64",
@@ -238,7 +238,7 @@
       {
         "module-list-file": {
           "owner": "YangModels",
-          "path": "vendor/cisco/xr//capabilities-ncs540l.xml",
+          "path": "vendor/cisco/xr/capabilities-ncs540l.xml",
           "repository": "yang.git"
         },
         "name": "ncs540l",


### PR DESCRIPTION
- files contained '//' in paths to the xml files

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>