### PR TITLE
updated the pointers for ietf/RFC/iana-*-type[s].yang

### DIFF
--- a/standard/iana/iana-if-type.yang
+++ b/standard/iana/iana-if-type.yang
@@ -1,0 +1,1 @@
+./iana-if-type@2023-01-26.yang

--- a/standard/iana/iana-routing-types.yang
+++ b/standard/iana/iana-routing-types.yang
@@ -1,0 +1,1 @@
+./iana-routing-types@2022-08-19.yang

--- a/standard/ietf/RFC/iana-if-type.yang
+++ b/standard/ietf/RFC/iana-if-type.yang
@@ -1,1 +1,0 @@
-iana-if-type@2017-01-19.yang

--- a/standard/ietf/RFC/iana-routing-types.yang
+++ b/standard/ietf/RFC/iana-routing-types.yang
@@ -1,1 +1,0 @@
-iana-routing-types@2018-10-29.yang


### PR DESCRIPTION
removed unresolved symlinks to the following:
- standard/ietf/RFC/iana-if-type.yang
- standard/ietf/RFC/iana-routing-types.yang

added symlinks to the latest versions of the following models within the iana hierarchy.
- standard/iana/iana-if-type.yang
- standard/iana/iana-routing-types.yang