### PR TITLE
Fix typo in dest-mac-address description

### DIFF
--- a/standard/ieee/published/802.1/ieee802-dot1ab-lldp.yang
+++ b/standard/ieee/published/802.1/ieee802-dot1ab-lldp.yang
@@ -261,7 +261,7 @@ module ieee802-dot1ab-lldp {
         description
           "Destination MAC address. The ieee:mac-address type has a pattern
           that allows upper and lower case letters. To avoid issues with
-          string compairson, it is suggested to only use upper case for the
+          string comparison, it is suggested to only use upper case for the
           letters in the hexadecimal numbers. Implementers using code
           comparing MAC addresses should note that there is still an issue
           with a difference between the IETF mac-address definition and the


### PR DESCRIPTION
While working with the LLDP schema I noticed a minor typo in the docs