### PR TITLE
Create dir for IEEE P1588f draft work

### DIFF
--- a/standard/ieee/draft/1588/P1588f/ieee1588-ptp-ms.yang
+++ b/standard/ieee/draft/1588/P1588f/ieee1588-ptp-ms.yang
@@ -1,0 +1,4301 @@
+module ieee1588-ptp-ms {
+  yang-version 1.1;
+  namespace urn:ieee:std:1588:yang:ieee1588-ptp-ms;
+  prefix "ptp-ms";
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+  import ietf-interfaces {
+    prefix if;
+  }
+
+  organization "IEEE 1588 Working Group";
+  contact
+    "Web: https://sagroups.ieee.org/1588/
+    E-mail: 1588officers@listserv.ieee.org
+
+    Postal: C/O IEEE 1588 Working Group Chair
+            IEEE Standards Association
+            445 Hoes Lane
+            Piscataway, NJ 08854
+            USA";
+  description
+    "This YANG module defines a data model for the configuration
+    and state of IEEE Std 1588 clocks. IEEE Std 1588 specifies the
+    Precision Time Protocol (PTP).
+
+    The nodes in this YANG module are designed for compatibility
+    with ietf-ptp.yang, the YANG data model for IEEE Std 1588-2008,
+    as specified in IETF RFC 8575.
+
+    NOTE regarding default value:
+    PTP's concept of 'initialization value' is analogous to YANG's
+    concept of a 'default value'. According to 8.1.3.4 of
+    IEEE Std 1588-2019, the initialization value for configuration
+    is specified in IEEE Std 1588, but that value can be overridden
+    by a PTP Profile specification, or by the product that
+    implements PTP. This makes it challenging to repeat the
+    specification of initialization value using a YANG 'default'
+    statement, because there is no straightforward mechanism for
+    a PTP Profile's (or product's) YANG module to import this
+    module and override its YANG default. Since a YANG management
+    client can read the default value from the operational
+    datastore, there is no need to re-specify the default in YANG.
+    The implementer of PTP refers to the relevant PTP
+    specifications for the default (not YANG modules).
+    Therefore, this YANG module avoids use of the YANG 'default'
+    statement.
+
+    NOTE regarding IEEE Std 1588 classification:
+    8.1.2 of IEEE Std 1588-2019 specifies a classification of
+    each data set member, which corresponds to a leaf in YANG.
+    The relationship between 1588 classification and
+    YANG 'config' (i.e., whether the leaf is read-write) is:
+    - 1588 static: The leaf is 'config false' (read-only).
+    - 1588 configurable: The leaf is 'config true', which is
+      the default value for a YANG leaf.
+    - 1588 dynamic: A judgement is made on a member-by-member
+      basis. If the member corresponds to the first item of
+      8.1.2.1.2 of IEEE Std 1588-2019 (i.e., value from protocol
+      only, such as log of protocol behavior), the YANG leaf
+      is 'config false'. Otherwise, the member's value can be
+      provided by an entity outside PTP (e.g., NETCONF or
+      RESTCONF client), and therefore the YANG leaf is
+      'config true'.
+      
+    NOTE regarding terminology (two YANG modules):
+    To accommodate the need by some organizations to use the
+    original terminology specified by IEEE Std 1588, and the
+    need by some other organizations to use the alternative
+    terminology specified in 4.4 of IEEE Std 1588g-2022,
+    two YANG modules are provided by IEEE Std 1588e (MIB and
+    YANG Data Models). For a detailed explanation, see 15.4.2.11
+    of IEEE Std 1588e.
+    This module uses the original terminology specified by
+    IEEE Std 1588 (master/slave).";
+
+  revision 2023-08-14 {
+    description
+      "Initial revision.";
+    reference
+      "IEEE Std 1588e-2024, IEEE Standard for a Precision Clock
+      Synchronization Protocol for Networked Measurement and
+      Control Systems - MIB and YANG Data Models.";
+  }
+
+  feature fault-log {
+    description
+      "Logging of faults detected in the PTP Instance.";
+    reference
+      "8.2.6 of IEEE Std 1588-2019";
+  }
+
+  feature unicast-negotiation {
+    description
+      "Unicast negotiation conducted through use of TLVs.";
+    reference
+      "16.1 of IEEE Std 1588-2019";
+  }
+
+  feature path-trace {
+    description
+      "Use of the PATH_TRACE TLV for tracing the route of
+      a PTP Announce message through the PTP Network.";
+    reference
+      "16.2 of IEEE Std 1588-2019";
+  }
+
+  feature alternate-timescale {
+    description
+      "The transmission of an ALTERNATE_TIME_OFFSET_INDICATOR TLV
+      entity from the Grandmaster PTP Instance may indicate the
+      offset of an alternate timescale from the timescale in
+      use in the domain.";
+    reference
+      "16.3 of IEEE Std 1588-2019";
+  }
+
+  feature holdover-upgrade {
+    description
+      "A holdover-upgradable PTP Instance can potentially
+      become the Grandmaster PTP Instance in the event the
+      previous Grandmaster PTP Instance is disconnected
+      or its characteristics degrade.";
+    reference
+      "16.4 of IEEE Std 1588-2019";
+  }
+
+  feature cmlds {
+    description
+      "The Common Mean Link Delay Service (CMLDS) is an optional
+      service that enables any PTP Port that would normally obtain
+      the value of a link's <meanLinkDelay> and <neighborRateRatio>
+      using the peer-to-peer method to instead obtain these
+      values from this optional service. The CMLDS service is
+      available to all PTP Instances communicating with a specific
+      transport mechanism, over the physical link between two PTP
+      Nodes.";
+    reference
+      "16.6 of IEEE Std 1588-2019";
+  }
+
+  feature timestamp-correction {
+    description
+      "Correction of timestamps using configurable management data.";
+    reference
+      "16.7 of IEEE Std 1588-2019";
+  }
+
+  feature asymmetry-correction {
+    description
+      "Calculation of the <delayAsymmetry> on a Direct PTP Link
+      between two PTP Instances connected using an applicable
+      bidirectional medium.";
+    reference
+      "16.8 of IEEE Std 1588-2019";
+  }
+
+  feature slave-monitoring {
+    description
+      "Mechanism for monitoring timing information in a PTP Port
+      in the slave state. The slave-monitoring feature specifies
+      TLVs that the Slave PTP Instance transmits with this
+      information, typically in a Signaling message.";
+    reference
+      "16.11 of IEEE Std 1588-2019";
+  }
+
+  feature enhanced-metrics {
+    description
+      "Mechanism for propagating estimates of various
+      inaccuracy components affecting the overall expected
+      PTP Instance Time accuracy. The metrics will be updated
+      and available for utilization at the various points along
+      the PTP timing chain: from the Grandmaster Instance, up to
+      a leaf PTP Instance in the synchronization tree. Each
+      PTP Instance along the timing path updates the
+      relevant metrics based on its contribution to the expected
+      degradation in PTP Instance Time accuracy due to various
+      induced timing error components.";
+    reference
+      "16.12 of IEEE Std 1588-2019";
+  }
+
+  feature grandmaster-cluster {
+    description
+      "Mechanism for faster selection of the Grandmaster PTP Instance
+      from the set of PTP Instances for which this option is both
+      implemented and enabled.";
+    reference
+      "17.2 of IEEE Std 1588-2019";
+  }
+
+  feature alternate-master {
+    description
+      "Mechanism for PTP Ports on a PTP Communication Path that
+      are not currently the MASTER port of that PTP Communication
+      Path to exchange PTP timing information with other PTP Ports
+      on the same PTP Communication Path, and for each of the other
+      PTP Ports to acquire knowledge of the characteristics
+      of the transmission path between itself and each alternate
+      master PTP Port.";
+    reference
+      "17.3 of IEEE Std 1588-2019";
+  }
+
+  feature unicast-discovery {
+    description
+      "Mechanism for PTP to be used over a network that does not
+      provide multicast. A PTP Instance is configured with the
+      addresses of PTP Ports of other PTP Instances with which
+      it should attempt to establish unicast communication.
+      The PTP Instance may request that these PTP Ports transmit
+      unicast Announce, Sync, and Delay_Resp messages to it.";
+    reference
+      "17.4 of IEEE Std 1588-2019";
+  }
+
+  feature acceptable-master {
+    description
+      "Mechanism that allows PTP Ports in the SLAVE state to be
+      configured to refuse to synchronize to PTP Instances not
+      on the acceptable master list.";
+    reference
+      "17.5 of IEEE Std 1588-2019";
+  }
+
+  feature external-port-config {
+    description
+      "External port configuration allows an external entity
+      (such as YANG-based remote management) to disable the
+      IEEE Std 1588 state machines that control each port's
+      state, including the BMCA. Each port's state is
+      then configured by the external entity.";
+    reference
+      "17.6 of IEEE Std 1588-2019";
+  }
+
+  feature performance-monitoring {
+    description
+      "Collection of performance monitoring logs that can be
+      read using management.";
+    reference
+      "Annex J of IEEE Std 1588-2019";
+  }
+
+  feature l1-sync {
+    description
+      "Layer 1-based synchronization performance
+      enhancement.";
+    reference
+      "Annex L of IEEE Std 1588-2019";
+  }
+
+  identity network-protocol {
+      description
+        "Enumeration for the protocol used by a PTP Instance to
+        transport PTP messages.
+        YANG identity is used so that a PTP Profile's YANG augment
+        can assign values, using numeric range F000 to FFFD hex.";
+      reference
+        "7.4.1 of IEEE Std 1588-2019";
+  }
+    identity udp-ipv4 {
+      base network-protocol;
+      description
+        "UDP on IPv4. Numeric value is 0001 hex.";
+    }
+    identity udp-ipv6 {
+      base network-protocol;
+      description
+        "UDP on IPv6. Numeric value is 0002 hex.";
+    }
+    identity ieee802-3 {
+      base network-protocol;
+      description
+        "IEEE Std 802.3 (Ethernet). Numeric value is 0003 hex.";
+    }
+    identity devicenet {
+      base network-protocol;
+      description
+        "DeviceNet. Numeric value is 0004 hex.";
+    }
+    identity controlnet {
+      base network-protocol;
+      description
+        "ControlNet. Numeric value is 0005 hex.";
+    }
+    identity profinet {
+      base network-protocol;
+      description
+        "PROFINET. Numeric value is 0006 hex.";
+    }
+    identity otn {
+      base network-protocol;
+      description
+        "Optical Transport Network (OTN). Numeric value
+        is 0007 hex.";
+    }
+    identity unknown {
+      base network-protocol;
+      description
+        "Unknown. Numeric value is FFFE hex.";
+    }
+
+  identity clock-class {
+    description
+      "Enumeration that denotes the traceability, synchronization
+      state and expected performance of the time or frequency
+      distributed by the Grandmaster PTP Instance.
+      IEEE Std 1588 does not specify a name for each clock-class,
+      but the names below are intended to be as intuitive as possible.
+      YANG identity is used so that a PTP Profile's YANG augment
+      can assign values using a numeric range designated for use by
+      alternate PTP Profiles.";
+    reference
+      "7.6.2.5 of IEEE Std 1588-2019";
+  }
+    identity cc-primary-sync {
+      base clock-class;
+      description
+        "A PTP Instance that is synchronized to a primary
+        reference time source. The timescale distributed shall be PTP.
+        Numeric value is 6 decimal.";
+    }
+    identity cc-primary-sync-lost {
+      base clock-class;
+      description
+        "A PTP Instance that has previously been designated
+        as clockClass 6, but that has lost the ability to
+        synchronize to a primary reference time source and is in
+        holdover mode and within holdover specifications. Or a PTP
+        Instance designated with clockClass 7 based on the Holdover
+        Upgrade option. The timescale distributed shall be PTP.
+        Numeric value is 7 decimal.";
+    }
+    identity cc-application-specific-sync {
+      base clock-class;
+      description
+        "A PTP Instance that is synchronized to an
+        application-specific source of time. The timescale
+        distributed shall be ARB.
+        Numeric value is 13 decimal.";
+    }
+    identity cc-application-specific-sync-lost {
+      base clock-class;
+      description
+        "A PTP Instance that has previously been designated as
+        clockClass 13, but that has lost the ability to synchronize
+        to an application-specific source of time and is in
+        holdover mode and within holdover specifications. Or a PTP
+        Instance designated with clockClass 14 based on the Holdover
+        Upgrade option. The timescale distributed shall be ARB.
+        Numeric value is 14 decimal.";
+    }
+    identity cc-primary-sync-alternative-a {
+      base clock-class;
+      description
+        "Degradation alternative A for a PTP Instance of
+        clockClass 7 that is not within holdover specification
+        or that is based on the specifications of the Holdover
+        Upgrade option.
+        Numeric value is 52 decimal.";
+    }
+    identity cc-application-specific-alternative-a {
+      base clock-class;
+      description
+        "Degradation alternative A for a PTP Instance of
+        clockClass 14 that is not within holdover specification or
+        that is based on the specifications of the Holdover Upgrade
+        option.
+        Numeric value is 58 decimal.";
+    }
+    identity cc-primary-sync-alternative-b {
+      base clock-class;
+      description
+        "Degradation alternative B for a PTP Instance of
+        clockClass 7 that is not within holdover specification
+        or that is based on the specifications of the Holdover
+        Upgrade option.
+        Numeric value is 187 decimal.";
+    }
+    identity cc-application-specific-alternative-b {
+      base clock-class;
+      description
+        "Degradation alternative B for a PTP Instance of
+        clockClass 14 that is not within holdover specification or
+        that is based on the specifications of the Holdover Upgrade
+        option.
+        Numeric value is 193 decimal.";
+    }
+    identity cc-default {
+      base clock-class;
+      description
+        "Default clockClass, used if none of the other
+        clockClass definitions apply.
+        Numeric value is 248 decimal.";
+    }
+    identity cc-slave-only {
+      base clock-class;
+      description
+        "A PTP Instance that is slave-only.
+        Numeric value is 255 decimal.";
+    }
+
+  identity clock-accuracy {
+    description
+      "Enumeration that indicates the expected accuracy of a
+      PTP Instance when it is the Grandmaster PTP Instance,
+      or in the event it becomes the Grandmaster PTP Instance.
+      The value shall be conservatively estimated by the PTP
+      Instance to a precision consistent with the value of the
+      selected clock-accuracy and of the next lower enumerated
+      value, for example, for clockAccuracy = 23 hex, between
+      250 ns and 1000 ns.
+      IEEE Std 1588 does not specify a name for each clock-accuracy,
+      but the names below are intended to be as intuitive as possible.
+      YANG identity is used so that a PTP Profile's YANG augment
+      can assign values, using numeric range 80 to FD hex.";
+    reference
+      "7.6.2.6 of IEEE Std 1588-2019";
+  }
+    identity ca-time-accurate-to-1000-fs {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 1 ps (1000 fs).
+        Numeric value is 17 hex.";
+    }
+    identity ca-time-accurate-to-2500-fs {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 2.5 ps (2500 fs).
+        Numeric value is 18 hex.";
+    }
+    identity ca-time-accurate-to-10-ps {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 10 ps.
+        Numeric value is 19 hex.";
+    }
+    identity ca-time-accurate-to-25ps {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 25 ps.
+        Numeric value is 1A hex.";
+    }
+    identity ca-time-accurate-to-100-ps {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 100 ps.
+        Numeric value is 1B hex.";
+    }
+    identity ca-time-accurate-to-250-ps {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 250 ps.
+        Numeric value is 1C hex.";
+    }
+    identity ca-time-accurate-to-1000-ps {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 1ns (1000 ps).
+        Numeric value is 1D hex.";
+    }
+    identity ca-time-accurate-to-2500-ps {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 2.5 ns (2500 ps).
+        Numeric value is 1E hex.";
+    }
+    identity ca-time-accurate-to-10-ns {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 10 ns.
+        Numeric value is 1F hex.";
+    }
+    identity ca-time-accurate-to-25-ns {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 25 ns.
+        Numeric value is 20 hex.";
+    }
+    identity ca-time-accurate-to-100-ns {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 100 ns.
+        Numeric value is 21 hex.";
+    }
+    identity ca-time-accurate-to-250-ns {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 250 ns.
+        Numeric value is 22 hex.";
+    }
+    identity ca-time-accurate-to-1000-ns {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 1 us (1000 ns).
+        Numeric value is 23 hex.";
+    }
+    identity ca-time-accurate-to-2500-ns {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 2.5 us (2500 ns).
+        Numeric value is 24 hex.";
+    }
+    identity ca-time-accurate-to-10-us {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 10 us.
+        Numeric value is 25 hex.";
+    }
+    identity ca-time-accurate-to-25-us {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 25 us.
+        Numeric value is 26 hex.";
+    }
+    identity ca-time-accurate-to-100-us {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 100 us.
+        Numeric value is 27 hex.";
+    }
+    identity ca-time-accurate-to-250-us {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 250 us.
+        Numeric value is 28 hex.";
+    }
+    identity ca-time-accurate-to-1000-us {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 1 ms (1000 us).
+        Numeric value is 29 hex.";
+    }
+    identity ca-time-accurate-to-2500-us {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 2.5 ms (2500 us).
+        Numeric value is 2A hex.";
+    }
+    identity ca-time-accurate-to-10-ms {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 10 ms.
+        Numeric value is 2B hex.";
+    }
+    identity ca-time-accurate-to-25-ms {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 25 ms.
+        Numeric value is 2Chex.";
+    }
+    identity ca-time-accurate-to-100-ms {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 100 ms.
+        Numeric value is 2D hex.";
+    }
+    identity ca-time-accurate-to-250-ms {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 250 ms.
+        Numeric value is 2E hex.";
+    }
+    identity ca-time-accurate-to-1-s {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 1 s.
+        Numeric value is 2F hex.";
+    }
+    identity ca-time-accurate-to-10-s {
+      base clock-accuracy;
+      description
+        "The time is accurate to within 10 s.
+        Numeric value is 30 hex.";
+    }
+    identity ca-time-accurate-to-gt-10-s {
+      base clock-accuracy;
+      description
+        "The time accuracy exceeds 10 s.
+        Numeric value is 31 hex.";
+    }
+
+  identity time-source {
+    description
+      "Enumeration for the source of time used by the Grandmaster
+      PTP Instance.
+      YANG identity is used so that a PTP Profile's YANG augment
+      can assign values, using numeric range F0 to FE hex.";
+    reference
+      "7.6.2.8 of IEEE Std 1588-2019";
+  }
+    identity atomic-clock {
+      base time-source;
+      description
+        "Any PTP Instance that is based on an atomic resonance
+        for frequency, or a PTP Instance directly connected
+        to a device that is based on an atomic resonance for
+        frequency. Numeric value is 10 hex.";
+    }
+    identity gnss {
+      base time-source;
+      description
+        "Any PTP Instance synchronized to a satellite system that
+        distributes time and frequency. Numeric value is 20 hex.";
+    }
+    identity terrestrial-radio {
+      base time-source;
+      description
+        "Any PTP Instance synchronized via any of the radio
+        distribution systems that distribute time and frequency.
+        Numeric value is 30 hex.";
+    }
+    identity serial-time-code {
+      base time-source;
+      description
+        "Any PTP Instance synchronized via any of the serial
+        time code distribution systems that distribute time
+        and frequency, for example, IRIG-B.
+        Numeric value is 39 hex.";
+    }
+    identity ptp {
+      base time-source;
+      description
+        "Any PTP Instance synchronized to a PTP-based source
+        of time external to the domain. Numeric value is 40 hex.";
+    }
+    identity ntp {
+      base time-source;
+      description
+        "Any PTP Instance synchronized via NTP or Simple Network
+        Time Protocol (SNTP) servers that distribute time and
+        frequency. Numeric value is 50 hex.";
+    }
+    identity hand-set {
+      base time-source;
+      description
+        "Used for any PTP Instance whose time has been set by
+        means of a human interface based on observation of a
+        source of time to within the claimed clock accuracy.
+        Numeric value is 60 hex.";
+    }
+    identity other {
+      base time-source;
+      description
+        "Other source of time and/or frequency not covered by
+        other values. Numeric value is 90 hex.";
+    }
+    identity internal-oscillator {
+      base time-source;
+      description
+        "Any PTP Instance whose frequency is not based on atomic
+        resonance, and whose time is based on a free-running
+        oscillator with epoch determined in an arbitrary or
+        unknown manner. Numeric value is A0 hex.";
+    }
+
+  typedef time-interval {
+    type int64;
+    description
+      "Time interval, expressed in nanoseconds, multiplied by 2^16.
+      Positive or negative time intervals outside the maximum range
+      of this data type shall be encoded as the largest positive and
+      negative values of the data type, respectively.";
+    reference
+      "5.3.2 of IEEE Std 1588-2019";
+  }
+
+  typedef clock-identity {
+    type string {
+      pattern "[0-9A-F]{2}(-[0-9A-F]{2}){7}";
+    }
+    description
+      "Identifies unique entities within a PTP Network,
+      e.g. a PTP Instance or an entity of a common service.
+      The identity is an 8-octet array, constructed according
+      to specifications in IEEE Std 1588, using an
+      organization identifier from the IEEE Registration
+      Authority.
+      Each octet is represented in YANG as a pair of
+      hexadecimal characters, using uppercase for a letter.
+      Each octet in the array is separated by the dash
+      character.";
+    reference
+      "5.3.4 of IEEE Std 1588-2019
+      7.5.2.2 of IEEE Std 1588-2019";
+  }
+
+  typedef relative-difference {
+    type int64;
+    description
+      "Relative difference expressed as a dimensionless
+      fraction and multiplied by 2^62, with any
+      remaining fractional part truncated.";
+    reference
+      "5.3.11 of IEEE Std 1588-2019";
+  }
+
+  typedef instance-type {
+    type enumeration {
+      enum oc {
+        value 0;
+        description
+          "Ordinary Clock";
+      }
+      enum bc {
+        value 1;
+        description
+          "Boundary Clock";
+      }
+      enum p2p-tc {
+        value 2;
+        description
+          "Peer-to-peer Transparent Clock";
+      }
+      enum e2e-tc {
+        value 3;
+        description
+          "End-to-end Transparent Clock";
+      }
+    }
+    description
+      "Enumeration for the type of PTP Instance.
+      Values for this enumeration are specified by the IEEE 1588
+      standard exclusively.";
+    reference
+      "8.2.1.5.5 of IEEE Std 1588-2019";
+  }
+
+  typedef fault-severity {
+    type enumeration {
+      enum emergency {
+        value 0;
+        description
+          "Emergency: system is unusable";
+      }
+      enum alert {
+        value 1;
+        description
+          "Alert: immediate action needed";
+      }
+      enum critical {
+        value 2;
+        description
+          "Critical: critical conditions";
+      }
+      enum error {
+        value 3;
+        description
+          "Error: error conditions";
+      }
+      enum warning {
+        value 4;
+        description
+          "Warning: warning conditions";
+      }
+      enum notice {
+        value 5;
+        description
+          "Notice: normal but significant condition";
+      }
+      enum informational {
+        value 6;
+        description
+          "Informational: informational messages";
+      }
+      enum debug {
+        value 7;
+        description
+          "Debug: debug-level messages";
+      }
+    }
+    description
+      "Enumeration for the severity of a fault record.
+      Values for this enumeration are specified by the IEEE 1588
+      standard exclusively.";
+    reference
+      "8.2.6.3 of IEEE Std 1588-2019";
+  }
+
+  typedef port-state {
+    type enumeration {
+      enum initializing {
+        value 1;
+        description
+          "The PTP Port is initializing its data sets, hardware, and
+          communication facilities. The PTP Port shall not place any
+          PTP messages on its communication path.";
+      }
+      enum faulty {
+        value 2;
+        description
+          "The fault state of the protocol. Except for PTP management
+          messages that are a required response to a PTP message
+          received from the applicable management mechanism,
+          a PTP Port in this state shall not transmit any PTP related
+          messages. In a Boundary Clock, no activity on a faulty
+          PTP Port shall affect the other PTP Ports of the
+          PTP Instance. If fault activity on a PTP Port in this state
+          cannot be confined to the faulty PTP Port, then all
+          PTP Ports shall be in the faulty state.";
+      }
+      enum disabled {
+        value 3;
+        description
+          "The PTP Port is disabled. Except for PTP management
+          messages that are a required response to a PTP message
+          received from the applicable management mechanism,
+          a PTP Port in this state shall not transmit any PTP related
+          messages. In a Boundary Clock, no activity at the PTP Port
+          shall be allowed to affect the activity at any other
+          PTP Port of the Boundary Clock. A PTP Port in this state
+          shall discard all received PTP messages except for PTP
+          management messages.";
+      }
+      enum listening {
+        value 4;
+        description
+          "The PTP Port is waiting for the announce-receipt-timeout
+          to expire or to receive an Announce message from a
+          Master PTP Instance. The purpose of this state is to allow
+          orderly addition of PTP Instances to a domain
+          (i.e. to know if this PTP Port is truly a port of the
+          Grandmaster PTP Instance prior to taking that role).";
+      }
+      enum pre-master {
+        value 5;
+        description
+          "This port state provides an additional mechanism to
+          support more orderly reconfiguration of PTP Networks when
+          PTP Instances are added or deleted, PTP Instance
+          characteristics change, or connection topology changes.
+          In this state, a PTP Port behaves as it would if it were in
+          the master state except that it does not place certain
+          classes of PTP messages on the PTP Communication Path
+          associated with the PTP Port.";
+      }
+      enum master {
+        value 6;
+        description
+          "The PTP Port is the source of time on the
+          PTP Communication Path.";
+      }
+      enum passive {
+        value 7;
+        description
+          "The PTP Port is not the source of time on the
+          PTP Communication Path nor does it synchronize to a
+          Master Clock (receive time). The PTP Port can potentially
+          change to slave when PTP Instances are added or deleted,
+          PTP Instance characteristics change, or connection
+          topology changes.";
+      }
+      enum uncalibrated {
+        value 8;
+        description
+          "The PTP Port is anticipating a change to the slave state,
+          but it has not yet satisfied all requirements
+          (implementation or PTP Profile) necessary to ensure
+          complete synchronization. For example, an implementation
+          might require a minimum number of PTP Sync messages
+          in order to completely synchronize its servo algorithm.";
+      }
+      enum slave {
+        value 9;
+        description
+          "The PTP Port synchronizes to the PTP Port on the
+          PTP Communication Path that is in the master state
+          (i.e. receives time).";
+      }
+    }
+    description
+      "Enumeration for the state of the protocol engine associated
+      with the PTP Port.  Values for this enumeration are specified
+      by the IEEE 1588 standard exclusively.";
+    reference
+      "8.2.15.3.1 of IEEE Std 1588-2019
+      9.2.5 of IEEE Std 1588-2019";
+  }
+
+  typedef delay-mechanism {
+    type enumeration {
+      enum e2e {
+        value 1;
+        description
+          "The PTP Port is configured to use the delay
+          request-response mechanism.";
+      }
+      enum p2p {
+        value 2;
+        description
+          "The PTP Port is configured to use the peer-to-peer
+          delay mechanism.";
+      }
+      enum no-mechanism {
+        value 254;
+        description
+          "The PTP Port does not implement the delay mechanism.
+          This value shall not be used except when the applicable
+          PTP Profile specifies either:
+          1) that the PTP Instance only supports frequency
+          transfer (syntonization) and that neither path delay
+          mechanism is to be used or
+          2) that the PTP Instance participates in time transfer,
+          but the system accuracy requirements are such that,
+          for a segment of the system path, delays can be neglected
+          allowing PTP Instances in that portion of the PTP Network
+          to use the no-mechanism value.";
+      }
+      enum common-p2p {
+        value 3;
+        description
+          "The PTP Port is configured to use the Common Mean Link
+          Delay Service option.";
+      }
+      enum special {
+        value 4;
+        description
+          "Special Ports do not use either delay mechanism.";
+      }
+    }
+    description
+      "Enumeration for the path delay measuring mechanism.
+      Values for this enumeration are specified by the IEEE 1588
+      standard exclusively.";
+    reference
+      "8.2.15.4.4 of IEEE Std 1588-2019";
+  }
+
+  typedef l1sync-state {
+    type enumeration {
+      enum disabled {
+        value 1;
+        description
+          "L1Sync is not enabled on this PTP Port,
+          or the event L1SYNC_RESET has occurred.";
+      }
+      enum idle {
+        value 2;
+        description
+          "L1Sync is enabled on this PTP Port. The PTP Port
+          sends messages with the L1_SYNC TLV. Initialization
+          occurs in this state.";
+      }
+      enum link-alive {
+        value 3;
+        description
+          "The PTP Port sends messages with the L1_SYNC TLV.
+          The PTP Port is receiving valid L1_SYNC TLV
+          from a peer PTP Port.";
+      }
+      enum config-match {
+        value 4;
+        description
+          "The PTP Port sends messages with the L1_SYNC TLV.
+          The PTP Port has a compatible configuration profile
+          when compared with its peer PTP Port configuration
+          profile received in the L1_SYNC TLV.";
+      }
+      enum l1-sync-up {
+        value 5;
+        description
+          "The PTP Port sends messages with the L1_SYNC TLV.
+          The relationship required by configuration is currently
+          in place. Synchronization enhancements are performed.";
+      }
+    }
+    description
+      "Enumeration for states of an L1Sync state machine associated
+      with an L1Sync port.
+      Values for this enumeration are specified by the IEEE 1588
+      standard exclusively.";
+    reference
+      "L.5.3.5 of IEEE Std 1588-2019
+      L.7.2 of IEEE Std 1588-2019";
+  }
+
+  grouping timestamp {
+    description
+      "The IEEE Std 1588 Timestamp type represents a
+      positive time with respect to the epoch
+      of PTP Instance Time.
+      This type is represented in YANG as a grouping,
+      with leafs seconds-field and nanoseconds-field.";
+    reference
+      "5.3.3 of IEEE Std 1588-2019
+      8.2.6.3 of IEEE Std 1588-2019";
+
+    leaf seconds-field {
+      type uint64 {
+        range "0..281474976710655";
+      }
+      description
+        "The seconds-field member is the integer portion
+        of the timestamp in units of seconds. Since the
+        IEEE 1588 type is UInteger48, only 48 bits
+        are represented in YANG.";
+    }
+
+    leaf nanoseconds-field {
+      type uint32;
+      description
+        "The nanoseconds-field member is the fractional
+        portion of the timestamp in units of nanoseconds.";
+    }
+  }
+  grouping port-identity {
+    description
+      "The IEEE Std 1588 PortIdentity type identifies a
+      PTP Port or Link Port.";
+    reference
+      "5.3.5 of IEEE Std 1588-2019";
+
+    leaf clock-identity {
+      type clock-identity;
+      description
+        "IEEE Std 1588 clockIdentity.";
+    }
+
+    leaf port-number {
+      type uint16;
+      description
+        "IEEE Std 1588 portNumber.
+        If portNumber is unavailable, the value 0 can
+        be used, or this leaf can be omitted from the
+        operational datastore.";
+      reference
+        "7.5.2.3 of IEEE Std 1588-2019";
+    }
+  }
+
+  grouping port-address {
+    description
+      "The IEEE Std 1588 PortAddress type represents the
+      protocol address of a PTP Port.";
+    reference
+      "5.3.6 of IEEE Std 1588-2019";
+
+    leaf network-protocol {
+      type identityref {
+        base network-protocol;
+      }
+      description
+        "Protocol used by a PTP Instance to transport
+        PTP messages.";
+    }
+
+    leaf address-length {
+      type uint16;
+      description
+        "Number of octets in address-field.";
+    }
+
+    leaf address-field {
+      type string {
+        pattern "[0-9A-F]{2}(-[0-9A-F]{2})*";
+      }
+      description
+        "The protocol address of a PTP Port in the format
+        defined by the mapping annex of the protocol as
+        identified by the network-protocol leaf.
+        The most significant octet of the address-field
+        is mapped into the octet of the address-field
+        member with index 0.
+        Each octet is represented in YANG as a pair of
+        hexadecimal characters, using uppercase for a letter.
+        Each octet in the array is separated by the dash
+        character.";
+    }
+  }
+
+  grouping clock-quality {
+    description
+      "Quality of a PTP Instance, which contains IEEE Std 1588
+      clockClass, clockAccuracy and offsetScaledLogVariance.
+      PTP Instances with better quality are more likely to
+      become the Grandmaster PTP Instance.";
+    reference
+      "5.3.7 of IEEE Std 1588-2019
+      8.2.1.3.1 of IEEE Std 1588-2019";
+
+    leaf clock-class {
+      type identityref {
+        base clock-class;
+      }
+      description
+        "The clockClass denotes the traceability of the time
+        or frequency distributed by the clock.";
+      reference
+        "7.6.2.5 of IEEE Std 1588-2019
+        8.2.1.3.1.2 of IEEE Std 1588-2019";
+    }
+
+    leaf clock-accuracy {
+      type identityref {
+        base clock-accuracy;
+      }
+      description
+        "The clockAccuracy indicates the accuracy of the clock
+        (Local Clock of the PTP Instance).";
+      reference
+        "7.6.2.6 of IEEE Std 1588-2019
+        8.2.1.3.1.3 of IEEE Std 1588-2019";
+    }
+
+    leaf offset-scaled-log-variance {
+      type uint16;
+      description
+        "The offsetScaledLogVariance indicates the stability of the
+        clock (Local Clock of the PTP Instance). It provides an
+        estimate of the variations of the clock from a linear timescale
+        when it is not synchronized to another clock using the
+        protocol.";
+      reference
+        "7.6.2.7 of IEEE Std 1588-2019";
+    }
+  }
+
+  grouping fault-record {
+    description
+      "Record of a fault in the PTP Instance.
+
+      NOTE - IEEE Std 1588 specifies a member
+      faultRecordLength for this type, which is needed
+      for PTP Management Messages, but is not needed for
+      YANG management.";
+    reference
+      "5.3.10 of IEEE Std 1588-2019";
+
+    container time {
+      description
+        "Time the fault occurred as indicated by the Timestamping
+        Clock of the PTP Instance. A value of all 1's for the
+        fields in the timestamp shall indicate that the occurrence
+        time is not available.";
+      uses timestamp;
+    }
+
+    leaf severity {
+      type fault-severity;
+      description
+        "Severity of the fault.";
+    }
+
+    leaf name {
+      type string;
+      description
+        "Name for the fault, unique within the implementation.";
+    }
+
+    leaf value {
+      type string;
+      description
+        "Any value that may be associated with the fault that is
+        necessary for fault diagnosis.";
+    }
+
+    leaf description {
+      type string;
+      description
+        "Any supplementary description of the fault.";
+    }
+  }
+
+  grouping communication-capabilities {
+    description
+      "Multicast/unicast capabilities for a port
+      and message type.
+      These attributes report the values that are transmitted
+      by this PTP Instance to other PTP Instance(s) in the
+      network to indicate the multicast/unicast capabilities
+      for a port and message type. Therefore, the context is
+      protocol communication, and not YANG configuration.";
+    reference
+      "5.3.12 of IEEE Std 1588-2019
+      8.2.25 of IEEE Std 1588-2019
+      16.9.2 of IEEE Std 1588-2019";
+
+    leaf multicast-capable {
+      type boolean;
+      description
+        "True if the PTP Port is capable of transmitting
+        PTP messages using multicast communication,
+        otherwise it shall be false.";
+    }
+
+    leaf unicast-capable {
+      type boolean;
+      description
+        "True if the PTP Port is capable of transmitting
+        PTP messages using unicast communication,
+        otherwise it shall be false.";
+    }
+
+    leaf unicast-negotiation-capable {
+      type boolean;
+      description
+        "True if the PTP Port is capable negotiating unicast
+        communication using the unicast negotiation feature,
+        and unicast-negotiation-port-ds/enable is true,
+        otherwise the value of shall be false.";
+    }
+
+    leaf unicast-negotiation-required {
+      type boolean;
+      description
+        "True if the value of unicast-negotiation-capable is true
+        and the use of the unicast negotiation feature is
+        required by the implementation, otherwise the value
+        shall be false.";
+    }
+  }
+
+  grouping ptp-instance-performance-parameters {
+    description
+      "PTP Instance Performance Monitoring Parameters,
+      related to the PTP Port or Link Port in the
+      slave state.";
+    reference
+      "Table J.1 of IEEE Std 1588-2019";
+
+    leaf average-master-slave-delay {
+      type time-interval;
+      description
+        "Average of the MasterSlaveDelay for this interval.";
+    }
+    leaf minimum-master-slave-delay {
+      type time-interval;
+      description
+        "Minimum of the MasterSlaveDelay for this interval.";
+    }
+    leaf maximum-master-slave-delay {
+      type time-interval;
+      description
+        "Maximum of the MasterSlaveDelay for this interval.";
+    }
+    leaf stddev-master-slave-delay {
+      type time-interval;
+      description
+        "StdDev of the MasterSlaveDelay for this interval.";
+    }
+    leaf average-slave-master-delay {
+      type time-interval;
+      description
+        "Average of the SlaveMasterDelay for this interval.";
+    }
+    leaf minimum-slave-master-delay {
+      type time-interval;
+      description
+        "Minimum of the SlaveMasterDelay for this interval.";
+    }
+    leaf maximum-slave-master-delay {
+      type time-interval;
+      description
+        "Maximum of the SlaveMasterDelay for this interval.";
+    }
+    leaf stddev-slave-master-delay {
+      type time-interval;
+      description
+        "StdDev of the SlaveMasterDelay for this interval.";
+    }
+    leaf average-mean-path-delay {
+      type time-interval;
+      description
+        "Average of the <meanPathDelay> this interval.";
+    }
+    leaf minimum-mean-path-delay {
+      type time-interval;
+      description
+        "Minimum of the <meanPathDelay> for this interval.";
+    }
+    leaf maximum-mean-path-delay {
+      type time-interval;
+      description
+        "Maximum of the <meanPathDelay> for this interval.";
+    }
+    leaf stddev-mean-path-delay {
+      type time-interval;
+      description
+        "StdDev of the <meanPathDelay> for this interval.";
+    }
+    leaf average-offset-from-master {
+      type time-interval;
+      description
+        "Average of the <offsetFromMaster> for this interval.";
+    }
+    leaf minimum-offset-from-master {
+      type time-interval;
+      description
+        "Minimum of the <offsetFromMaster> for this interval.";
+    }
+    leaf maximum-offset-from-master {
+      type time-interval;
+      description
+        "Maximum of the <offsetFromMaster> for this interval.";
+    }
+    leaf stddev-offset-from-master {
+      type time-interval;
+      description
+        "StdDev of the <offsetFromMaster> for this interval.";
+    }
+  }
+
+  grouping ptp-port-performance-parameters-peer-delay {
+    description
+      "PTP Port Performance Monitoring Parameters,
+      related to the PTP Port or Link Port using the
+      peer-to-peer delay mechanism.";
+    reference
+      "Table J.2 of IEEE Std 1588-2019";
+
+    leaf average-mean-link-delay {
+      type time-interval;
+      description
+        "Average of the <meanLinkDelay> for this interval.";
+    }
+    leaf min-mean-link-delay {
+      type time-interval;
+      description
+        "Minimum of the <meanLinkDelay> for this interval.";
+    }
+    leaf max-mean-link-delay {
+      type time-interval;
+      description
+        "Maximum of the <meanLinkDelay> for this interval.";
+    }
+    leaf stddev-mean-link-delay {
+      type time-interval;
+      description
+        "StdDev of the <meanLinkDelay> for this interval.";
+    }
+  }
+
+  grouping additional-performance-parameters {
+    description
+      "Additional Performance Monitoring Parameters,
+      intended to complement ptp-instance-performance-parameters.";
+    reference
+      "Table J.3 of IEEE Std 1588-2019";
+
+    leaf announce-tx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Announce
+        messages that have been transmitted for this
+        interval.";
+    }
+    leaf announce-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Announce
+        messages from the current GM that have been
+        received for this interval.";
+    }
+    leaf announce-foreign-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the total number of Announce
+        messages from the foreign Masters that have been
+        received for this interval.";
+    }
+    leaf sync-tx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Sync
+        messages that have been transmitted for this
+        interval.";
+    }
+    leaf sync-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Sync
+        messages that have been received for this
+        interval.";
+    }
+    leaf follow-up-tx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Follow_Up
+        messages that have been transmitted for this
+        interval.";
+    }
+    leaf follow-up-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Follow_Up
+        messages that have been received for this
+        interval.";
+    }
+    leaf delay-req-tx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Delay_Req
+        messages that have been transmitted for this
+        interval.";
+    }
+    leaf delay-req-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Delay_Req
+        messages that have been received for this
+        interval.";
+    }
+    leaf delay-resp-tx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Delay_Resp
+        messages that have been transmitted for this
+        interval.";
+    }
+    leaf delay-resp-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Delay_Resp
+        messages that have been received for this
+        interval.";
+    }
+    leaf pdelay-req-tx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Pdelay_Req
+        messages that have been transmitted for this
+        interval.";
+    }
+    leaf pdelay-req-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Pdelay_Req
+        messages that have been received for this
+        interval.";
+    }
+    leaf pdelay-resp-tx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Pdelay_Resp
+        messages that have been transmitted for this
+        interval.";
+    }
+    leaf pdelay-resp-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of Pdelay_Resp
+        messages that have been received for this
+        interval.";
+    }
+    leaf pdelay-resp-follow-up-tx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of
+        Pdelay_Resp_Follow_Up messages that have
+        been transmitted for this interval.";
+    }
+    leaf pdelay-resp-follow-up-rx {
+      type yang:zero-based-counter32;
+      description
+        "Counter indicating the number of
+        Pdelay_Resp_Follow_Up messages that have
+        been transmitted for this interval.";
+    }
+  }
+
+  grouping clock-performance-monitoring-data-record {
+    description
+      "The IEEE Std 1588 ClockPerformanceMonitoringDataRecord
+      type is used for PTP Instance performance monitoring
+      statistics.";
+    reference
+      "Table J.4.1 of IEEE Std 1588-2019";
+
+    leaf index {
+      type uint16;
+      description
+        "Index to each record in the list (0-99).";
+    }
+
+    leaf measurement-valid {
+      type boolean;
+      description
+        "The measurement-valid flag shall indicate the data
+        can be correctly interpreted. Validity is
+        implementation specific and may be defined in
+        a PTP Profile. If for some periods the data is not
+        valid for part of the data collection interval
+        (e.g. the clock is not locked), a specific
+        implementation can report the statistics only for
+        valid data and with measurement-valid true.
+
+        This flag applies to all parameters for a
+        given measurement period, including PTP Port
+        and Link Port related.";
+    }
+
+    leaf period-complete {
+      type boolean;
+      description
+        "The period-complete flag shall indicate that
+        measurements were performed during the entire
+        period (15-minute or 24-hour). For example,
+        if the PTP Instance is disabled for five minutes
+        of a 15-minute period, period-complete is false.
+        The period-complete flag is not related to the
+        validity of measurements that were performed.
+
+        This flag applies to all parameters for a
+        given measurement period, including PTP Port
+        and Link Port related.";
+    }
+
+    leaf pm-time {
+      type yang:timestamp;
+      description
+        "Time of the beginning of the measurement record.
+        This leaf's type is YANG timestamp, which is based
+        on system time (also known as local time). System
+        time is an unsigned integer in units of
+        10 milliseconds, using an epoch defined by the
+        implementation (typically time of boot-up).";
+      reference
+        "IETF RFC 6991";
+    }
+
+    uses ptp-instance-performance-parameters;
+  }
+
+  grouping port-performance-monitoring-peer-delay-data-record {
+    description
+      "The IEEE Std 1588 PortPerformanceMonitoringPeerDelayDataRecord
+      type is used for the PTP Port related performance monitoring
+      statistics for the peer-to-peer delay measurement mechanism.";
+    reference
+      "Table J.4.1 of IEEE Std 1588-2019";
+
+    leaf index {
+      type uint16;
+      description
+        "Index to each record in the list (0-99).";
+    }
+
+    leaf pm-time {
+      type yang:timestamp;
+      description
+        "Time of the beginning of the measurement record.
+        This leaf's type is YANG timestamp, which is based
+        on system time (also known as local time). System
+        time is an unsigned integer in units of
+        10 milliseconds, using an epoch defined by the
+        implementation (typically time of boot-up).";
+      reference
+        "RFC 6991";
+    }
+
+    uses ptp-port-performance-parameters-peer-delay;
+  }
+
+  grouping port-performance-monitoring-data-record {
+    description
+      "The IEEE Std 1588 PortPerformanceMonitoringDataRecord
+      type is used for additional PTP Port related performance
+      monitoring statistics.";
+    reference
+      "Table J.4.1 of IEEE Std 1588-2019";
+
+    leaf index {
+      type uint16;
+      description
+        "Index to each record in the list (0-99).";
+    }
+
+    leaf pm-time {
+      type yang:timestamp;
+      description
+        "Time of the beginning of the measurement record.
+        This leaf's type is YANG timestamp, which is based
+        on system time (also known as local time). System
+        time is an unsigned integer in units of
+        10 milliseconds, using an epoch defined by the
+        implementation (typically time of boot-up).";
+      reference
+        "RFC 6991";
+    }
+
+    uses additional-performance-parameters;
+  }
+
+  container ptp {
+    description
+      "Contains all YANG nodes for the PTP data sets.
+      This hierarchy can be augmented with YANG nodes
+      for a specific vendor or PTP Profile.";
+
+    container instances {
+      description
+        "YANG container that is used to get all PTP Instances.
+        YANG does not allow get of all elements in a YANG list,
+        so a YANG container wrapping the YANG list is provided for
+        that purpose. The naming convention uses plural for the
+        wrapping YANG container, and singular for the YANG list.";
+
+      list instance {
+
+        key "instance-index";
+
+        description
+          "List of one or more PTP Instances in the product (PTP Node).
+          Each PTP Instance represents a distinct instance of PTP
+          implementation (i.e. distinct Ordinary Clock, Boundary Clock,
+          or Transparent Clock), maintaining a distinct time.
+          PTP Instances may be created or deleted dynamically in
+          implementations that support dynamic create/delete.";
+        reference
+          "8.1.4.2 of IEEE Std 1588-2019";
+
+        leaf instance-index {
+          type uint32;
+          description
+            "The instance list is indexed using a number that is
+            unique per PTP Instance within the PTP Node, applicable
+            to the management context only (i.e. not used in PTP
+            messages). The domain-number of the PTP Instance is not
+            used as the key to instance-list, since it is possible
+            for a PTP Node to contain multiple PTP Instances using
+            the same domain-number.";
+          reference
+            "8.1.4.2 of IEEE Std 1588-2019";
+        }
+
+        container default-ds {
+          description
+            "The default data set of the PTP Instance.";
+          reference
+            "8.2.1 of IEEE Std 1588-2019";
+
+          leaf two-step-flag {
+            type boolean;
+            config false;
+            status deprecated;
+            description
+              "When set to true, the PTP Instance is two-step,
+              otherwise the PTP Instance is one-step.
+              This data set member is no longer used. However,
+              the twoStepFlag of the PTP common header is used.
+              One step or two step egress behavior is allowed to
+              be specified per PTP Port, or per PTP Instance.
+              Management of the one/two step egress behavior of
+              a PTP Port is not provided by this standard, but
+              can be specified as extensions to the data sets by a
+              PTP Profile or a product specification.";
+            reference
+              "8.2.1.2.1 of IEEE Std 1588-2019";
+          }
+
+          leaf clock-identity {
+            type clock-identity;
+            config false;
+            description
+              "The IEEE Std 1588 clockIdentity of the PTP Instance.";
+            reference
+              "8.2.1.2.2 of IEEE Std 1588-2019";
+          }
+
+          leaf number-ports {
+            type uint16;
+            config false;
+            description
+              "The number of PTP Ports on the PTP Instance.
+              For an Ordinary Clock, the value shall be one.";
+            reference
+              "8.2.1.2.3 of IEEE Std 1588-2019";
+          }
+
+          container clock-quality {
+            description
+              "The IEEE Std 1588 clockQuality of the PTP Instance.
+              PTP Instances with better quality are more likely to
+              become the Grandmaster PTP Instance.";
+            reference
+              "8.2.1.3.1 of IEEE Std 1588-2019";
+            uses clock-quality;
+        }
+
+          leaf priority1 {
+            type uint8;
+            description
+              "The IEEE Std 1588 priority1 of the PTP Instance.
+              Since priority1 is one of the first comparisons
+              performed by the Best Master Clock Algorithm (BMCA),
+              this leaf's configuration can be used to explicitly
+              select a Grandmaster PTP Instance.
+              Lower values take precedence.
+              The value of priority1 shall be configurable to any
+              value in the range 0 to 255, unless restricted by
+              limits established by the applicable PTP Profile.";
+            reference
+              "7.6.2.3 of IEEE Std 1588-2019
+              8.2.1.4.1 of IEEE Std 1588-2019";
+          }
+
+          leaf priority2 {
+            type uint8;
+            description
+              "The IEEE Std 1588 priority2 of the PTP Instance.
+              The priority2 member is compared by the Best Master
+              Clock Algorithm (BMCA) after priority1 and clockQuality.
+              Lower values take precedence.
+              The value of priority2 shall be configurable to any
+              value in the range 0 to 255, unless restricted by
+              limits established by the applicable PTP Profile.";
+            reference
+              "7.6.2.4 of IEEE Std 1588-2019
+              8.2.1.4.2 of IEEE Std 1588-2019";
+          }
+
+          leaf domain-number {
+            type uint8;
+            description
+              "The IEEE Std 1588 domainNumber of the PTP Instance.
+              A domain consists of one or more PTP Instances
+              communicating with each other as defined by the
+              protocol. A domain shall define the scope of PTP message
+              communication, state, operations, data sets, and
+              timescale. Therefore, each domain represents a distinct
+              time.
+              Within a PTP Network, a domain is identified by two
+              data set members: domainNumber and sdoId.
+              The domainNumber is the primary mechanism for end users
+              and system integrators to isolate the operation of a
+              PTP Instance from PTP messages used in other domains.
+              The value of the domainNumber shall be configurable
+              to values permitted in IEEE Std 1588, unless the
+              allowed values are further restricted by the applicable
+              PTP Profile.";
+            reference
+              "7.1 of IEEE Std 1588-2019
+              8.2.1.4.3 of IEEE Std 1588-2019";
+          }
+
+          leaf slave-only {
+            type boolean;
+            description
+              "The value of slave-only shall be true if the
+              PTP Instance is a slave-only PTP Instance
+              (false for non-slave-only).
+              The slave-only member can be true for Ordinary Clocks
+              only.
+              When slave-only is true, the PTP Instance implements
+              special behavior in the context of the state machines
+              that determine port-state.";
+            reference
+              "8.2.1.4.4 of IEEE Std 1588-2019
+              9.2.2.1 of IEEE Std 1588-2019";
+          }
+
+          leaf sdo-id {
+            type uint16 {
+              range "0..4095";
+            }
+            description
+              "The IEEE Std 1588 sdoId of the PTP Instance.
+              A domain consists of one or more PTP Instances
+              communicating with each other as defined by the
+              protocol. A domain shall define the scope of PTP message
+              communication, state, operations, data sets, and
+              timescale. Therefore, each domain represents a distinct
+              time.
+              Within a PTP Network, a domain is identified by two
+              data set members: domainNumber and sdoId.
+              The sdoId of a domain is a 12-bit integer in the
+              closed range 0 to 4095.
+              The sdoId member is the primary mechanism for providing
+              isolation of PTP Instances operating a PTP Profile
+              specified by a Standards Development Organization (SDO),
+              from other PTP Instances operating a PTP Profile
+              specified by a different SDO.";
+            reference
+              "7.1 of IEEE Std 1588-2019
+              8.2.1.4.5 of IEEE Std 1588-2019
+              16.5 of IEEE Std 1588-2019";
+          }
+
+          container current-time {
+            description
+              "For management read, this member shall return the
+              current value of the PTP Instance Time.
+              When management write is supported, this member
+              shall set the PTP Instance Time.
+              Time originates in the Grandmaster PTP Instance and
+              is distributed by PTP to other PTP Instances in
+              the domain.
+              NOTE 1 - The time in the Grandmaster PTP Instance
+              is normally determined by interacting with a primary
+              reference, e.g., GPS, by means outside the scope of
+              this standard.
+              NOTE 2 - When this member is used to set time in a
+              PTP Instance other than the Grandmaster PTP Instance,
+              the PTP Node can return a management error.
+              NOTE 3 - If the time is set in a PTP Instance other
+              than the Grandmaster PTP Instance, it will be
+              overwritten by the operation of the protocol and will
+              therefore exist only as a transient.";
+            reference
+              "8.2.1.5.1 of IEEE Std 1588-2019";
+            uses timestamp;
+          }
+
+          leaf instance-enable {
+            type boolean;
+            description
+              "Indicates if the PTP Instance is enabled for
+              PTP operation.
+              When management write is supported:
+              - Write of the value true shall cause the PTP Instance
+                to initialize, only if the value was previously false.
+              - Write of the value false shall immediately disable
+                operation of the PTP Instance (i.e. analogous to power
+                off).
+              If this leaf is not supported, the PTP Instance shall be
+              specified-by-design to be enabled (true).";
+            reference
+              "8.2.1.5.2 of IEEE Std 1588-2019";
+          }
+
+          leaf external-port-config-enable {
+            if-feature external-port-config;
+            type boolean;
+            description
+              "This value determines whether the external port
+              configuration option is in the disabled state (false)
+              or enabled state (true).
+              When this value is false, each PTP Port's state
+              is determined by PTP state machines, including
+              the Best Master Clock Algorithm (BMCA).
+              When this value is true, each PTP Port's state
+              is configured externally, and PTP state machines
+              are effectively disabled. External configuration
+              of PTP Port state can be accomplished using the
+              desiredState member of the port (i.e.,
+              ../ports/port[]/external-port-config-port-ds/
+              desired-state).";
+            reference
+              "8.2.1.5.3 of IEEE Std 1588-2019
+              17.6 of IEEE Std 1588-2019";
+          }
+
+          leaf max-steps-removed {
+            type uint8 {
+              range "2..255";
+            }
+            description
+              "If the value of stepsRemoved of an Announce message
+              is greater than or equal to the value of this
+              max-steps-removed leaf, the Announce message is not
+              considered in the operation of the
+              Best Master Clock Algorithm (BMCA).
+              The value shall be in the closed range 2 to 255.
+              If the leaf is not supported, the value used shall
+              be 255.";
+            reference
+              "8.2.1.5.4 of IEEE Std 1588-2019
+              9.3.2.5 of IEEE Std 1588-2019";
+          }
+
+          leaf instance-type {
+            type instance-type;
+            description
+              "The type of PTP Instance.
+              This leaf is read-only unless support for write is
+              explicitly specified by the applicable PTP Profile or
+              product specification.";
+            reference
+              "8.2.1.5.5 of IEEE Std 1588-2019";
+          }
+        }
+
+        container current-ds {
+          description
+            "Provides current data from operation
+            of the protocol.";
+          reference
+            "8.2.2 of IEEE Std 1588-2019";
+
+          leaf steps-removed {
+            type uint16;
+            config false;
+            description
+              "The number of PTP Communication Paths traversed
+              between this PTP Instance and the Grandmaster
+              PTP Instance.";
+            reference
+              "8.2.2.2 of IEEE Std 1588-2019";
+          }
+
+          leaf offset-from-master {
+            type time-interval;
+            config false;
+            description
+              "The current value of the time difference between
+              a Master PTP Instance and a Slave PTP Instance as
+              computed by the Slave PTP Instance.
+              NOTE - When a PTP Profile requires a Boundary
+              Clock to transfer offset information internally
+              from Slave PTP Port to Master PTP Port(s), this value
+              effectively returns the offset from the Grandmaster
+              PTP Instance.";
+            reference
+              "8.2.2.3 of IEEE Std 1588-2019";
+          }
+
+          leaf mean-delay {
+            type time-interval;
+            config false;
+            description
+              "The current value of the mean propagation time between
+              a Master PTP Instance and a Slave PTP Instance as
+              computed by the Slave PTP Instance.
+              If the PTP Instance has no PTP Port in slave or
+              uncalibrated state, this returns zero.
+              Otherwise, the Slave PTP Port returns this value
+              depending on its delay-mechanism:
+              e2e: mean propagation time over the
+                PTP Communication Path, i.e. <meanPathDelay>
+              p2p or common-p2p: mean propagation time over the
+                PTP Link, i.e. <meanLinkDelay>
+              disabled or special: zero";
+            reference
+              "7.4.2 of IEEE Std 1588-2019
+              8.2.2.4 of IEEE Std 1588-2019";
+          }
+
+          leaf mean-path-delay {
+            type time-interval;
+            config false;
+            status deprecated;
+            description
+              "In IEEE Std 1588-2008, currentDS.meanDelay was called
+              currentDS.meanPathDelay. While the specification of
+              this member is retained in the current standard, the
+              member is renamed to currentDS.meanDelay. This change
+              is consistent with other changes that ensure clarity
+              and consistency of naming, where
+              - 'path' is associated with the
+                request-response mechanism
+              - 'link' is associated with the
+                peer-to-peer delay mechanism";
+            reference
+              "8.2.2.4 of IEEE Std 1588-2008";
+          }
+
+          leaf synchronization-uncertain {
+            type boolean;
+            config false;
+            description
+              "This boolean is true when synchronization is
+              uncertain (e.g., not within specification)
+              in either the Parent PTP Port or this
+              PTP Instance. The value is copied from a
+              received Announce message to transmitted Announce
+              message, such that it reflects uncertain
+              synchronization from this PTP Instance to the
+              Grandmaster. Performance metrics for determining
+              uncertainty are specified by the applicable
+              PTP Profile.";
+            reference
+              "8.2.2.5 of IEEE Std 1588-2019";
+          }
+        }
+
+        container parent-ds {
+          description
+            "Provides data learned from the parent of this
+            PTP Instance (i.e. master port on the other side
+            of the path/link).";
+          reference
+            "8.2.3 of IEEE Std 1588-2019";
+
+          container parent-port-identity {
+            config false;
+            description
+              "The IEEE Std 1588 portIdentity of the PTP Port on the
+              Master PTP Instance that issues the Sync messages
+              used in synchronizing this PTP Instance.";
+            reference
+              "8.2.3.2 of IEEE Std 1588-2019";
+            uses port-identity;
+          }
+
+          leaf parent-stats {
+            type boolean;
+            config false;
+            description
+              "When set to true, the values of
+              parent-ds/observed-parent-offset-scaled-log-variance
+              and
+              parent-ds/observed-parent-clock-phase-change-rate
+              have been measured and are valid.";
+            reference
+              "8.2.3.3 of IEEE Std 1588-2019";
+          }
+
+          leaf observed-parent-offset-scaled-log-variance {
+            type uint16;
+            config false;
+            description
+              "Estimate of the variance of the phase offset of the
+              Local PTP Clock of the Parent PTP Instance as measured
+              with respect to the Local PTP Clock in the Slave PTP
+              Instance. This measurement is optional, but if not made,
+              the value of parent-ds/parent-stats shall be false.";
+            reference
+              "7.6.3.3 of IEEE Std 1588-2019
+              7.6.3.5 of IEEE Std 1588-2019
+              8.2.3.4 of IEEE Std 1588-2019";
+          }
+
+          leaf observed-parent-clock-phase-change-rate {
+            type int32;
+            config false;
+            description
+              "Estimate of the phase change rate of the
+              Local PTP Clock of the Parent PTP Instance as measured
+              by the Slave PTP Instance using its Local PTP Clock.
+              If the estimate exceeds the capacity of its data type,
+              this value shall be set to 7FFF FFFF (base 16) or
+              8000 0000 (base 16), as appropriate. A positive sign
+              indicates that the phase change rate in the
+              Parent PTP Instance is greater than that in the
+              Slave PTP Instance. The measurement of this value is
+              optional, but if not measured, the value of
+              parent-ds/parent-stats shall be false.";
+            reference
+              "7.6.4.4 of IEEE Std 1588-2019
+              8.2.3.5 of IEEE Std 1588-2019";
+          }
+
+          leaf grandmaster-identity {
+            type clock-identity;
+            config false;
+            description
+              "The IEEE Std 1588 clockIdentity of the Grandmaster PTP
+              Instance.";
+            reference
+              "8.2.3.6 of IEEE Std 1588-2019";
+          }
+
+          container grandmaster-clock-quality {
+            config false;
+            description
+              "The IEEE Std 1588 clockQuality of the Grandmaster PTP
+              Instance.";
+            reference
+              "8.2.3.7 of IEEE Std 1588-2019";
+            uses clock-quality;
+          }
+
+          leaf grandmaster-priority1 {
+            type uint8;
+            config false;
+            description
+              "The IEEE Std 1588 priority1 of the Grandmaster PTP
+              Instance.";
+            reference
+              "8.2.3.8 of IEEE Std 1588-2019";
+          }
+
+          leaf grandmaster-priority2 {
+            type uint8;
+            config false;
+            description
+              "The IEEE Std 1588 priority2 of the Grandmaster PTP
+              Instance.";
+            reference
+              "8.2.3.9 of IEEE Std 1588-2019";
+          }
+
+          container protocol-address {
+            description
+              "The protocol address of the PTP Port
+              that issues the Sync messages used in synchronizing
+              this PTP Instance.";
+            reference
+              "8.2.3.10 of IEEE Std 1588-2019";
+            uses port-address;
+          }
+
+          leaf synchronization-uncertain {
+            type boolean;
+            config false;
+            description
+              "This boolean is true when synchronization is
+              uncertain in the Parent PTP Port.";
+            reference
+              "8.2.3.11 of IEEE Std 1588-2019";
+          }
+        }
+
+        container time-properties-ds {
+          description
+            "Provides data learned from the current
+            Grandmaster PTP Instance.";
+          reference
+            "8.2.4 of IEEE Std 1588-2019";
+
+          leaf current-utc-offset {
+            when "../current-utc-offset-valid='true'";
+            type int16;
+            description
+              "Specified as <dLS> in IERS Bulletin C, this provides
+              the offset from UTC (TAI - UTC). The offset is in
+              units of seconds.";
+            reference
+              "7.2.4 of IEEE Std 1588-2019
+              8.2.4.2 of IEEE Std 1588-2019";
+          }
+
+          leaf current-utc-offset-valid {
+            type boolean;
+            description
+              "The value of current-utc-offset-valid shall be true
+              if the values of current-utc-offset, leap59, and leap61
+              are known to be correct, otherwise it shall be false.
+              NOTE - The constraint for leap59 and leap61 did not
+              exist in IEEE Std 1588-2008, and for compatibility,
+              corresponding when statements were not included below.";
+            reference
+              "8.2.4.3 of IEEE Std 1588-2019";
+          }
+
+          leaf leap59 {
+            type boolean;
+            description
+              "If the timescale is PTP, a true value for leap59
+              shall indicate that the last minute of the
+              current UTC day contains 59 seconds.
+              If the timescale is not PTP, the value shall be
+              false.";
+            reference
+              "8.2.4.4 of IEEE Std 1588-2019";
+          }
+
+          leaf leap61 {
+            type boolean;
+            description
+              "If the timescale is PTP, a true value for leap61
+              shall indicate that the last minute of the
+              current UTC day contains 61 seconds.
+              If the timescale is not PTP, the value shall be
+              false.";
+          reference
+            "8.2.4.5 of IEEE Std 1588-2019";
+          }
+
+          leaf time-traceable {
+            type boolean;
+            description
+              "The value of time-traceable shall be true if the
+              timescale is traceable to a primary reference;
+              otherwise, the value shall be false.
+              The uncertainty specifications appropriate to the
+              evaluation of whether traceability to a primary
+              reference is achieved should be defined in the
+              applicable PTP Profile. In the absence of such a
+              definition the value of time-traceable is
+              implementation specific.";
+            reference
+              "8.2.4.6 of IEEE Std 1588-2019";
+          }
+
+          leaf frequency-traceable {
+            type boolean;
+            description
+              "The value of time-traceable shall be true if the
+              frequency determining the timescale is traceable
+              to a primary reference; otherwise, the value shall
+              be false.
+              The uncertainty specifications appropriate to the
+              evaluation of whether traceability to a primary
+              reference is achieved should be defined in the
+              applicable PTP Profile. In the absence of such a
+              definition the value of frequency-traceable is
+              implementation specific.";
+          reference
+            "8.2.4.7 of IEEE Std 1588-2019";
+          }
+
+          leaf ptp-timescale {
+            type boolean;
+            description
+              "If ptp-timescale is true, the timescale of
+              the Grandmaster PTP Instance is PTP, which is
+              the elapsed time since the PTP epoch measured
+              using the second defined by International Atomic
+              Time (TAI).
+              If ptp-timescale is false, the timescale of
+              the Grandmaster PTP Instance is ARB, which is
+              the elapsed time since an arbitrary epoch.";
+            reference
+              "7.2.1 of IEEE Std 1588-2019
+              8.2.4.8 of IEEE Std 1588-2019";
+          }
+
+          leaf time-source {
+            type identityref {
+              base time-source;
+            }
+            description
+              "The source of time used by the Grandmaster
+              PTP Instance.";
+            reference
+              "7.6.2.8 of IEEE Std 1588-2019
+              8.2.4.9 of IEEE Std 1588-2019";
+          }
+        }
+
+        container description-ds {
+          description
+            "Provides descriptive information for the PTP Instance.";
+          reference
+            "8.2.5 of IEEE Std 1588-2019";
+
+          leaf manufacturer-identity {
+            type string {
+              pattern "[0-9A-F]{2}(-[0-9A-F]{2}){2}";
+            }
+            config false;
+            description
+              "3-octet OUI or CID owned by the manufacturer of the
+              PTP Instance, assigned by the IEEE Registration
+              Authority.
+              Each octet is represented in YANG as a pair of
+              hexadecimal characters, using uppercase for a letter.
+              Each octet in the array is separated by the dash
+              character.";
+            reference
+              "8.2.5.2 of IEEE Std 1588-2019";
+          }
+
+          leaf product-description {
+            type string {
+              length "2..64";
+            }
+            config false;
+            description
+              "The product-description string shall indicate, in order:
+              - The name of the manufacturer of the PTP Instance,
+                manufacturerName, followed by a semicolon (;)
+              - The model number of the PTP Instance, modelNumber,
+                followed by a semicolon (;)
+              - A unique identifier of this PTP Instance,
+                instanceIdentifier, such as the MAC address or
+                the serial number.
+              The content and meaning of the manufacturerName,
+              modelNumber, and the instanceIdentifier strings are
+              determined by the manufacturer of the PTP Instance.";
+            reference
+              "8.2.5.3 of IEEE Std 1588-2019";
+          }
+
+          leaf product-revision {
+            type string {
+              length "2..32";
+            }
+            config false;
+            description
+              "Indicate the revisions for PTP Instance's
+              hardware (HW), firmware (FW), and software (SW).
+              This information shall be semicolon (;) separated
+              text fields in the order HW;FW;SW. Non-applicable
+              revisions shall be indicated by a text fields of
+              zero length.";
+            reference
+              "8.2.5.4 of IEEE Std 1588-2019";
+          }
+
+          leaf user-description {
+            type string {
+              length "0..128";
+            }
+            description
+              "Configurable description of the product's PTP Instance.
+              The user-description string should indicate, in order:
+              - A user-defined name of the PTP Instance,
+                e.g., Sensor-1, followed by a semicolon (;)
+              - A user-defined physical location of the PTP Instance,
+                e.g., Rack-2 Shelf-3.";
+            reference
+              "8.2.5.5 of IEEE Std 1588-2019";
+          }
+        }
+
+        container fault-log-ds {
+          if-feature fault-log;
+          config false;
+          description
+            "Represents an optional mechanism for logging of faults
+            that occur in the PTP Instance. If one member of
+            fault-log-ds is supported, all members shall be
+            supported.";
+          reference
+            "8.2.6 of IEEE Std 1588-2019";
+
+          leaf number-of-fault-records {
+            type uint16;
+            config false;
+            description
+              "The number of fault records available in
+              fault-record-list.";
+            reference
+              "8.2.6.2 of IEEE Std 1588-2019";
+          }
+
+          list fault-record-list {
+            config false;
+            description
+              "List of fault records, number-of-fault-records
+              in length.
+              The maximum length of fault-record-list is
+              implementation-specific. The fault-record-list
+              is maintained by the PTP Instance until
+              fault-log-ds.reset is used.";
+            reference
+              "8.2.6.3 of IEEE Std 1588-2019";
+
+            uses fault-record;
+          }
+
+          action reset {
+            description
+              "This action causes the contents of fault-record-list
+              to be cleared, and number-of-fault-records to be set
+              to zero.";
+            reference
+              "8.2.6.4 of IEEE Std 1588-2019";
+          }
+        }
+
+        // The nonvolatileStorageDS in 8.2.7 of IEEE Std 1588-2019
+        // is not applicable for YANG, since protocols like NETCONF
+        // and RESTCONF specify analogous features for configuration
+        // storage.
+
+        container path-trace-ds {
+          if-feature path-trace;
+          description
+            "Provides data for the optional path
+            trace mechanism.";
+          reference
+            "16.2 of IEEE Std 1588-2019";
+
+          leaf-list list {
+            type clock-identity;
+            config false;
+            description
+              "List of IEEE Std 1588 clock identity values
+              (type ClockIdentity), in the order provided in the
+              PATH_TRACE TLV.";
+            reference
+              "16.2.2.2.1 of IEEE Std 1588-2019";
+          }
+
+          leaf enable {
+            type boolean;
+            description
+              "Allows for enable/disable of the path trace mechanism
+              using management. If path-trace-ds.enable is true,
+              the path trace mechanism shall be operational.
+              If path-trace-ds.enable is false, the path trace
+              mechanism shall be inactive.";
+            reference
+              "16.2.2.3.1 of IEEE Std 1588-2019";
+          }
+        }
+
+        container alternate-timescale-ds {
+          if-feature alternate-timescale;
+          description
+            "Provides data for the optional alternate
+            timescale offsets mechanism.";
+          reference
+            "16.3 of IEEE Std 1588-2019";
+
+          leaf max-key {
+            type uint8;
+            config false;
+            description
+              "The value of max-key shall indicate the value of
+              the largest key-field in the list.";
+            reference
+              "16.3.4.3.1 of IEEE Std 1588-2019";
+          }
+
+          list list {
+            key "key-field";
+            description
+              "List of alternate timescales in the PTP Instance.
+              Elements in the list can be created or deleted, if
+              those operations are supported by management.
+
+              If management write is supported for items
+              current-offset, jump-seconds, and time-of-next-jump,
+              the value for all three items shall be provided
+              within a single write operation, and the update of
+              all three items shall be atomic. If any of the three
+              values fails to update, a management error shall be
+              returned.";
+            reference
+              "16.3.4.4.1 of IEEE Std 1588-2019";
+
+            leaf key-field {
+              type uint8;
+              description
+                "Unique identifier of each element in the list.";
+            }
+
+            leaf enable {
+              type boolean;
+              description
+                "If enable is true, the
+                ALTERNATE_TIME_OFFSET_INDICATOR TLV
+                for this alternate timescale shall be attached
+                to Announce messages. If enable is false, the TLV
+                shall not be attached.";
+            }
+
+            leaf current-offset {
+              type int32;
+              description
+                "Offset of the alternate time, in seconds, from
+                PTP Instance Time in the Grandmaster PTP Instance.";
+            }
+
+            leaf jump-seconds {
+              type int32;
+              description
+                "Size of the next discontinuity, in seconds, in the
+                alternate timescale. A value of zero indicates that
+                no discontinuity is expected. A positive value
+                indicates that the discontinuity will cause the
+                current-offset of the alternate timescale to
+                increase.";
+            }
+
+            leaf time-of-next-jump {
+              type uint64;
+              description
+                "Value of the seconds-field of the transmitting PTP
+                Instance Time at the time that the next discontinuity
+                will occur. The discontinuity occurs at the start of
+                the second indicated by the value of time-of-next-jump.
+                Only 48-bits are valid (the upper 16-bits are always
+                zero).";
+            }
+
+            leaf display-name {
+              type string {
+                length "0..10";
+              }
+              description
+                "Textual description of the alternate timescale.";
+            }
+          }
+        }
+
+        container holdover-upgrade-ds {
+          if-feature holdover-upgrade;
+          description
+            "Provides data for the optional holdover
+            upgrade mechanism.";
+          reference
+            "16.4 of IEEE Std 1588-2019";
+
+          leaf enable {
+            type boolean;
+            description
+              "Used to enable (true) or disable (false) the
+              holdover upgrade mechanism.";
+          }
+        }
+
+        container grandmaster-cluster-ds {
+          if-feature grandmaster-cluster;
+          description
+            "Provides data for the optional grandmaster
+            cluster mechanism.";
+          reference
+            "17.2.3 of IEEE Std 1588-2019";
+
+          leaf max-table-size {
+            type uint8;
+            config false;
+            description
+              "Maximum number of elements permitted
+              in the port-address list.
+
+              NOTE - The actualTableSize of IEEE Std 1588 is not
+              applicable for YANG, since YANG mechanisms can be used
+              to control the number of elements in port-address.";
+          }
+
+          leaf log-query-interval {
+            type int8;
+            description
+              "Logarithm to the base 2 of the mean interval in
+              seconds between unicast Announce messages from
+              cluster members.";
+          }
+
+          list port-address {
+            key "index";
+            description
+              "List of port addresses, one for each member of the
+              grandmaster cluster.";
+
+            leaf index {
+              type uint16;
+              description
+                "Index to a port address in the list, typically
+                sequential from 0 to N-1, where N is the number of
+                port addresses.";
+            }
+
+            uses port-address;
+          }
+        }
+
+        container acceptable-master-ds {
+          if-feature acceptable-master;
+          description
+            "Provides data for the optional acceptable
+            master table mechanism.";
+          reference
+            "17.5.3 of IEEE Std 1588-2019";
+
+          leaf max-table-size {
+            type uint16;
+            config false;
+            description
+              "Maximum number of elements permitted
+              in the list.
+
+              NOTE - The actualTableSize of IEEE Std 1588 is not
+              applicable for YANG, since YANG mechanisms can be used
+              to control the number of elements in list.";
+            reference
+              "17.5.3.3.1 of IEEE Std 1588-2019";
+          }
+
+          list list {
+            key "index";
+            description
+              "List of acceptable masters in the PTP Instance.
+              Elements in the list can be created or deleted, if
+              those operations are supported by management.
+
+              If management write is supported for items
+              acceptable-clock-identity, acceptable-port-number,
+              and alternate-priority1, the value for all three items
+              shall be provided  within a single write operation,
+              and the update of all three items shall be atomic.
+              If any of the three values fails to update, a management
+              error shall be returned.";
+            reference
+              "17.5.3.4.2 of IEEE Std 1588-2019";
+
+            leaf index {
+              type uint8;
+              description
+                "Unique index to each element in the list, typically
+                sequential from 0 to N-1, where N is the number of
+                elements.";
+            }
+
+            container acceptable-port-identity {
+              description
+                "The IEEE Std 1588 portIdentity of the
+                acceptable master.";
+              uses port-identity;
+            }
+
+            leaf alternate-priority1 {
+              type uint8;
+              description
+                "The IEEE Std 1588 priority1 used as an alternate
+                for the acceptable master.";
+            }
+          }
+        }
+
+        container performance-monitoring-ds {
+          if-feature performance-monitoring;
+          description
+            "Provides data for the optional performance
+            monitoring mechanism, scoped to the PTP Instance.";
+          reference
+            "8.2.13 of IEEE Std 1588-2019
+            J.5.1 of IEEE Std 1588-2019";
+
+          leaf enable {
+            type boolean;
+            description
+              "Permits management control over the collection of
+              performance monitoring data, including
+              performance-monitoring-ds (PTP Instance),
+              ports/port[]/performance-monitoring-port-ds
+              (PTP Port of PTP Instance), and
+              common-services/cmlds/ports/port[]/
+              performance-monitoring-port-ds (CMLDS Link Port
+              associated with enabled PTP Port).";
+            reference
+              "J.5.1.1 of IEEE Std 1588-2019";
+          }
+
+          list record-list {
+            key "index";
+            config false;
+            max-elements 99;
+            description
+              "List of performance monitoring records for the
+              PTP Instance. The list is organized as follows:
+              - 97 15-minute measurement records, the current record
+                at index 0, followed by the most recent 96 records.
+              - 2 24-hour measurement records, the current record
+                at index 97, and the previous record at index 98.
+
+              If a record is not implemented for a specific index,
+              management does not return the record. For example,
+              if only four 15-minute periods are implemented,
+              a management request for performance-monitoring-ds/
+              record-list[6] returns an error.
+
+              If only some of the data is reported, the same index
+              values are used. As an example, if only the 24-hour
+              statistics are accessed, the indexes are still 97 and 98.
+
+              If a specific parameter (e.g. max-master-slave-delay)
+              is not implemented, management does not return the
+              parameter (i.e., error). Parameters that are invalid
+              (not measured correctly) shall be indicated with
+              one in all bits, except the most significant. This
+              represents the largest positive value of
+              time-interval, indicating a value outside the
+              maximum range.";
+            reference
+              "J.5.1.2 of IEEE Std 1588-2019";
+
+            uses clock-performance-monitoring-data-record;
+          }
+        }
+
+        container enhanced-metrics-ds {
+          if-feature enhanced-metrics;
+          description
+            "Provides data for the optional enhanced
+            synchronization accuracy metrics mechanism.";
+          reference
+            "16.12 of IEEE Std 1588-2019";
+
+          leaf enable {
+            type boolean;
+            description
+              "If the Enhanced Synchronization Accuracy Metrics feature
+              is implemented, the value true shall indicate that
+              the feature is enabled on the PTP Instance, and the
+              value false shall indicate that the option is disabled
+              on the PTP Instance.";
+            reference
+              "8.2.14.2 of IEEE Std 1588-2019";
+          }
+        }
+
+        container ports {
+          description
+            "YANG container that is used to get all PTP Ports
+            in the PTP Instance.
+            YANG does not allow get of all elements in a YANG list,
+            so a YANG container wrapping the YANG list is provided for
+            that purpose. The naming convention uses plural for the
+            wrapping YANG container, and singular for the YANG list.";
+
+          list port {
+            key "port-index";
+            description
+              "List of data for each PTP Port in the PTP Instance.
+              While the PTP Instance is disabled, it is possible to
+              have zero PTP Ports (i.e., ports not yet created).
+              While the PTP Instance is enabled, an Ordinary Clock
+              will have one PTP Port, and a Boundary Clock or
+              Transparent Clock will have more than one PTP Port.";
+            reference
+              "8.1.4.2 of IEEE Std 1588-2019";
+
+            leaf port-index {
+              type uint16;
+              description
+                "The port list is indexed using a number that is
+                unique per PTP Port within the PTP Instance,
+                applicable to the management context only
+                (i.e., not used in PTP messages).";
+            }
+
+            leaf underlying-interface {
+              type if:interface-ref;
+              description
+                "Reference to the configured underlying IETF YANG
+                interface that is used by this PTP Port for
+                transport of PTP messages. Among other data,
+                physical identifiers for the interface
+                (e.g., MAC address) can be obtained using this
+                reference.";
+              reference
+                "RFC 8343";
+            }
+
+            container port-ds {
+              description
+                "Primary data set for the PTP Port.";
+              reference
+                "8.2.15 of IEEE Std 1588-2019";
+
+              container port-identity {
+                config false;
+                description
+                  "The IEEE Std 1588 portIdentity of this PTP Port.";
+                reference
+                  "8.2.15.2.1 of IEEE Std 1588-2019";
+                uses port-identity;
+              }
+
+              leaf port-state {
+                type port-state;
+                config false;
+                description
+                  "Current state of the protocol engine associated
+                  with this PTP Port.";
+                reference
+                  "8.2.15.3.1 of IEEE Std 1588-2019";
+              }
+
+              leaf log-min-delay-req-interval {
+                type int8;
+                description
+                  "Logarithm to the base 2 of the IEEE Std 1588
+                  minDelayReqInterval, the minimum permitted
+                  mean time interval between successive Delay_Req
+                  messages sent by a Slave PTP Instance.";
+                reference
+                  "7.7.2.4 of IEEE Std 1588-2019
+                  8.2.15.3.2 of IEEE Std 1588-2019";
+              }
+
+              leaf mean-link-delay {
+                type time-interval;
+                config false;
+                description
+                  "If the value of the delay-mechanism leaf is p2p
+                  this value shall be an estimate of the current
+                  one-way propagation delay on the PTP Link attached
+                  to this PTP Port, computed using the peer-to-peer
+                  delay mechanism.
+                  If the value of the delay-mechanism leaf is
+                  common-p2p, this value shall be equal to the value of
+                  ptp/common-services/cmlds/ports/port[]/port-ds/
+                  mean-link-delay.
+                  If the value of the delay-mechanism leaf is e2e,
+                  disabled, or special, this value shall be zero.";
+                reference
+                  "8.2.15.3.3 of IEEE Std 1588-2019";
+              }
+
+              leaf peer-mean-path-delay {
+                type time-interval;
+                config false;
+                status deprecated;
+                description
+                  "In IEEE Std 1588-2008, this data set member was
+                  called portDS.peerMeanPathDelay. While the
+                  specification of this member is retained in the
+                  current standard, the member is renamed to
+                  portDS.meanLinkDelay (i.e., ../mean-link-delay).
+                  This change is consistent with other changes that
+                  ensure clarity and consistency of naming, where
+                  - 'path' is associated with the
+                    request-response mechanism
+                  - 'link' is associated with the
+                    peer-to-peer delay mechanism";
+                reference
+                  "8.2.5.3.3 of IEEE Std 1588-2008";
+              }
+
+              leaf log-announce-interval {
+                type int8;
+                description
+                  "Logarithm to the base 2 of the mean IEEE Std 1588
+                  announceInterval, the time interval between
+                  successive Announce messages sent by a PTP Port.";
+                reference
+                  "7.7.2.2 of IEEE Std 1588-2019
+                  8.2.15.4.1 of IEEE Std 1588-2019";
+              }
+
+              leaf announce-receipt-timeout {
+                type uint8;
+                description
+                  "The integral multiple of IEEE Std 1588
+                  announceInterval that must pass without receipt of
+                  an Announce message before the occurrence of the
+                  event ANNOUNCE_RECEIPT_TIMEOUT_EXPIRES. The range
+                  shall be 2 to 255 subject to further restrictions of
+                  the applicable PTP Profile. While 2 is permissible,
+                  normally the value should be at least 3.";
+                reference
+                  "7.7.3.1 of IEEE Std 1588-2019
+                  8.2.15.4.2 of IEEE Std 1588-2019";
+              }
+
+              leaf log-sync-interval {
+                type int8;
+                description
+                  "Logarithm to the base 2 of the mean IEEE Std 1588
+                  syncInterval, the time interval between successive
+                  Sync messages, when transmitted as multicast
+                  messages. The rates for unicast transmissions are
+                  negotiated separately on a per PTP Port basis and
+                  are not constrained by this leaf.";
+                reference
+                  "7.7.2.3 of IEEE Std 1588-2019
+                  8.2.15.4.3 of IEEE Std 1588-2019";
+              }
+
+              leaf delay-mechanism {
+                type delay-mechanism;
+                description
+                  "The path delay measuring mechanism used by the PTP
+                  Port in computing <meanDelay> (propagation delay).";
+                reference
+                  "8.2.15.4.4 of IEEE Std 1588-2019";
+              }
+
+              leaf log-min-pdelay-req-interval {
+                type int8;
+                description
+                  "Logarithm to the base 2 of the IEEE Std 1588
+                  minPdelayReqInterval, the minimum permitted
+                  mean time interval between successive Pdelay_Req
+                  messages sent over a PTP Link.";
+                reference
+                  "7.7.2.5 of IEEE Std 1588-2019
+                  8.2.15.4.5 of IEEE Std 1588-2019";
+              }
+
+              leaf version-number {
+                type uint8;
+                description
+                  "The PTP major version in use on the PTP Port.
+                  NOTE - This indicates the version of the
+                  IEEE 1588 standard, and not the version of an
+                  applicable PTP Profile.";
+                reference
+                  "8.2.15.4.6 of IEEE Std 1588-2019";
+              }
+
+              leaf minor-version-number {
+                type uint8;
+                description
+                  "The PTP minor version in use on the PTP Port.
+                  NOTE - This indicates the version of the
+                  IEEE 1588 standard, and not the version of an
+                  applicable PTP Profile.";
+                reference
+                  "8.2.15.4.7 of IEEE Std 1588-2019";
+              }
+
+              leaf delay-asymmetry {
+                type time-interval;
+                description
+                  "The value of IEEE Std 1588 <delayAsymmetry>
+                  applicable to the PTP Port, which is the
+                  difference in transmission time in one direction
+                  as compared to the opposite direction.";
+                reference
+                  "7.4.2 of IEEE Std 1588-2019
+                  8.2.15.4.8 of IEEE Std 1588-2019";
+              }
+
+              leaf port-enable {
+                type boolean;
+                description
+                  "Indicates if the PTP Port is enabled for
+                  PTP operation.
+                  When management write is supported:
+                  - Write of the value true causes the
+                    DESIGNATED_ENABLED event to occur, even if the
+                    value was previously true.
+                  - Write of the value false causes the
+                    DESIGNATED_DISABLED event to occur, even if the
+                    value was previously false.
+                  If this leaf is not supported, the PTP Port shall be
+                  specified-by-design to be enabled (true).";
+                reference
+                  "8.2.15.5.1 of IEEE Std 1588-2019";
+              }
+
+              leaf master-only {
+                type boolean;
+                description
+                  "If the value of master-only is true, the PTP Port
+                  shall be in the IEEE Std 1588 masterOnly mode.
+                  If the value is false, the PTP Port shall not be
+                  in the masterOnly mode.
+                  When master-only is true, the PTP Port can never
+                  enter the slave port-state.";
+                reference
+                  "8.2.15.5.2 of IEEE Std 1588-2019
+                  9.2.2.2 of IEEE Std 1588-2019";
+              }
+            }
+
+            container timestamp-correction-port-ds {
+              if-feature timestamp-correction;
+              description
+                "Provides access to the configurable correction of
+                timestamps provided to the PTP protocol.";
+              reference
+                "8.2.16 of IEEE Std 1588-2019
+                16.7 of IEEE Std 1588-2019";
+
+              leaf egress-latency {
+                type time-interval;
+                description
+                  "Interval between the <egressProvidedTimestamp>
+                  provided for a PTP message and the time at which
+                  the message timestamp point of the PTP message
+                  crosses the reference plane.";
+                reference
+                  "7.3.4.2 of IEEE Std 1588-2019
+                  8.2.16.2 of IEEE Std 1588-2019";
+              }
+
+              leaf ingress-latency {
+                type time-interval;
+                description
+                  "Interval between the time the message timestamp
+                  point of an ingress PTP message crosses the
+                  reference plane and the <ingressProvidedTimestamp>
+                  provided for the PTP message.";
+                reference
+                  "7.3.4.2 of IEEE Std 1588-2019
+                  8.2.16.3 of IEEE Std 1588-2019";
+              }
+            }
+
+            container asymmetry-correction-port-ds {
+              if-feature asymmetry-correction;
+              description
+                "Provides access to asymmetry correction parameters
+                that are used to compute the value of
+                delayAsymmetry>.";
+              reference
+                "8.2.17 of IEEE Std 1588-2019
+                16.8 of IEEE Std 1588-2019";
+
+              leaf constant-asymmetry {
+                type time-interval;
+                description
+                  "Constant asymmetry used to fine adjust the
+                  dynamically calculated value of <delayAsymmetry>,
+                  when the mechanism to calculate <delayAsymmetry>
+                  or certain media is enabled.";
+                reference
+                  "8.2.17.2 of IEEE Std 1588-2019";
+              }
+
+              leaf scaled-delay-coefficient {
+                type relative-difference;
+                description
+                  "This is the <delayCoefficient>.";
+                reference
+                  "8.2.17.3 of IEEE Std 1588-2019";
+              }
+
+              leaf enable {
+                type boolean;
+                description
+                  "When this value is true, the mechanism to calculate
+                  <delayAsymmetry> for certain media is enabled on
+                  this PTP Port. When this value is false, this
+                  mechanism is disabled on this PTP Port.";
+                reference
+                  "8.2.17.4 of IEEE Std 1588-2019";
+              }
+            }
+
+            container description-port-ds {
+              description
+                "Provides descriptive information for the PTP Port.";
+              reference
+                "8.2.18 of IEEE Std 1588-2019";
+
+              leaf profile-identifier {
+                type string {
+                  pattern "[0-9A-F]{2}(-[0-9A-F]{2}){5}";
+                }
+                config false;
+                description
+                  "When profile-identifier is supported, its value
+                  shall identify the PTP Profile implemented by the
+                  PTP Port, using the value assigned by the
+                  organization that created the PTP Profile.
+                  The profile identifier is six octets that identify
+                  the PTP Profile's organization, profile within the
+                  organization, and version.
+                  Each octet is represented in YANG as a pair of
+                  hexadecimal characters, using uppercase for a letter.
+                  Each octet in the array is separated by the dash
+                  character.";
+                reference
+                  "8.2.18.2 of IEEE Std 1588-2019
+                  20.3.3 of IEEE Std 1588-2019";
+              }
+
+              container protocol-address {
+                config false;
+                description
+                  "Protocol address which is used as the source address
+                  by the network transport protocol for this
+                  PTP Port.";
+                reference
+                  "8.2.18.3 of IEEE Std 1588-2019";
+                uses port-address;
+              }
+            }
+
+            container unicast-negotiation-port-ds {
+              if-feature unicast-negotiation;
+              description
+                "Provides management access to the optional unicast
+                negotiation mechanism.";
+              reference
+                "16.1 of IEEE Std 1588-2019";
+
+              leaf enable {
+                type boolean;
+                description
+                  "When enable is false, the unicast negotiation
+                  mechanism is disabled on this PTP Port.
+                  When enable is true, the unicast negotiation
+                  mechanism is enabled on this PTP Port.";
+                reference
+                  "8.2.19.2 of IEEE Std 1588-2019";
+              }
+            }
+
+            container alternate-master-port-ds {
+              if-feature alternate-master;
+              description
+                "Provides management access to the optional alternate
+                master mechanism.";
+              reference
+                "17.3.3 of IEEE Std 1588-2019";
+
+              leaf number-of-alt-masters {
+                type uint8;
+                description
+                  "Limits the number of PTP Ports that can
+                  simultaneously transmit messages with the
+                  alternate master flag set to TRUE.";
+                reference
+                  "17.3.3.2.1 of IEEE Std 1588-2019";
+              }
+
+              leaf tx-alt-multicast-sync {
+                type boolean;
+                description
+                  "Controls Sync transmission. If true and the
+                  PTP Port is currently transmitting multicast
+                  Announce messages with alternateMasterFlag
+                  TRUE, the PTP Port shall also transmit multicast
+                  Sync and, if a two-step PTP Instance,
+                  Follow_Up messages. Otherwise do not transmit
+                  these messages.";
+                reference
+                  "17.3.3.2.2 of IEEE Std 1588-2019";
+              }
+
+              leaf log-alt-multicast-sync-interval {
+                type int8;
+                description
+                  "Logarithm to the base 2 of the mean interval
+                  in seconds between Sync messages transmitted
+                  under the terms of this alternate masters
+                  mechanism.";
+                reference
+                  "17.3.3.2.3 of IEEE Std 1588-2019";
+              }
+            }
+
+            container unicast-discovery-port-ds {
+              if-feature unicast-discovery;
+              description
+                "Provides management access to the optional unicast
+                discovery mechanism.";
+              reference
+                "17.4.3 of IEEE Std 1588-2019";
+
+              leaf max-table-size {
+                type uint16;
+                config false;
+                description
+                  "Maximum number of elements permitted
+                  in the port-address list.
+
+                  NOTE - The actualTableSize of IEEE Std 1588 is not
+                  applicable for YANG, since YANG mechanisms can be
+                  used to control the number of elements in
+                  port-address.";
+              }
+
+              leaf log-query-interval {
+                type int8;
+                description
+                  "Logarithm to the base 2 of the mean interval in
+                  seconds between requests from a PTP Instance for
+                  a unicast Announce message.";
+              }
+
+              list port-address {
+                key "index";
+                description
+                  "List of port addresses for unicast discovery.";
+
+                leaf index {
+                  type uint16;
+                  description
+                    "Index to a port address in the list, typically
+                    sequential from 0 to N-1, where N is the number of
+                    port addresses.";
+                }
+
+                uses port-address;
+              }
+            }
+
+            container acceptable-master-port-ds {
+              if-feature acceptable-master;
+              description
+                "Provides management access to the optional acceptable
+                master mechanism.";
+              reference
+                "17.5.4 of IEEE Std 1588-2019";
+
+              leaf enable {
+                type boolean;
+                description
+                  "When enable is false, the acceptable master table
+                  option is not used on this PTP Port, and the normal
+                  operation of the protocol is in effect.
+                  When enable is true, the acceptable master table
+                  option is used on this PTP Port as specified
+                  in the standard.";
+                reference
+                  "17.5.4.2.1 of IEEE Std 1588-2019";
+              }
+            }
+
+            container l1-sync-basic-port-ds {
+              if-feature l1-sync;
+              description
+                "Provides data for operation of the optional layer-1
+                based synchronization performance enhancement feature.
+                This data is required when the feature is supported.";
+              reference
+                "8.2.23 of IEEE Std 1588-2019
+                L.5 of IEEE Std 1588-2019";
+
+              leaf enabled {
+                type boolean;
+                description
+                  "Specifies whether the L1Sync option is enabled
+                  on the PTP Port. If enabled is true, then the
+                  L1Sync message exchange is supported and enabled.";
+                reference
+                  "L.4.1 of IEEE Std 1588-2019";
+              }
+
+              leaf tx-coherent-is-required {
+                type boolean;
+                description
+                  "Specifies whether the L1Sync port is required
+                  to be a transmit coherent port.";
+                reference
+                  "L.4.2 of IEEE Std 1588-2019";
+              }
+
+              leaf rx-coherent-is-required {
+                type boolean;
+                description
+                  "Specifies whether the L1Sync port is required
+                  to be a receive coherent port.";
+                reference
+                  "L.4.3 of IEEE Std 1588-2019";
+              }
+
+              leaf congruent-is-required {
+                type boolean;
+                description
+                  "Specifies whether the L1Sync port is required
+                  to be a congruent port.";
+                reference
+                  "L.4.4 of IEEE Std 1588-2019";
+              }
+
+              leaf opt-params-enabled {
+                type boolean;
+                description
+                  "Specifies whether the L1Sync port transmitting
+                  the L1_SYNC TLV extends this TLV with optional
+                  parameters.";
+                reference
+                  "L.4.5 of IEEE Std 1588-2019";
+              }
+
+              leaf log-l1sync-interval {
+                type int8;
+                description
+                  "Logarithm to the base 2 of the mean IEEE Std 1588
+                  L1SyncInterval, the time interval between successive
+                  periodic messages sent by the L1Sync port and
+                  carrying the L1_SYNC TLV.";
+                reference
+                  "L.4.6 of IEEE Std 1588-2019";
+              }
+
+              leaf l1sync-receipt-timeout {
+                type uint8;
+                description
+                  "The intergral number of elapsed IEEE Std 1588
+                  L1SyncIntervals that must pass without receipt
+                  of the L1_SYNC TLV before the L1_SYNC TLV
+                  reception timeout occurs.";
+                reference
+                  "L.4.7 of IEEE Std 1588-2019";
+              }
+
+              leaf link-alive {
+                type boolean;
+                config false;
+                description
+                  "True when a L1_SYNC TLV is received at the PTP Port
+                  and L1Sync is enaled on the PTP Port. False when the
+                  L1_SYNC TLV reception timeout occurs.";
+                reference
+                  "L.5.3.1 of IEEE Std 1588-2019";
+              }
+
+              leaf is-tx-coherent {
+                type boolean;
+                config false;
+                description
+                  "True when the L1Sync port is a transmit coherent
+                  port.";
+                reference
+                  "L.5.3.2 of IEEE Std 1588-2019";
+              }
+
+              leaf is-rx-coherent {
+                type boolean;
+                config false;
+                description
+                  "True when the L1Sync port is a receive coherent
+                  port.";
+                reference
+                  "L.5.3.3 of IEEE Std 1588-2019";
+              }
+
+              leaf is-congruent {
+                type boolean;
+                config false;
+                description
+                  "True when the L1Sync port is a congruent port.";
+                reference
+                  "L.5.3.4 of IEEE Std 1588-2019";
+              }
+
+              leaf l1sync-state {
+                type l1sync-state;
+                config false;
+                description
+                  "Current state of the L1Sync state machine associated
+                  with this L1Sync port.";
+                reference
+                  "L.5.3.5 of IEEE Std 1588-2019";
+              }
+
+              leaf peer-tx-coherent-is-required {
+                type boolean;
+                config false;
+                description
+                  "Specifies whether this L1Sync port is required
+                  to be a transmit coherent port by a peer,
+                  as indicated in the value of the TCR field of the
+                  most recently received L1_SYNC TLV.";
+                reference
+                  "L.5.3.6 of IEEE Std 1588-2019";
+              }
+
+              leaf peer-rx-coherent-is-required {
+                type boolean;
+                config false;
+                description
+                  "Specifies whether this L1Sync port is required
+                  to be a receive coherent port by a peer,
+                  as indicated in the value of the RCR field of the
+                  most recently received L1_SYNC TLV.";
+                reference
+                  "L.5.3.7 of IEEE Std 1588-2019";
+              }
+
+              leaf peer-congruent-is-required {
+                type boolean;
+                config false;
+                description
+                  "Specifies whether this L1Sync port is required
+                  is required to be a congruent port by a peer,
+                  as indicated in the value of the CR field of the
+                  most recently received L1_SYNC TLV.";
+                reference
+                  "L.5.3.8 of IEEE Std 1588-2019";
+              }
+
+              leaf peer-is-tx-coherent {
+                type boolean;
+                config false;
+                description
+                  "True when the peer L1Sync port is a
+                  transmit coherent port
+                  (as received in the L1_SYNC TLV).";
+                reference
+                  "L.5.3.9 of IEEE Std 1588-2019";
+              }
+
+              leaf peer-is-rx-coherent {
+                type boolean;
+                config false;
+                description
+                  "True when the peer L1Sync port is a
+                  receive coherent port
+                  (as received in the L1_SYNC TLV).";
+                reference
+                  "L.5.3.10 of IEEE Std 1588-2019";
+              }
+
+              leaf peer-is-congruent {
+                type boolean;
+                config false;
+                description
+                  "True when the peer L1Sync port is a
+                  congruent port
+                  (as received in the L1_SYNC TLV).";
+                reference
+                  "L.5.3.11 of IEEE Std 1588-2019";
+              }
+            }
+
+            container l1-sync-opt-params-port-ds {
+              if-feature l1-sync;
+              description
+                "Provides data for operation of the optional layer-1
+                based synchronization performance enhancement feature.
+                This data is optional when the feature is supported.";
+              reference
+                "8.2.24 of IEEE Std 1588-2019
+                L.8.4 of IEEE Std 1588-2019";
+
+              leaf timestamps-corrected-tx {
+                type boolean;
+                description
+                  "When true, the L1Sync port shall correct the
+                  transmitted egress timestamps with the known value
+                  of the phase offset, as indicated in the Link
+                  Reference Model.";
+                reference
+                  "L.8.4.2.1 of IEEE Std 1588-2019";
+              }
+
+              leaf phase-offset-tx-valid {
+                type boolean;
+                config false;
+                description
+                  "True if and only if the values of the transmission
+                  phase offset parameters (phase-offset-tx
+                  and phase-offset-tx-timestamp) are valid.";
+                reference
+                  "L.8.4.3.1 of IEEE Std 1588-2019";
+              }
+
+              leaf phase-offset-tx {
+                type time-interval;
+                config false;
+                description
+                  "Transmission phase offset, which is the
+                  time difference between the significant instant
+                  with which the passage of the message timestamp
+                  point through the reference plane is aligned,
+                  and the time represented by the captured
+                  timestamp of this passage of the message.";
+                reference
+                  "L.8.4.3.3 of IEEE Std 1588-2019";
+              }
+
+              container phase-offset-tx-timestamp {
+                config false;
+                description
+                  "Transmission phase offset timestamp
+                  for the associated transmission phase offset.";
+                reference
+                  "L.8.4.3.4 of IEEE Std 1588-2019";
+
+                uses timestamp;
+              }
+
+              leaf frequency-offset-tx-valid {
+                type boolean;
+                config false;
+                description
+                  "True if and only if the values of the transmission
+                  frequency offset parameters (frequency-offset-tx
+                  and frequency-offset-tx-timestamp) are valid.";
+                reference
+                  "L.8.4.3.2 of IEEE Std 1588-2019";
+              }
+
+              leaf frequency-offset-tx {
+                type time-interval;
+                config false;
+                description
+                  "Transmission frequency offset, multiplied
+                  by one second. Transmission frequency offset
+                  is the known rate of change of the transmission
+                  phase offset.";
+                reference
+                  "L.8.4.3.5 of IEEE Std 1588-2019";
+              }
+
+              container frequency-offset-tx-timestamp {
+                config false;
+                description
+                  "Transmission frequency offset timestamp
+                  for the associated transmission frequency
+                  offset.";
+                reference
+                  "L.8.4.3.6 of IEEE Std 1588-2019";
+
+                uses timestamp;
+              }
+            }
+
+            container communication-cap-port-ds {
+              config false;
+              description
+                "Provides data for multicast/unicast communication
+                capabilities.";
+              reference
+                "8.2.25 of IEEE Std 1588-2019";
+
+              container sync {
+                description
+                  "Communication capabilities of the PTP Port with
+                  respect to sending Sync messages.";
+
+                uses communication-capabilities;
+              }
+
+              container delay-resp {
+                description
+                  "Communication capabilities of the PTP Port with
+                  respect to sending Delay_Resp messages.";
+
+                uses communication-capabilities;
+              }
+            }
+
+            container performance-monitoring-port-ds {
+              if-feature performance-monitoring;
+              description
+                "Provides data for the optional performance
+                monitoring mechanism, scoped to each PTP Port.";
+              reference
+                "8.2.26 of IEEE Std 1588-2019
+                J.5.2 of IEEE Std 1588-2019";
+
+              list record-list-peer-delay {
+                key "index";
+                config false;
+                max-elements 99;
+                description
+                  "List of performance monitoring records for the
+                  PTP Port that is using the peer-to-peer delay
+                  measurement mehanism. The list is organized
+                  as follows:
+                  - 97 15-minute measurement records, the current
+                    record at index 0, followed by the most recent
+                    96 records.
+                  - 2 24-hour measurement records, the current record
+                    at index 97, and the previous record at index 98.
+
+                  If a record is not implemented for a specific index,
+                  management does not return the record. For example,
+                  if only four 15-minute periods are implemented,
+                  a management request for
+                  performance-monitoring-port-ds/
+                  record-list-peer-delay[6] returns an error.
+
+                  If only some of the data is reported, the same index
+                  values are used. As an example, if only the 24-hour
+                  statistics are accessed, the indexes are still
+                  97 and 98.
+
+                  If a specific parameter (e.g. min-mean-link-delay)
+                  is not implemented, management does not return the
+                  parameter (i.e., error). Parameters that are invalid
+                  (not measured correctly) shall be indicated with
+                  one in all bits, except the most significant. This
+                  represents the largest positive value of
+                  time-interval, indicating a value outside the
+                  maximum range.";
+                reference
+                  "J.5.2.1 of IEEE Std 1588-2019";
+
+                uses port-performance-monitoring-peer-delay-data-record;
+              }
+
+              list record-list {
+                key "index";
+                config false;
+                max-elements 99;
+                description
+                  "List of performance monitoring records for the
+                  PTP Port, not specific to the peer-to-peer delay
+                  measurement mehanism. The list is organized
+                  as follows:
+                  - 97 15-minute measurement records, the current
+                    record at index 0, followed by the most recent
+                    96 records.
+                  - 2 24-hour measurement records, the current record
+                    at index 97, and the previous record at index 98.
+
+                  If a record is not implemented for a specific index,
+                  management does not return the record. For example,
+                  if only four 15-minute periods are implemented,
+                  a management request for
+                  performance-monitoring-port-ds/record-list[6]
+                  returns an error.
+
+                  If only some of the data is reported, the same index
+                  values are used. As an example, if only the 24-hour
+                  statistics are accessed, the indexes are still
+                  97 and 98.
+
+                  If a specific parameter (e.g. sync-tx)
+                  is not implemented, management does not return the
+                  parameter (i.e., error). Parameters that are invalid
+                  (not measured correctly) shall be indicated with
+                  with the value zero, indicating that nothing was
+                  counted.
+
+                  Each counter in the record shall be initialized to
+                  zero at the start of a new 15-minute and
+                  24-hour interval.";
+                reference
+                  "J.5.2.2 of IEEE Std 1588-2019";
+
+                uses port-performance-monitoring-data-record;
+              }
+            }
+
+            container common-services-port-ds {
+              description
+                "Provides management access to the common services,
+                scoped to each PTP Port.";
+              reference
+                "16.6.5 of IEEE Std 1588-2019";
+
+              leaf cmlds-link-port-port-number {
+                if-feature cmlds;
+                type uint16;
+                config false;
+                description
+                  "Common services operate on all PTP Instances
+                  of the PTP Node. When a common service has
+                  port-specific behavior, it specifies a Link Port,
+                  which represents the physical port that the service
+                  uses to transport PTP messages. In the context of
+                  such a common service, the PTP Port represents a
+                  logical port.
+                  The Common Mean Link Delay Service (CMLDS) is
+                  port-specific, and this leaf provides the
+                  mapping of the PTP Port of this PTP Instance
+                  to the corresponding Link Port in CMLDS. The
+                  Link Port is identified using an IEEE Std 1588
+                  portNumber. The corresponding Link Port's
+                  portNumber is located in the hierarchy at
+                  /ptp/common-services/cmlds/ports/port[]/port-ds/
+                  port-identity/port-number.";
+                reference
+                  "16.6.5.1.1.1 of IEEE Std 1588-2019";
+              }
+            }
+
+            container external-port-config-port-ds {
+              if-feature external-port-config;
+              description
+                "Provides management access to the external
+                configuration option, scoped to each PTP Port.";
+              reference
+                "17.6.3 of IEEE Std 1588-2019";
+
+              leaf desired-state {
+                type port-state;
+                description
+                  "When the value of
+                  default-ds/external-port-config-enable is true,
+                  this desired-state is used to externally configure
+                  the PTP Port's state (i.e., ../../port-ds/port-state)
+                  to a desired value.";
+                reference
+                  "17.6.3.2 of IEEE Std 1588-2019";
+              }
+            }
+
+            container slave-monitoring-port-ds {
+              if-feature slave-monitoring;
+              description
+                "Provides management access to the optional
+                Slave Event Monitor service, scoped to each PTP Port.";
+              reference
+                "16.11.6 of IEEE Std 1588-2019";
+
+              leaf enable {
+                type bits {
+                  bit slave-rx-sync-timing-data {
+                    position 0;
+                    description
+                      "True activates generation of the
+                      SLAVE_RX_SYNC_TIMING_DATA TLV.";
+                  }
+                  bit slave-rx-sync-computed-data {
+                    position 1;
+                    description
+                      "True activates generation of the
+                      SLAVE_RX_SYNC_COMPUTED_DATA TLV.";
+                  }
+                  bit slave-tx-event-timestamps {
+                    position 2;
+                    description
+                      "True activates generation of the
+                      SLAVE_TX_EVENT_TIMESTAMPS_DATA TLV.";
+                  }
+                }
+                description
+                  "Each bit (boolean flag) indicates whether
+                  the data for a corresponding slave event monitoring
+                  TLV is computed, and whether the data is transmitted
+                  by the slave.";
+                reference
+                  "16.11.6.2 of IEEE Std 1588-2019";
+              }
+
+              leaf events-per-rx-sync-timing-tlv {
+                type uint8;
+                description
+                  "Indicates the number of events to report per
+                  SLAVE_RX_SYNC_TIMING_DATA TLV.";
+                reference
+                  "16.11.6.3 of IEEE Std 1588-2019";
+              }
+
+              leaf events-per-rx-sync-computed-tlv {
+                type uint8;
+                description
+                  "Indicates the number of events to report per
+                  SLAVE_RX_SYNC_COMPUTED_DATA TLV.";
+                reference
+                  "16.11.6.4 of IEEE Std 1588-2019";
+              }
+
+              leaf events-per-tx-timestamps-tlv {
+                type uint8;
+                description
+                  "Indicates the number of events to report per
+                  SLAVE_TX_EVENT_TIMESTAMPS_DATA TLV.";
+                reference
+                  "16.11.6.5 of IEEE Std 1588-2019";
+              }
+
+              leaf tx-event-type {
+                type uint8;
+                description
+                  "Indicates the event message type selected for
+                  the egress event monitoring. The four low-order
+                  bits are defined to correspond to the
+                  IEEE Std 1588 messageType field.";
+                reference
+                  "16.11.6.6 of IEEE Std 1588-2019";
+              }
+
+              leaf rx-sync-timing-tlv-message-m {
+                type uint8;
+                description
+                  "The value M, where M indicates that every Mth
+                  event message is selected for monitoring in the
+                  SLAVE_RX_SYNC_TIMING_DATA TLV. For example, if
+                  the value of M is 4, every fourth event message
+                  is selected for monitoring in the TLV.";
+                reference
+                  "16.11.6.7 of IEEE Std 1588-2019";
+              }
+
+              leaf rx-sync-computed-tlv-message-m {
+                type uint8;
+                description
+                  "The value M, where M indicates that every Mth
+                  event message is selected for monitoring in the
+                  SLAVE_RX_SYNC_COMPUTED_DATA TLV. For example, if
+                  the value of M is 4, every fourth event message
+                  is selected for monitoring in the TLV.";
+                reference
+                  "16.11.6.8 of IEEE Std 1588-2019";
+              }
+
+              leaf tx-timestamps-tlv-message-m {
+                type uint8;
+                description
+                  "The value M, where M indicates that every Mth
+                  event message is selected for monitoring in the
+                  SLAVE_TX_EVENT_TIMESTAMPS_DATA TLV. For example, if
+                  the value of M is 4, every fourth event message
+                  is selected for monitoring in the TLV.";
+                reference
+                  "16.11.6.9 of IEEE Std 1588-2019";
+              }
+            }
+          }
+        }
+      }
+    }
+
+    container transparent-clock-default-ds {
+      status deprecated;
+      description
+        "This default data set was specified in
+        IEEE Std 1588-2008, and under some interpretations,
+        it applied to all domains, which in turn means that it
+        represents multiple Transparent Clocks.
+        In IEEE Std 1588-2019, this data set is specified as
+        applying to the PTP Node (all domains), but the data set is
+        deprecated. For new designs, the standard recommends that
+        Transparent Clocks use the PTP Instance data sets
+        (i.e., /ptp/instances/instance[]), such that each
+        Transparent Clock supports a single PTP Instance and
+        domain.";
+      reference
+        "8.3.1 of IEEE Std 1588-2019";
+
+      leaf clock-identity {
+        type clock-identity;
+        config false;
+        status deprecated;
+        description
+          "The clockIdentity of the local clock.";
+        reference
+          "8.3.2.2.1 of IEEE Std 1588-2019";
+      }
+
+      leaf number-ports {
+        type uint16;
+        config false;
+        status deprecated;
+        description
+          "The number of PTP Ports of the device.";
+        reference
+          "8.3.2.2.2 of IEEE Std 1588-2019";
+      }
+
+      leaf delay-mechanism {
+        type delay-mechanism;
+        status deprecated;
+        description
+          "The propagation delay measuring mechanism (e2e or p2p).";
+        reference
+          "8.3.2.3.1 of IEEE Std 1588-2019";
+      }
+
+      leaf primary-domain {
+        type uint8;
+        status deprecated;
+        description
+          "The domainNumber of the primary syntonization domain.";
+        reference
+          "8.3.2.3.2 of IEEE Std 1588-2019";
+      }
+    }
+
+    container transparent-clock-ports {
+      status deprecated;
+      description
+        "YANG container that is used to get all ports of the
+        IEEE Std 1588 transparentClockPortDS.
+        YANG does not allow get of all elements in a YANG list,
+        so a YANG container wrapping the YANG list is provided for
+        that purpose. The naming convention uses plural for the
+        wrapping YANG container, and singular for the YANG list.";
+
+      list port {
+        key "port-index";
+        status deprecated;
+        description
+          "This list of Transparent Clock port data sets was specified
+          in IEEE Std 1588-2008, and under some interpretations,
+          it applied to all domains, which in turn means that it
+          represents multiple Transparent Clocks.
+          In IEEE Std 1588-2019, this list is specified as
+          applying to the PTP Node (all domains), but the list is
+          deprecated. For new designs, the standard recommends that
+          Transparent Clocks use the PTP Instance data sets
+          (i.e., /ptp/instances/instance[]), such that each
+          Transparent Clock supports a single PTP Instance
+          and domain.";
+        reference
+          "8.3.1 of IEEE Std 1588-2019";
+
+        leaf port-index {
+          type uint16;
+          description
+            "The port list is indexed using a number that is
+            unique per port within the Transparent Clock,
+            applicable to the management context only
+            (i.e., not used in PTP messages).";
+        }
+
+        leaf underlying-interface {
+          type if:interface-ref;
+          description
+            "Reference to the configured underlying IETF YANG
+            interface that is used by this port for
+            transport of PTP messages. Among other data,
+            physical identifiers for the interface
+            (e.g. MAC address) can be obtained using this
+            reference.";
+          reference
+            "RFC 8343";
+        }
+
+        container port-ds {
+          description
+            "IEEE Std 1588 transparentClockPortDS.";
+          reference
+            "8.3.3 of IEEE Std 1588-2019";
+
+          container port-identity {
+            config false;
+            status deprecated;
+            description
+              "The IEEE Std 1588 portIdentity of this port.";
+            reference
+              "8.3.3.2.1 of IEEE Std 1588-2019";
+            uses port-identity;
+          }
+
+          leaf log-min-pdelay-req-interval {
+            type int8;
+            status deprecated;
+            description
+              "The logarithm to the base 2 of the
+              minPdelayReqInterval (minimum permitted mean time
+              interval between successive Pdelay_Req messages).";
+            reference
+              "8.3.3.3.1 of IEEE Std 1588-2019";
+          }
+
+          leaf faulty-flag {
+            type boolean;
+            status deprecated;
+            description
+              "Shall be true if the port is faulty and false
+              if the port is operating normally.";
+            reference
+              "8.3.3.3.2 of IEEE Std 1588-2019";
+          }
+
+          leaf peer-mean-path-delay {
+            type time-interval;
+            config false;
+            status deprecated;
+            description
+              "An estimate of the current one-way propagation delay
+              on the link when the delayMechanism is P2P; otherwise,
+              it is zero.";
+            reference
+              "8.3.3.3.3 of IEEE Std 1588-2019";
+          }
+        }
+      }
+    }
+
+    container common-services {
+      description
+        "Provides management access to the common services.
+        Common services operate on all PTP Instances
+        of the PTP Node.";
+
+      container cmlds {
+        if-feature cmlds;
+        description
+          "The Common Mean Link Delay Service (CMLDS) is an
+          optional service that enables any PTP Port that would
+          normally obtain the value of a link's <meanLinkDelay>
+          and <neighborRateRatio> using the peer-to-peer method
+          to instead obtain these values from this optional service.
+          The CMLDS service is available to all PTP Instances
+          communicating with a specific transport mechanism,
+          e.g. using Annex F, over the physical link between two PTP
+          Nodes.
+
+          In this option, the term Link Port refers to the mechanism
+          enabling communication with a specific transport mechanism,
+          e.g. using Annex F, over the physical link between two PTP
+          Nodes.
+
+          The Common Mean Link Delay Service is designed to run
+          independently from any PTP Instances communicating
+          over a Link Port. The service provides information on the
+          <meanLinkDelay> as well as the as the <neighborRateRatio>
+          measured in the timescale used by the service. The service
+          runs on every Link Port where the CMLDS is present.
+          Information required by a PTP Port is requested from and
+          delivered by the service running on the associated
+          Link Port.";
+        reference
+          "16.6.4 of IEEE Std 1588-2019";
+
+        container default-ds {
+          description
+            "The default data set of CMLDS.";
+          reference
+            "16.6.4.1 of IEEE Std 1588-2019";
+
+          leaf clock-identity {
+            type clock-identity;
+            config false;
+            description
+              "The IEEE Std 1588 clockIdentity used by CMLDS.";
+            reference
+              "16.6.4.1.2.1 of IEEE Std 1588-2019";
+          }
+
+          leaf number-link-ports {
+            type uint16;
+            config false;
+            description
+              "The number of Link Ports of CMLDS.";
+            reference
+              "16.6.4.1.2.2 of IEEE Std 1588-2019";
+          }
+        }
+
+        container ports {
+          description
+            "YANG container that is used to get all Link Ports
+            of CMLDS.
+            YANG does not allow get of all elements in a YANG list,
+            so a YANG container wrapping the YANG list is provided for
+            that purpose. The naming convention uses plural for the
+            wrapping YANG container, and singular for the YANG list.";
+
+          list port {
+            key "port-index";
+            description
+              "List of data for each Link Port of CMLDS.
+              The list is structured as leafs for each member
+              of the IEEE Std 1588 cmldsLinkPortDS (primary
+              Link Port data set), followed by containers for
+              each optional Link Port data set. Members of data set
+              cmldsLinkPortDS.commonMeanLinkDelayInformation
+              are listed directly under the list, in order
+              to keep the YANG naming hierarchy as short as
+              possible.";
+            reference
+              "16.6.4.2 of IEEE Std 1588-2019";
+
+            leaf port-index {
+              type uint16;
+              description
+                "The port list is indexed using a number that is
+                unique per Link Port within the CMLDS, applicable
+                to the management context only (i.e. not used in PTP
+                messages).";
+            }
+
+            leaf underlying-interface {
+              type if:interface-ref;
+              description
+                "Reference to the configured underlying IETF YANG
+                interface that is used by this Link Port for
+                transport of PTP messages. Among other data,
+                physical identifiers for the interface
+                (e.g. MAC address) can be obtained using this
+                reference.";
+              reference
+                "RFC 8343";
+            }
+
+            container link-port-ds {
+              description
+                "The IEEE Std 1588 cmldsLinkPortDS of this Link Port.";
+              reference
+                "16.6.4.2 of IEEE Std 1588-2019";
+
+              container port-identity {
+                config false;
+                description
+                  "The IEEE Std 1588 portIdentity of this Link Port.";
+                reference
+                  "16.6.4.2.2.1 of IEEE Std 1588-2019";
+                uses port-identity;
+              }
+
+              leaf domain-number {
+                type uint8;
+                config false;
+                description
+                  "The IEEE Std 1588 domainNumber used by this
+                  Link Port. This domain number is not configurable,
+                  since its value is determined by the transport
+                  mechanism of the Link Port.";
+                reference
+                  "16.6.4.2.2.2 of IEEE Std 1588-2019";
+              }
+
+              leaf service-measurement-valid {
+                type boolean;
+                config false;
+                description
+                  "This boolean is initialized to false, and will
+                  be false whenever the required PTP messages for
+                  CMLDS are not received on the Link Port. When
+                  the required PTP messages for CMLDS are received,
+                  this boolean is true.
+                  This value is obtained from the
+                  CommonMeanLinkDelayInformation structure returned
+                  by CMLDS.";
+                reference
+                  "16.6.3.2 of IEEE Std 1588-2019";
+              }
+
+              leaf mean-link-delay {
+                type time-interval;
+                config false;
+                description
+                  "Estimate of the current one-way propagation delay
+                  on the PTP Link, i.e., <meanLinkDelay>, attached
+                  to this Link Port, computed using the peer-to-peer
+                  delay mechanism.
+                  This value is obtained from the
+                  CommonMeanLinkDelayInformation structure returned
+                  by CMLDS.";
+                reference
+                  "16.6.3.2 of IEEE Std 1588-2019";
+              }
+
+              leaf scaled-neighbor-rate-ratio {
+                type int32;
+                config false;
+                description
+                  "Ratio of the rate of this PTP Node's clock to
+                  the clock of its neighbor attached
+                  to this Link Port, i.e., <neighborRateRatio>,
+                  scaled as specified in the standard.
+                  This value is obtained from the
+                  CommonMeanLinkDelayInformation structure returned
+                  by CMLDS.";
+                reference
+                  "16.6.3.2 of IEEE Std 1588-2019";
+              }
+
+              leaf log-min-pdelay-req-interval {
+                type int8;
+                description
+                  "Logarithm to the base 2 of the IEEE Std 1588
+                  minPdelayReqInterval, the minimum permitted
+                  mean time interval between successive Pdelay_Req
+                  messages sent by CMLDS.";
+                reference
+                  "16.6.4.2.4.1 of IEEE Std 1588-2019";
+              }
+
+              leaf version-number {
+                type uint8;
+                description
+                  "The PTP major version in use on the Link Port.
+                  NOTE - This indicates the version of the
+                  IEEE 1588 standard, and not the version of an
+                  applicable PTP Profile.";
+                reference
+                  "16.6.4.2.4.2 of IEEE Std 1588-2019";
+              }
+
+              leaf minor-version-number {
+                type uint8;
+                description
+                  "The PTP minor version in use on the Link Port.
+                  NOTE - This indicates the version of the
+                  IEEE 1588 standard, and not the version of an
+                  applicable PTP Profile.";
+                reference
+                  "16.6.4.2.4.3 of IEEE Std 1588-2019";
+              }
+
+              leaf delay-asymmetry {
+                type time-interval;
+                description
+                  "The value of IEEE Std 1588 <delayAsymmetry>
+                  applicable to the Link Port, which is the
+                  difference in transmission time in one direction
+                  as compared to the opposite direction.";
+                reference
+                  "7.4.2 of IEEE Std 1588-2019
+                  16.6.4.2.4.4 of IEEE Std 1588-2019";
+              }
+            }
+
+            container timestamp-correction-port-ds {
+              if-feature timestamp-correction;
+              description
+                "Provides access to the configurable correction of
+                timestamps provided to the PTP protocol.";
+              reference
+                "16.6.4.3 of IEEE Std 1588-2019";
+
+              leaf egress-latency {
+                type time-interval;
+                description
+                  "Interval between the <egressProvidedTimestamp>
+                  provided for a PTP message and the time at which
+                  the message timestamp point of the PTP message
+                  crosses the reference plane.";
+                reference
+                  "7.3.4.2 of IEEE Std 1588-2019
+                  8.2.16.2 of IEEE Std 1588-2019";
+              }
+
+              leaf ingress-latency {
+                type time-interval;
+                description
+                  "Interval between the time the message timestamp
+                  point of an ingress PTP message crosses the
+                  reference plane and the <ingressProvidedTimestamp>
+                  provided for the PTP message.";
+                reference
+                  "7.3.4.2 of IEEE Std 1588-2019
+                  8.2.16.3 of IEEE Std 1588-2019";
+              }
+            }
+
+            container asymmetry-correction-port-ds {
+              if-feature asymmetry-correction;
+              description
+                "Provides access to asymmetry correction parameters
+                that are used to compute the value of
+                <delayAsymmetry>.";
+              reference
+                "16.6.4.4 of IEEE Std 1588-2019";
+
+              leaf enable {
+                type boolean;
+                description
+                  "When this value is true, the mechanism to calculate
+                  <delayAsymmetry> for certain media is enabled on
+                  this PTP Port. When this value is false, this
+                  mechanism is disabled on this PTP Port.";
+                reference
+                  "8.2.17.4 of IEEE Std 1588-2019";
+              }
+
+              leaf constant-asymmetry {
+                type time-interval;
+                description
+                  "Constant asymmetry used to fine adjust the
+                  dynamically calculated value of <delayAsymmetry>,
+                  when the mechanism to calculate <delayAsymmetry>
+                  or certain media is enabled.";
+                reference
+                  "8.2.17.2 of IEEE Std 1588-2019";
+              }
+
+              leaf scaled-delay-coefficient {
+                type relative-difference;
+                description
+                  "This is the <delayCoefficient>.";
+                reference
+                  "8.2.17.3 of IEEE Std 1588-2019";
+              }
+            }
+
+            container performance-monitoring-port-ds {
+              if-feature performance-monitoring;
+              description
+                "Provides data for the optional performance
+                monitoring mechanism, scoped to each Link Port.";
+              reference
+                "16.6.4.5 of IEEE Std 1588-2019";
+
+              list record-list-peer-delay {
+                key "index";
+                config false;
+                max-elements 99;
+                description
+                  "List of performance monitoring records for the
+                  Link Port that is using the peer-to-peer delay
+                  measurement mehanism. The list is organized
+                  as follows:
+                  - 97 15-minute measurement records, the current
+                    record at index 0, followed by the most recent
+                    96 records.
+                  - 2 24-hour measurement records, the current record
+                    at index 97, and the previous record at index 98.
+
+                  If a record is not implemented for a specific index,
+                  management does not return the record. For example,
+                  if only four 15-minute periods are implemented,
+                  a management request for
+                  performance-monitoring-port-ds/
+                  record-list-peer-delay[6] returns an error.
+
+                  If only some of the data is reported, the same index
+                  values are used. As an example, if only the 24-hour
+                  statistics are accessed, the indexes are still
+                  97 and 98.
+
+                  If a specific parameter (e.g. min-mean-link-delay)
+                  is not implemented, management does not return the
+                  parameter (i.e., error). Parameters that are invalid
+                  (not measured correctly) shall be indicated with
+                  one in all bits, except the most significant. This
+                  represents the largest positive value of
+                  time-interval, indicating a value outside the
+                  maximum range.";
+                reference
+                  "J.5.2.1 of IEEE Std 1588-2019";
+
+                uses port-performance-monitoring-peer-delay-data-record;
+              }
+
+              list record-list {
+                key "index";
+                config false;
+                max-elements 99;
+                description
+                  "List of performance monitoring records for the
+                  Link Port, not specific to the peer-to-peer delay
+                  measurement mehanism. The list is organized
+                  as follows:
+                  - 97 15-minute measurement records, the current
+                    record at index 0, followed by the most recent
+                    96 records.
+                  - 2 24-hour measurement records, the current record
+                    at index 97, and the previous record at index 98.
+
+                  If a record is not implemented for a specific index,
+                  management does not return the record. For example,
+                  if only four 15-minute periods are implemented,
+                  a management request for
+                  performance-monitoring-port-ds/record-list[6]
+                  returns an error.
+
+                  If only some of the data is reported, the same index
+                  values are used. As an example, if only the 24-hour
+                  statistics are accessed, the indexes are still
+                  97 and 98.
+
+                  If a specific parameter (e.g. sync-tx)
+                  is not implemented, management does not return the
+                  parameter (i.e., error). Parameters that are invalid
+                  (not measured correctly) shall be indicated with
+                  with the value zero, indicating that nothing was
+                  counted.
+
+                  Each counter in the record shall be initialized to
+                  zero at the start of a new 15-minute and
+                  24-hour interval.";
+                reference
+                  "J.5.2.2 of IEEE Std 1588-2019";
+
+                uses port-performance-monitoring-data-record;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The IEEE P1588f amendment project is currently in draft (in work in the IEEE 1588 working group).
Since IEEE 1588 does not anticipate significant changes due to amendments, we plan to simply revise the base 1588 modules, rather than create a new module (with augments) for each amendment, as IEEE 802.1 does.
This directory for P1588f will start with the published ieee1588-ptp-ms.yang module, and later we will submit another PR with changes made by the current draft of P1588f, so that the diff can be used to view changes relative to publication (i.e., changes of the amendment).